### PR TITLE
fix(subscribe): fix retain message flash/mis-render issue

### DIFF
--- a/src/components/SubscriptionsList.vue
+++ b/src/components/SubscriptionsList.vue
@@ -253,7 +253,10 @@ export default class SubscriptionsList extends Vue {
       this.subRecord.topic = sub.topic
       this.subRecord.qos = sub.qos
       this.subRecord.color = sub.color
-      this.subscribe(this.subRecord)
+      // TODO sync subscribe with connection without setTimeout maybe better.
+      setTimeout(() => {
+        this.subscribe(this.subRecord)
+      }, 300)
     })
   }
 

--- a/src/database/services/ConnectionService.ts
+++ b/src/database/services/ConnectionService.ts
@@ -43,7 +43,7 @@ export default class ConnectionService {
       ...data,
       // sort message by Date
       messages:
-        data.messages.sort((a, b) =>
+        data?.messages.sort((a, b) =>
           moment(new Date(a.createAt), sqliteDateFormat).isBefore(new Date(b.createAt)) ? -1 : 1,
         ) ?? [],
       subscriptions: data.subscriptions ?? [],


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?


#### Issue Number

Example: \#123

#### What is the new behavior?

![image](https://user-images.githubusercontent.com/36698124/134778434-5dc06254-2d3e-4a6d-8d49-9146da1219a9.png)

I think the reason is the sync problem between connection / subscribe  (resubscribe) /  messageArrive event.

so delay subscribing (resubscribe), maybe a better way, which makes the sub-event behind the on message arrives.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
