### PR TITLE
feat(connection): support quick connection when the panel is folded

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -37,7 +37,7 @@
           </div>
           <div class="connection-tail">
             <transition name="el-fade-in">
-              <span v-if="!showClientInfo && client.connected">
+              <template v-if="!showClientInfo && client.connected">
                 <el-tooltip
                   v-if="sendTimeId"
                   placement="bottom"
@@ -60,12 +60,19 @@
                     <i v-else class="el-icon-loading"></i>
                   </a>
                 </el-tooltip>
-              </span>
-              <span v-if="!showClientInfo && this.connectLoading">
-                <a class="connect-loading" href="javascript:;">
-                  <i class="el-icon-loading"></i>
+              </template>
+              <el-tooltip
+                v-if="!showClientInfo && !client.connected"
+                placement="bottom"
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                :open-delay="500"
+                :content="$t('connections.connectBtn')"
+              >
+                <a class="connect-btn" href="javascript:;" @click="connect">
+                  <i v-if="!connectLoading" class="el-icon-caret-right"></i>
+                  <i v-else class="el-icon-loading"></i>
                 </a>
-              </span>
+              </el-tooltip>
             </transition>
             <el-tooltip
               v-if="scriptOption !== null"
@@ -1359,6 +1366,7 @@ export default class ConnectionsDetail extends Vue {
         }
         .connect-loading,
         .edit-btn,
+        .connect-btn,
         .new-window-btn {
           margin-right: 12px;
         }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

When the MQTT broker is actively disconnected, the panel will not expand. At this time, you cannot see the connection button and you cannot quickly connect.

#### Issue Number

#509

#### What is the new behavior?

Add a CONNECT button in the top bar when the collapsed panel is not expanded.

![image](https://user-images.githubusercontent.com/21299158/108318424-c83aee00-71fa-11eb-8d83-dbf51d1141c4.png)

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

## Other information
