### PR TITLE
fix(app): modify component name casing in templates

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="app">
-    <router-view/>
+    <RouterView/>
   </div>
 </template>
 

--- a/src/components/Leftbar.vue
+++ b/src/components/Leftbar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="leftbar">
     <slot></slot>
-    <tabbar/>
+    <Tabbar/>
   </div>
 </template>
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="home-view">
-    <router-view/>
+    <RouterView/>
     <Ipc @setTheme="setTheme" @setLang="setLang"/>
   </div>
 </template>

--- a/src/views/brokers/index.vue
+++ b/src/views/brokers/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <leftbar/>
+    <Leftbar/>
     <div class="brokers-view right-content">
       <div class="titlebar">Brokers</div>
     </div>

--- a/src/views/connections/index.vue
+++ b/src/views/connections/index.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <leftbar>
-      <left-topbar/>
-      <left-list/>
+      <LeftTopbar/>
+      <LeftList/>
     </leftbar>
 
     <div class="connections-view right-content">
-      <right-topbar/>
+      <RightTopbar/>
     </div>
   </div>
 </template>


### PR DESCRIPTION
@CrazyWisdom 

We should follow Vue‘s style guide to regular closing-self components naming.

Docs 👇

https://vuejs.org/v2/style-guide/index.html#Self-closing-components-strongly-recommended