### PR TITLE
fix(MsgPublish): fix editor error when router jump from other page to creation & connection

### DIFF
--- a/src/components/MsgPublish.vue
+++ b/src/components/MsgPublish.vue
@@ -107,6 +107,14 @@ export default class MsgPublish extends Vue {
       ipcRenderer.removeAllListeners('sendPayload')
     }
   }
+
+  /**
+   * Notice:
+   * when we jump order by`creation page` <-> `connection page`,
+   * the monaco will not init or destroy, because we use the v-show to hidden Msgpublish componment.
+   * So we need to operate editor creation and destroy manually by listening on route.
+   * relative PR: https://github.com/emqx/MQTTX/pull/518 https://github.com/emqx/MQTTX/pull/446
+   */
   @Watch('$route.params.id', { immediate: true, deep: true })
   private handleIdChanged(to: string, from: string) {
     const editorRef = this.$refs.payloadEditor as Editor
@@ -117,6 +125,16 @@ export default class MsgPublish extends Vue {
       // destroy the editor when rout jump to creation page
       editorRef.destroyEditor()
     }
+  }
+
+  // Notice: add editor creation and destroy manually export for it's father componment.
+  public editorDestory() {
+    const editorRef = this.$refs.payloadEditor as Editor
+    editorRef.destroyEditor()
+  }
+  public editorInit() {
+    const editorRef = this.$refs.payloadEditor as Editor
+    editorRef.initEditor()
   }
 
   private send() {

--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -368,6 +368,26 @@ export default class ConnectionsDetail extends Vue {
   @Getter('showClientInfo') private clientInfoVisibles!: { [id: string]: boolean }
   @Getter('currentScript') private scriptOption!: ScriptState | null
 
+  /**
+   * Notice: when we jump order by `other page` -> `creation page` -> `connection page`,
+   * MsgPublish/editor twice which is not we expected, it should be init only once.
+   * `other page` -> `creation page` the MsgPublish/editor will init, `creation page` -> `connection page` init editor again.
+   * So when route jump order by `other page` -> `creation page`, we need to operate editor creation and destroy manually by listening on route.
+   * relative PR: https://github.com/emqx/MQTTX/pull/518 https://github.com/emqx/MQTTX/pull/446
+   */
+  @Watch('$route.path', { immediate: true, deep: true })
+  private handleIdChanged(to: string, from: string) {
+    // When route jump order by `other page` -> `creation page`
+    if (!from && to && to === '/recent_connections/0') {
+      // Destroy the MsgPublish/editor
+      setTimeout(() => {
+        const thisMsgPublish: MsgPublish = this.$refs.msgPublish as MsgPublish
+        thisMsgPublish.editorDestory()
+      }, 100)
+      // When we jump order by `other page` -> `creation page` -> `connection page`, it's should only init once.
+    }
+  }
+
   private showSubs = true
   private showClientInfo = true
   private showExportData = false


### PR DESCRIPTION

### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

When we jump order by `other page` -> `creation page` -> `connection page`, and press on `ctrl/cmd` + `enter`, we will get two message.

I hold the view that it caused by the `editor` init early when we jump from `other page` to `creation page`, so we init two`editor`s here.

We should destroy the early init `editor`  component, like before we do: #446 

Here is my solution:

Spy on the router, when we jump from `other page` to `creation page`, we just destroy the editor which init in `MsgPublish`.

#### Issue Number

None:

#### What is the new behavior?

When we follow jump order by `other page` -> `creation page` -> `connection page`, and press on `ctrl/cmd` + `enter`, we will get only one message.
![success](https://user-images.githubusercontent.com/36698124/108341625-ce3dc880-7214-11eb-8820-79f02f3a2c27.gif)


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions


## Other information
