### PR TITLE
feat(connection): support append timestamp to MQTT client id.

### DIFF
--- a/src/lang/connections.ts
+++ b/src/lang/connections.ts
@@ -279,6 +279,11 @@ export default {
     en: 'Quick selection of created connection configurations',
     ja: '作成された接続構成を早めに選択することができます',
   },
+  clientIdWithTimeTip: {
+    zh: '附加时间戳到 ClientID 后，以防止重复的连接',
+    en: 'Append a timestamp to the ClientID to prevent duplicate connections',
+    ja: '重複接続を防ぐために、ClientIDにタイムスタンプを追加します',
+  },
   publishMsg: {
     zh: '发送消息',
     en: 'Publish message',

--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -52,7 +52,7 @@ export const getClientOptions = (record: ConnectionModel): IClientOptions => {
   }
   options.connectTimeout = time.convertSecondsToMs(connectTimeout)
   // Append timestamp to MQTT client id
-  if (clientIdWithTime === true) {
+  if (clientIdWithTime) {
     const clickIconTime = Date.parse(new Date().toString())
     options.clientId = `${options.clientId}_${clickIconTime}`
   }

--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -38,6 +38,7 @@ export const getClientOptions = (record: ConnectionModel): IClientOptions => {
     reconnect,
     will,
     rejectUnauthorized,
+    clientIdWithTime,
   } = record
   // reconnectPeriod = 0 disabled automatic reconnection in the client
   const reconnectPeriod = reconnect ? 4000 : 0
@@ -50,6 +51,11 @@ export const getClientOptions = (record: ConnectionModel): IClientOptions => {
     protocolVersion,
   }
   options.connectTimeout = time.convertSecondsToMs(connectTimeout)
+  // Append timestamp to MQTT client id
+  if (clientIdWithTime === true) {
+    const clickIconTime = Date.parse(new Date().toString())
+    options.clientId = `${options.clientId}_${clickIconTime}`
+  }
   // Auth
   if (username !== '') {
     options.username = username

--- a/src/views/connections/ConnectionForm.vue
+++ b/src/views/connections/ConnectionForm.vue
@@ -56,10 +56,29 @@
                 <el-input size="mini" v-model="record.clientId"></el-input>
               </el-form-item>
             </el-col>
-            <el-col :span="2">
+            <el-col :span="1">
               <a href="javascript:;" class="icon-oper" @click="setClientID">
                 <i class="el-icon-refresh-right"></i>
               </a>
+            </el-col>
+            <!-- add clientID timestamp check icon -->
+            <el-col :span="1">
+              <el-tooltip
+                placement="top"
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                :open-delay="500"
+                :offset="80"
+                :content="$t('connections.clientIdWithTimeTip')"
+              >
+                <a
+                  href="javascript:;"
+                  class="icon-oper"
+                  @click="reverseClientIDWithTime"
+                  :class="{ 'icon-oper-active': clientIdWithTime }"
+                >
+                  <i class="el-icon-time"></i>
+                </a>
+              </el-tooltip>
             </el-col>
             <el-col :span="22">
               <el-form-item class="host-item" label-width="93px" :label="$t('connections.brokerIP')" prop="host">
@@ -492,6 +511,7 @@ export default class ConnectionCreate extends Vue {
     sessionExpiryInterval: undefined,
     receiveMaximum: undefined,
     topicAliasMaximum: undefined,
+    clientIdWithTime: false,
   }
 
   @Watch('record', { immediate: true, deep: true })
@@ -501,6 +521,10 @@ export default class ConnectionCreate extends Vue {
     } else {
       this.willLabelWidth = 180
     }
+  }
+
+  get clientIdWithTime() {
+    return this.record.clientIdWithTime
   }
 
   get rules() {
@@ -566,6 +590,11 @@ export default class ConnectionCreate extends Vue {
 
   private setClientID() {
     this.record.clientId = getClientId()
+  }
+
+  // Reverse the status of clientIdWithTime.
+  private reverseClientIDWithTime() {
+    this.record.clientIdWithTime = !this.record.clientIdWithTime
   }
 
   private getFilePath(key: 'ca' | 'cert' | 'key') {
@@ -689,10 +718,13 @@ export default class ConnectionCreate extends Vue {
       color: var(--color-text-default);
       line-height: 43px;
       transition: 0.2s color ease;
-      &:hover,
-      &:focus {
+      &:hover {
         color: var(--color-main-green);
       }
+    }
+    // icon active
+    .icon-oper-active {
+      color: var(--color-main-green);
     }
     .el-form-item__error {
       top: 80%;

--- a/src/views/connections/ConnectionInfo.vue
+++ b/src/views/connections/ConnectionInfo.vue
@@ -9,6 +9,23 @@
         </el-col>
         <el-col :span="8">
           <el-form-item label="Client ID" prop="clientId">
+            <el-tooltip
+              class="icon-client-time"
+              placement="top"
+              :effect="theme !== 'light' ? 'light' : 'dark'"
+              :open-delay="500"
+              :offset="80"
+              :content="$t('connections.clientIdWithTimeTip')"
+            >
+              <a
+                href="javascript:;"
+                class="icon-oper"
+                @click="reverseClientIDWithTime"
+                :class="{ 'icon-oper-active': clientIdWithTime }"
+              >
+                <i class="el-icon-time"></i>
+              </a>
+            </el-tooltip>
             <el-input size="mini" v-model="connection.clientId">
               <i slot="suffix" title="Refresh" class="el-icon-refresh" @click="refreshClientId"> </i>
             </el-input>
@@ -89,6 +106,7 @@ export default class ConnectionInfo extends Vue {
   @Prop({ required: true }) public client!: MqttClient | {}
   @Prop({ required: true }) public titleName!: string
 
+  @Getter('currentTheme') private theme!: Theme
   @Getter('allConnections') private allConnections!: ConnectionModel[] | []
 
   private oldName = ''
@@ -110,6 +128,21 @@ export default class ConnectionInfo extends Vue {
 
   get vueForm(): VueForm {
     return this.$refs.form as VueForm
+  }
+
+  get clientIdWithTime(): boolean {
+    if (this.connection.clientIdWithTime === undefined) {
+      this.connection.clientIdWithTime = false
+    }
+    return this.connection.clientIdWithTime
+  }
+
+  // Reverse the status of clientIdWithTime.
+  private reverseClientIDWithTime() {
+    if (this.connection.clientIdWithTime === undefined) {
+      this.connection.clientIdWithTime = false
+    }
+    this.connection.clientIdWithTime = !this.connection.clientIdWithTime
   }
 
   private async validateName(rule: FormRule, name: string, callBack: NameCallBack['callBack']) {
@@ -168,7 +201,27 @@ export default class ConnectionInfo extends Vue {
         line-height: 35px;
         height: 35px;
       }
+      // icon click event
+      .icon-oper {
+        color: var(--color-text-default);
+        line-height: 43px;
+        transition: 0.2s color ease;
+        &:hover {
+          color: var(--color-main-green);
+        }
+      }
+      // icon active
+      .icon-oper-active {
+        color: var(--color-main-green);
+      }
     }
+    // adjust the position of the clientID timestamp element
+    .icon-client-time {
+      position: absolute;
+      top: -2.65em;
+      left: 5em;
+    }
+
     .el-checkbox {
       margin-top: 42px;
     }

--- a/src/views/connections/types.ts
+++ b/src/views/connections/types.ts
@@ -86,6 +86,7 @@ export interface ConnectionModel extends SSLPath {
     lastWillRetain: boolean
     properties?: WillPropertiesModel
   }
+  clientIdWithTime?: boolean //Fill in client_id.Ensure that client_id field is unique.
 }
 
 export interface SSLContent {


### PR DESCRIPTION
Feature realization:

* Support append timestamp to MQTT client ID, which prevent duplicate connections.
* Add floating tips to explain what the client ID timestamp button does.


The timestamp of the attachment will not be displayed on the connection interface, but will be attached to the clientID when actually connecting.

![connect success](https://user-images.githubusercontent.com/36698124/101856670-bb69a080-3ba0-11eb-85c2-7b717a60d607.png)

And two connections with the same client ID will exist at the same time due to attachment time.(Actually not the same clientID)

![Two connections with the same id will exist at the same time due to attachment time](https://user-images.githubusercontent.com/36698124/101856842-18fded00-3ba1-11eb-9776-722a535cec91.png)


[https://github.com/emqx/MQTTX/issues/394#event-4082449360](https://github.com/emqx/MQTTX/issues/394#event-4082449360)

