### PR TITLE
fix(connection): reopen client topic not lasted

### DIFF
--- a/src/database/services/HistoryMessageHeaderService.ts
+++ b/src/database/services/HistoryMessageHeaderService.ts
@@ -38,6 +38,14 @@ export default class HistoryMessageHeaderService {
     return await this.messageRepository.save(data)
   }
 
+  public async orderChange(
+    id: string,
+    data: HistoryMessageHeaderModel,
+  ): Promise<HistoryMessageHeaderModel | undefined> {
+    await this.delete(id)
+    return await this.messageRepository.save(data)
+  }
+
   public async clean(): Promise<HistoryMessageHeaderModel[] | undefined> {
     const query: HistoryMessageHeaderEntity[] | undefined = await this.messageRepository.find()
     if (!query) {

--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -143,16 +143,18 @@ export const hasMessagePayload = async (data: HistoryMessagePayloadModel): Promi
   return false
 }
 
-export const hasMessageHeader = async (data: HistoryMessageHeaderModel): Promise<boolean> => {
+export const hasMessageHeader = async (
+  data: HistoryMessageHeaderModel,
+): Promise<HistoryMessageHeaderModel | undefined> => {
   const { historyMessageHeaderService } = useServices()
   const headers = await historyMessageHeaderService.getAll()
   if (headers) {
-    const res = headers.some((el: HistoryMessageHeaderModel) => {
+    const res = headers.find((el: HistoryMessageHeaderModel) => {
       return data.qos === el.qos && data.topic === el.topic && data.retain === el.retain
     })
     return res
   }
-  return false
+  return undefined
 }
 
 export default {}

--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -1150,9 +1150,13 @@ export default class ConnectionsDetail extends Vue {
   private async insertHistory(payload: HistoryMessagePayloadModel, header: HistoryMessageHeaderModel) {
     const { historyMessagePayloadService, historyMessageHeaderService } = useServices()
     const isNewPayload = !(await hasMessagePayload(payload))
-    const isNewHeader = !(await hasMessageHeader(header))
+    const isNewHeader = await hasMessageHeader(header)
     isNewPayload && (await historyMessagePayloadService.create(payload))
-    isNewHeader && (await historyMessageHeaderService.create(header))
+    if (isNewHeader) {
+      await historyMessageHeaderService.orderChange(isNewHeader.id as string, header)
+    } else {
+      await historyMessageHeaderService.create(header)
+    }
     return { isNewPayload, isNewHeader }
   }
 


### PR DESCRIPTION
#### Issue Number

Example: no

#### What is the new behavior?

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] No

#### Specific Instructions
Questions raised by colleagues after use。

After using topic to send data for '111', close the client and reopen it. The topic will become '555', which should be '111'

I can only think of deleting first and then adding, but I didn't think of a good solution

![image](https://user-images.githubusercontent.com/89761177/135231484-6eb51dbe-d78e-491c-a0d9-ea5dcb161336.png)
![image](https://user-images.githubusercontent.com/89761177/135231502-e472f15d-9566-45e3-b981-4145c5bb330f.png)


#### Other information
