### PR TITLE
fix(msg): fix payload type can not restored

### DIFF
--- a/src/components/MsgPublish.vue
+++ b/src/components/MsgPublish.vue
@@ -170,6 +170,7 @@ export default class MsgPublish extends Vue {
   private handleHistoryIndexChange(val: number, lastval: number) {
     if (lastval !== val && val >= 0 && val < this.payloadsHistory.length) {
       this.msgRecord = Object.assign(this.msgRecord, this.payloadsHistory[val])
+      this.payloadType = this.payloadsHistory[val].payloadType
     }
   }
 
@@ -251,6 +252,7 @@ export default class MsgPublish extends Vue {
       this.headersHistory[this.headersHistory.length - 1],
       this.payloadsHistory[this.payloadsHistory.length - 1],
     )
+    this.payloadType = this.payloadsHistory[this.historyIndex].payloadType
   }
 
   private created() {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

The historical payload can be obtained, but the payload type cannot be set

#### Issue Number

Example: None

#### What is the new behavior?

Payload Type should be consistent with Payload when switching history.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
