### PR TITLE
fix(MsgPulish): fix editorRef invalidation becauseof route params undefined

### DIFF
--- a/src/components/MsgPublish.vue
+++ b/src/components/MsgPublish.vue
@@ -110,10 +110,10 @@ export default class MsgPublish extends Vue {
   @Watch('$route.params.id', { immediate: true, deep: true })
   private handleIdChanged(to: string, from: string) {
     const editorRef = this.$refs.payloadEditor as Editor
-    if (from === '0' && to !== '0') {
+    if (to && from === '0' && to !== '0') {
       // Init the editor when rout jump from creation page
       editorRef.initEditor()
-    } else if (from !== '0' && to === '0') {
+    } else if (from && from !== '0' && to === '0') {
       // destroy the editor when rout jump to creation page
       editorRef.destroyEditor()
     }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

When we jump from the `creation` page to `log/script` page, the editor ref `undefined`. Error occurs.


#### Issue Number

None.

#### What is the new behavior?

Deal with editor create and destroy when jumping to `creation` from `connection`, and do nothing otherwise.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

None

## Other information
