### PR TITLE
fix(connectionHistory): history connection duplication id issue

### DIFF
--- a/src/database/models/HistoryConnectionEntity.ts
+++ b/src/database/models/HistoryConnectionEntity.ts
@@ -1,5 +1,4 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm'
-import WillEntity from './WillEntity'
 
 type Protocol = 'ws' | 'wss' | 'mqtt' | 'mqtts'
 type CertType = '' | 'server' | 'self'

--- a/src/database/services/ConnectionService.ts
+++ b/src/database/services/ConnectionService.ts
@@ -319,6 +319,7 @@ export default class ConnectionService {
     }
     return {
       ...query,
+      id: undefined,
       messages: [],
       subscriptions: [],
       isCollection: false,
@@ -363,6 +364,7 @@ export default class ConnectionService {
     // TODO: refactor historyConnectionRepository field
     await this.historyConnectionRepository.save({
       ...res,
+      id: undefined,
       lastWillTopic: res.will.lastWillPayload,
       lastWillPayload: res.will.lastWillPayload,
       lastWillQos: res.will.lastWillQos,


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

Fetch history connection record without `id` field.

#### Issue Number

Example: \#123

#### What is the new behavior?

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
