### PR TITLE
style(connection): fix the layout disorder caused by the long name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,4 @@ Please describe the new behavior or provide screenshots.
 
 Are there any specific instructions or things that should be known prior to reviewing?
 
-## Other information
+#### Other information

--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -5,7 +5,7 @@
         <div class="topbar">
           <div class="connection-head">
             <h2 :class="{ offline: !client.connected }">
-              {{ titleName }}
+              <span class="title-name">{{ titleName }}</span>
               <a
                 href="javascript:;"
                 :class="['collapse-btn', showClientInfo ? 'top' : 'bottom']"
@@ -1325,6 +1325,13 @@ export default class ConnectionsDetail extends Vue {
       }
       .connection-head {
         display: flex;
+        .title-name {
+          display: inline-block;
+          max-width: 200px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
         .offline {
           color: var(--color-text-light);
         }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

When the title name is too long, there is a problem with the page layout.

#### Issue Number

#493 

#### What is the new behavior?

When the title name of the top bar is too long, omit part of it, and then an ellipsis appears.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

![image](https://user-images.githubusercontent.com/21299158/107320908-992acb00-6adc-11eb-9940-b330c31a18dc.png)

## Other information
