### PR TITLE
fix(connectionDetails): only allow insert into history after connected

### DIFF
--- a/src/components/MsgPublish.vue
+++ b/src/components/MsgPublish.vue
@@ -210,27 +210,7 @@ export default class MsgPublish extends Vue {
 
   private async send() {
     this.msgRecord.mid = uuidv4()
-    this.$emit('handleSend', this.msgRecord, this.payloadType)
-    await this.insertHistory() // insert message into local storage
-  }
-
-  private async insertHistory() {
-    const payload: HistoryMessagePayloadModel = {
-      payload: this.msgRecord.payload,
-      payloadType: this.payloadType,
-    } as HistoryMessagePayloadModel
-    const header: HistoryMessageHeaderModel = {
-      retain: this.msgRecord.retain,
-      topic: this.msgRecord.topic,
-      qos: this.msgRecord.qos,
-    } as HistoryMessageHeaderModel
-    !(await hasMessagePayload(payload)) && (await createHistoryMessagePayload(payload))
-    !(await hasMessageHeader(header)) && (await createHistoryMessageHeader(header))
-    const payloads: HistoryMessagePayloadModel[] = this.payloadsHistory as HistoryMessagePayloadModel[]
-    const headers: HistoryMessageHeaderModel[] = this.headersHistory as HistoryMessageHeaderModel[]
-    payloads.push(payload)
-    headers.push(header)
-    this.historyIndex = this.payloadsHistory.length - 1
+    this.$emit('handleSend', this.msgRecord, this.payloadType, this.loadHistoryData)
   }
 
   private handleInputFoucs() {
@@ -253,16 +233,20 @@ export default class MsgPublish extends Vue {
     ipcRenderer.removeAllListeners('sendPayload')
   }
 
-  private async loadData() {
+  private async loadHistoryData() {
     this.headersHistory = await loadHistoryMessageHeaders()
     this.payloadsHistory = await loadHistoryMessagePayloads()
+    this.historyIndex = this.payloadsHistory.length - 1
+  }
+
+  private async loadData() {
+    await this.loadHistoryData()
     Object.assign(
       this.msgRecord,
       this.defaultMsgRecord,
       this.headersHistory[this.headersHistory.length - 1],
       this.payloadsHistory[this.payloadsHistory.length - 1],
     )
-    this.historyIndex = this.payloadsHistory.length - 1
   }
 
   private created() {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

when the connection is disconnect, and we send a message that will insert a new history to local storage.
#### Issue Number

None

#### What is the new behavior?

only allow insert into history after connected

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
