### PR TITLE
fix(logs): fix windows filename error & build error

### DIFF
--- a/docs/manual-cn.md
+++ b/docs/manual-cn.md
@@ -211,7 +211,7 @@ sudo snap install mqttx
 - macOS: `~/Library/Application Support/MQTTX/logs/log`
 - Windows: `%USERPROFILE%\AppData\Roaming\MQTTX\logs\log`
 
-在每次关闭 MQTTX 时，当前的日志文件会被重命名为 timestamp `[YY]-[MM]-[DD]T[hh]:[mm].log` 格式。
+在每次关闭 MQTTX 时，当前的日志文件会被重命名为 timestamp `[YY]-[MM]-[DD]T[hh]-[mm]-[ss].log` 格式。
 
 ### 其它
 

--- a/docs/manual-jp.md
+++ b/docs/manual-jp.md
@@ -212,7 +212,7 @@ v1.5.0以降、MQTT Xは、ユーザーが接続をデバッグしてエラー�
 - macOS: `~/Library/Application Support/MQTTX/logs/log`
 - Windows: `%USERPROFILE%\AppData\Roaming\MQTTX\logs\log`
 
-MQTTXが閉じられるたびに、現在のログファイルの名前がタイムスタンプ `[YY]-[MM]-[DD] T [hh]：[mm] .log`形式に変更されます。
+MQTTXが閉じられるたびに、現在のログファイルの名前がタイムスタンプ `[YY]-[MM]-[DD]T[hh]-[mm]-[ss].log`形式に変更されます。
 
 ### その他
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -211,7 +211,7 @@ By default, the log will be written to the log file:
 - macOS: `~/Library/Application Support/MQTTX/logs/log`
 - Windows: `%USERPROFILE%\AppData\Roaming\MQTTX\logs\log`
 
-Every time MQTTX is closed, the current log file will be renamed to timestamp `[YY]-[MM]-[DD]T[hh]:[mm].log` format.
+Every time MQTTX is closed, the current log file will be renamed to timestamp `[YY]-[MM]-[DD]T[hh]-[mm]-[ss].log` format.
 
 ### Others
 

--- a/package.json
+++ b/package.json
@@ -95,5 +95,8 @@
     ]
   },
   "license": "Apache",
-  "repository": "https://github.com/emqx/MQTTX"
+  "repository": "https://github.com/emqx/MQTTX",
+  "resolutions": {
+    "electron-builder": "22.2.0"
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,10 +13,11 @@ import VueLog4js from './plugins/logPlugin/index'
 import log4js from 'log4js'
 import { getOrCreateLogDir } from './utils/logger'
 import logConfig from './plugins/logPlugin/logConfig.json'
+import path from 'path'
 
 // set logFile dir
 const LOG_DIR = getOrCreateLogDir()
-const LOG_PATH = `${LOG_DIR}/log`
+const LOG_PATH = path.join(LOG_DIR, 'log')
 logConfig.appenders.fileOutput.filename = LOG_PATH
 const config: log4js.Configuration = logConfig
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import log4js from 'log4js'
 import { app, remote } from 'electron'
 import fs from 'fs-extra'
+import path from 'path'
 
 export const getOrCreateLogDir = () => {
   const isRenderer: boolean = process.type === 'renderer'
@@ -8,7 +9,7 @@ export const getOrCreateLogDir = () => {
   const APP: Electron.App = isRenderer ? remote.app : app
 
   const STORE_PATH: string = APP.getPath('userData')
-  const LOG_DIR: string = `${STORE_PATH}/logs`
+  const LOG_DIR: string = path.join(STORE_PATH, 'logs')
 
   // In production mode, during the first open application
   // APP.getPath('userData') gets the path nested.
@@ -32,11 +33,12 @@ export const quitAndRenameLogger = () => {
   log4js.shutdown()
 
   const LOG_DIR = getOrCreateLogDir()
-  if (fs.existsSync(`${LOG_DIR}/log`)) {
+  if (fs.existsSync(path.join(LOG_DIR, 'log'))) {
     // YYYY-MM-DD-hh-mm
-    const curDate = new Date().toISOString().slice(0, 16)
+    const curISODate = new Date().toISOString().slice(0, 19)
+    const curDate = curISODate.replace(/:/g, '-')
     // rename current log to yy-mm-dd-hh-mm.log
-    fs.renameSync(`${LOG_DIR}/log`, `${LOG_DIR}/${curDate}.log`)
+    fs.renameSync(path.join(LOG_DIR, 'log'), path.join(LOG_DIR, `${curDate}.log`))
   }
 }
 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

when we close the MQTTX in the windows, it shows something error like:

```
Uncaught Exception:
Error: EINVAL: invalid argument, rename
‘C:\Users\MYUSERNAME\AppData\Roaming\MQTTX/logs/log' ->
'C:\Users\MYUSERNAME\AppData\Roaming\MQTTX/logs/log/2021-01-29T1948.log'
```

#### Issue Number

#491 

#### What is the new behavior?

I rewrite the logger part, it works also in the windows platform without any error report.


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

None.

## Other information
