### PR TITLE
refactor(connection): remove requestResponse properties

### DIFF
--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -22,14 +22,6 @@ const setMQTT5Properties = (
     option.topicAliasMaximum === 0) {
     properties.topicAliasMaximum = option.topicAliasMaximum
   }
-  if (option.requestResponseInformation === true ||
-    option.requestResponseInformation === false) {
-    properties.requestResponseInformation = option.requestResponseInformation
-  }
-  if (option.requestProblemInformation === true ||
-    option.requestProblemInformation === false) {
-    properties.requestProblemInformation = option.requestProblemInformation
-  }
   return properties
 }
 
@@ -64,15 +56,12 @@ export const getClientOptions = (
   }
   // MQTT Version
   if (protocolVersion === 5) {
-    const { sessionExpiryInterval, receiveMaximum,
-      topicAliasMaximum, requestResponseInformation, requestProblemInformation,
+    const { sessionExpiryInterval, receiveMaximum, topicAliasMaximum,
     } = record
     const properties = setMQTT5Properties({
       sessionExpiryInterval,
       receiveMaximum,
       topicAliasMaximum,
-      requestResponseInformation,
-      requestProblemInformation,
     })
     if (properties && Object.keys(properties).length > 0) {
       options.properties =  properties

--- a/src/views/connections/ConnectionForm.vue
+++ b/src/views/connections/ConnectionForm.vue
@@ -241,30 +241,6 @@
                   </el-form-item>
                 </el-col>
                 <el-col :span="2"></el-col>
-                <el-col :span="22">
-                  <el-form-item
-                    label-width="120"
-                    :label="$t('connections.requestResponseInformation')"
-                    prop="requestResponseInformation">
-                    <el-radio-group v-model="record.requestResponseInformation">
-                      <el-radio :label="true"></el-radio>
-                      <el-radio :label="false"></el-radio>
-                    </el-radio-group>
-                  </el-form-item>
-                </el-col>
-                <el-col :span="2"></el-col>
-                <el-col :span="22">
-                  <el-form-item
-                    label-width="120"
-                    :label="$t('connections.requestProblemInformation')"
-                    prop="requestProblemInformation">
-                    <el-radio-group v-model="record.requestProblemInformation">
-                      <el-radio :label="true"></el-radio>
-                      <el-radio :label="false"></el-radio>
-                    </el-radio-group>
-                  </el-form-item>
-                </el-col>
-                <el-col :span="2"></el-col>
               </template>
             </el-row>
           </el-card>
@@ -389,8 +365,6 @@ export default class ConnectionCreate extends Vue {
     sessionExpiryInterval: undefined,
     receiveMaximum: undefined,
     topicAliasMaximum: undefined,
-    requestResponseInformation: undefined,
-    requestProblemInformation: undefined,
   }
 
   get rules() {


### PR DESCRIPTION
Because the use of these two properties needs to be redesigned.