### PR TITLE
fix(connecionsList): fix connection hightlight incorrect issue

### DIFF
--- a/src/views/connections/index.vue
+++ b/src/views/connections/index.vue
@@ -1,12 +1,7 @@
 <template>
   <div class="connections">
     <div class="leftList">
-      <ConnectionsList
-        :ConnectionModelData="records"
-        :CollectionModelData="collections"
-        :connectionId="connectionId"
-        @delete="onDelete"
-      />
+      <ConnectionsList :ConnectionModelData="records" :CollectionModelData="collections" @delete="onDelete" />
     </div>
 
     <div class="connections-view">


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

highlight issue like:

1. click a connection `A`
2. click another connection `B`
3. connection current connection
4. the  highlight connection is `A`(expect highlight `B`)


#### Issue Number

None.

#### What is the new behavior?

Lead to the `current-node-key` is not reactive, so it won't change like  we expect.

ref issue: https://github.com/ElemeFE/element/issues/17246

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to reviewing?

#### Other information
