### PR TITLE
fix(messageItem): fix left message item data state render issue

### DIFF
--- a/src/components/MsgLeftItem.vue
+++ b/src/components/MsgLeftItem.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="msg-left-item">
-    <span class="topic-color" :style="{ height: topicColorHeight, background: currentTopicColor }"></span>
+    <span class="topic-color" :style="{ background: color }"></span>
     <div ref="leftPayload" class="left-payload payload" @contextmenu.prevent="customMenu($event)">
       <p class="left-info">
         <span class="topic">Topic: {{ topic }}</span>
@@ -14,7 +14,6 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
-import { matchTopicMethod } from '@/utils/topicMatch'
 
 @Component
 export default class MsgLeftItem extends Vue {
@@ -22,28 +21,10 @@ export default class MsgLeftItem extends Vue {
   @Prop({ required: true }) public qos!: number
   @Prop({ required: true }) public payload!: string
   @Prop({ required: true }) public createAt!: string
-  @Prop({ required: true }) public subsList!: SubscriptionModel[]
-
-  private topicColorHeight = '0px'
-  private currentTopicColor = ''
-
-  private setCurrentTopicColor() {
-    const topic: SubscriptionModel | undefined = this.subsList.find((sub: SubscriptionModel) =>
-      matchTopicMethod(sub.topic, this.topic),
-    )
-    if (topic && topic.color) {
-      this.currentTopicColor = topic.color
-    }
-  }
+  @Prop({ required: false, default: '' }) public color!: string
 
   private customMenu(event: MouseEvent) {
     this.$emit('showmenu', this.payload, event)
-  }
-
-  private mounted() {
-    const leftPayloadRef = this.$refs.leftPayload as HTMLElement
-    this.topicColorHeight = `${leftPayloadRef.offsetHeight - 12}px`
-    this.setCurrentTopicColor()
   }
 }
 </script>
@@ -56,6 +37,7 @@ export default class MsgLeftItem extends Vue {
   text-align: left;
   position: relative;
   .topic-color {
+    height: calc(100% - 44px);
     display: inline-block;
     width: 4px;
     position: absolute;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -161,6 +161,7 @@ declare global {
     qos: QoS
     retain: boolean
     topic: string
+    color?: string
   }
 
   interface HistoryMessageHeaderModel {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

Lost left message color bar.

#### Issue Number


#### What is the new behavior?

`vue-virtual-scroller` can't use state component originally, typescript with vue-class is incompatible well with `vue-virtual-scroller` 

<img src="https://user-images.githubusercontent.com/36698124/133783500-bb20db55-e14d-413a-adbd-663d186dcfb4.png" width="256" height="256" />

reference: 

* https://github.com/Akryum/vue-virtual-scroller#idstate
* https://github.com/Akryum/vue-virtual-scroller/issues/513


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
