### PR TITLE
fix(logs): fix can't record log message when we send in other filter

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -1138,12 +1138,12 @@ export default class ConnectionsDetail extends Vue {
       if (isFromActiveTopic || isFromNotActiveTopic) {
         this.messages.push(publishMessage)
         this.messagesAddedNewItem = true
-        this.$log.info(
-          `Sucessfully published message ${JSON.stringify(publishMessage.payload)} to topic ${JSON.stringify(
-            publishMessage.topic,
-          )}`,
-        )
       }
+      this.$log.info(
+        `Sucessfully published message ${JSON.stringify(publishMessage.payload)} to topic ${JSON.stringify(
+          publishMessage.topic,
+        )}`,
+      )
       this.scrollToBottom()
     })
   }


### PR DESCRIPTION

### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

If we send a message with checked the `test` topic filter, and send the topic `testtopic/1` with the message, the log message won't record.

How to recurrent

click send button:

![image](https://user-images.githubusercontent.com/36698124/108314523-fddcd880-71f4-11eb-80db-5b30e5ced2d6.png)

We can't find the message send record after clicking the send button:

![image](https://user-images.githubusercontent.com/36698124/108314531-0208f600-71f5-11eb-949b-e027989be088.png)

unless we are in the right topic, the topic send log will not record.

#### Issue Number

None.


#### What is the new behavior?

Whatever topic filter you are checked, we will get the message log record.

![image](https://user-images.githubusercontent.com/36698124/108314942-a854fb80-71f5-11eb-85ff-16acdd2fb22a.png)



#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

## Other information
