### PR TITLE
feat(connection): auto focus on new collection input

### DIFF
--- a/src/views/connections/ConnectionsList.vue
+++ b/src/views/connections/ConnectionsList.vue
@@ -23,16 +23,16 @@
           :allow-drop="allowDrop"
         >
           <span class="custom-tree-node" slot-scope="{ node, data }">
-            <div v-if="data.isEdit">
-              <el-input
-                size="small"
-                @blur="handleEditCompeleted(node, data)"
-                @keyup.enter.native="handleEditCompeleted(node, data)"
-                @keyup.esc.native="handleEditCancel(node, data)"
-                :placeholder="$t('connections.collectionPlaceholder')"
-                v-model="data.name"
-              ></el-input>
-            </div>
+            <el-input
+              v-if="data.isEdit"
+              ref="newCollectionInput"
+              size="small"
+              @blur="handleEditCompeleted(node, data)"
+              @keyup.enter.native="handleEditCompeleted(node, data)"
+              @keyup.esc.native="handleEditCancel(node, data)"
+              :placeholder="$t('connections.collectionPlaceholder')"
+              v-model="data.name"
+            ></el-input>
             <!-- connection -->
             <div
               v-else-if="!data.isCollection"
@@ -478,6 +478,13 @@ export default class ConnectionsList extends Vue {
       isCollection: true,
       children: [],
       isEdit: true,
+    })
+    this.$nextTick(() => {
+      const newCollectionInputDom = this.$refs.newCollectionInput as Vue
+      if (newCollectionInputDom) {
+        const input = newCollectionInputDom.$el.children[0] as HTMLElement
+        input.focus()
+      }
     })
     this.flushCollectionChange()
   }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

After clicking the new collection button, you need to manually focus on the input.

#### Issue Number

Example: none

#### What is the new behavior?

After clicking the new collection button, the input is automatically focused

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
