### PR TITLE
fix(subscription): fix SYS topic reject prompt error

### DIFF
--- a/src/components/SubscriptionsList.vue
+++ b/src/components/SubscriptionsList.vue
@@ -239,11 +239,10 @@ export default class SubscriptionsList extends Vue {
         this.$log.error(`Topic: ${topic} subscribe error ${error} `)
         return false
       }
-
       let errorReason: SubscribeErrorReason = SubscribeErrorReason.normal
       if (res.length < 1) {
         errorReason = SubscribeErrorReason.emptySubFailed
-      } else if (![0, 1, 2].includes(res[0].qos) && !topic.match('/^($SYS)//i')) {
+      } else if (![0, 1, 2].includes(res[0].qos) && topic.match(/^(\$SYS)/i)) {
         errorReason = SubscribeErrorReason.qosSubSysFailed
       } else if (![0, 1, 2].includes(res[0].qos)) {
         errorReason = SubscribeErrorReason.qosSubFailed

--- a/src/lang/connections.ts
+++ b/src/lang/connections.ts
@@ -91,9 +91,9 @@ export default {
       '$SYSトピックを拒否しま。した予期しないQoS、MQTT Brokerはサブスクリプションを拒否しました。ACL構成を確認してください',
   },
   qosSubFailed: {
-    zh: '错误的 QoS',
-    en: 'Unexpected QoS',
-    ja: '予期しないQoS',
+    zh: '错误的 QoS, SubACK 失败, 请检查 MQTT broker 设置',
+    en: 'Unexpected QoS, SubACK failed, Please check MQTT broker configuration',
+    ja: '予期しないQoS, MQTT broker 構成を確認してください',
   },
   emptySubFailed: {
     zh: '订阅为空',


### PR DESCRIPTION

### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

when we deny any sub in emqx ACL rules, and use MQTT X sub any topic will get prompt : $SYS reject.

#### Issue Number

#527 

#### What is the new behavior?

If we sub MQTT Broker, and get deny, there should be prompt

Unexpected QoS, SubACK failed, Please check MQTT broker configuration

and when we sub $sys topic will get :

Rejected the $SYS topic,Unexpected QoS, MQTT Broker declined the subscription. Please check ACL configuration


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to reviewing?

#### Other information
