### PR TITLE
fix(message): fix leftItem color bar display issue

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -152,7 +152,13 @@ export default class MessageList extends Vue {
 .message-list {
   padding: 0 16px;
   overflow-x: hidden;
-  overflow-y: overlay;
+  overflow-y: auto;
+  .vue-recycle-scroller.direction-vertical:not(.page-mode) {
+    overflow-y: visible;
+    .vue-recycle-scroller__item-wrapper {
+      overflow: visible;
+    }
+  }
   &.scrolling {
     &::-webkit-scrollbar {
       width: 8px;


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

The left message color bar was hidden by `vue-recycle-scroller`.

#### Issue Number

None.

#### What is the new behavior?

remove the hidden rule.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
