### PR TITLE
fix(subs): fix copy topic and tooltip disappears

### DIFF
--- a/src/assets/scss/theme/dark.scss
+++ b/src/assets/scss/theme/dark.scss
@@ -15,6 +15,7 @@ body.dark {
   --color-bg-code: #38404a;
   --color-bg-input_btn: transparent;
   --color-bg-radio: #37363d80;
+  --color-bg-popover: #ffffff;
 
   /* Font color */
   --color-text-title: #ffffff;

--- a/src/assets/scss/theme/light.scss
+++ b/src/assets/scss/theme/light.scss
@@ -15,6 +15,7 @@ body.light {
   --color-bg-code: #e6eef7;
   --color-bg-input_btn: #f5f7fa;
   --color-bg-radio: #f6f7fb;
+  --color-bg-popover: #303133f0;
 
   /* Font color */
   --color-text-title: #262626;

--- a/src/assets/scss/theme/night.scss
+++ b/src/assets/scss/theme/night.scss
@@ -15,6 +15,7 @@ body.night {
   --color-bg-code: #4f5965;
   --color-bg-input_btn: transparent;
   --color-bg-radio: #262529b3;
+  --color-bg-popover: #ffffff;
 
   /* Font color */
   --color-text-title: #ffffff;

--- a/src/components/SubscriptionsList.vue
+++ b/src/components/SubscriptionsList.vue
@@ -30,13 +30,15 @@
             }"
             class="topics-color-box"
           ></div>
-          <el-tooltip
-            :effect="theme !== 'light' ? 'light' : 'dark'"
-            :content="copySuccess ? $t('connections.topicCopied') : sub.topic"
-            :open-delay="!copySuccess ? 0 : 500"
+          <el-popover
             placement="top"
+            trigger="hover"
+            width="100%"
+            popper-class="topic-tooltip"
+            :content="copySuccess ? $t('connections.topicCopied') : sub.topic"
           >
             <a
+              slot="reference"
               v-clipboard:copy="sub.topic"
               v-clipboard:success="onCopySuccess"
               href="javascript:;"
@@ -45,7 +47,7 @@
             >
               {{ sub.alias || sub.topic }}
             </a>
-          </el-tooltip>
+          </el-popover>
           <span class="qos">QoS {{ sub.qos }}</span>
           <a href="javascript:;" class="close" @click.stop="removeSubs(sub)">
             <i class="el-icon-close"></i>
@@ -329,10 +331,10 @@ export default class SubscriptionsList extends Vue {
     this.copySuccess = true
     setTimeout(() => {
       this.copySuccess = false
-    }, 1000)
+    }, 1500)
   }
   private stopClick(): boolean {
-    return false
+    return true
   }
 
   private handleClickTopic(item: SubscriptionModel, index: number) {
@@ -352,6 +354,8 @@ export default class SubscriptionsList extends Vue {
 </script>
 
 <style lang="scss">
+@import '~@/assets/scss/variable.scss';
+
 .subscriptions-list-view {
   &.el-card {
     border-top: 0px;
@@ -461,6 +465,19 @@ export default class SubscriptionsList extends Vue {
       right: 0;
       top: 6px;
     }
+  }
+}
+.topic-tooltip {
+  color: var(--color-bg-normal);
+  padding: 8px;
+  font-size: $font-size--tips;
+  background: var(--color-bg-popover);
+  text-align: center;
+  min-width: auto;
+  border-radius: 4px;
+  .popper__arrow::after {
+    bottom: 0px !important;
+    border-top-color: var(--color-bg-popover) !important;
   }
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,10 @@ const LOG_PATH = path.join(LOG_DIR, 'log')
 logConfig.appenders.fileOutput.filename = LOG_PATH
 const config: log4js.Configuration = logConfig
 
+// Clipboard
+VueClipboard.config.appendToBody = false
+VueClipboard.config.autoSetContainer = true
+
 Vue.use(element)
 Vue.use(VueI18n)
 Vue.use(VueClipboard)


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

When you click on the topic name, the tooltip will show the successfully copied content and then disappear automatically

#### Issue Number

None

#### What is the new behavior?

Optimize the tips for copying Topic information. Tooltip will not automatically disappear if the copied content appears

![image](https://user-images.githubusercontent.com/21299158/111127554-ece27580-85ae-11eb-9aac-3dc85a759536.png)


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

#### Other information
