### PR TITLE
fix(mqtt5): update receiveMaximum initial value

### DIFF
--- a/src/database/migration/1635393164071-huLang.ts
+++ b/src/database/migration/1635393164071-huLang.ts
@@ -1,6 +1,8 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
 
 export class huLang1635392304194 implements MigrationInterface {
+  name = 'huLang1635392304194'
+
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
         CREATE TABLE "temporary_SettingEntity" (

--- a/src/database/services/ConnectionService.ts
+++ b/src/database/services/ConnectionService.ts
@@ -58,7 +58,7 @@ export default class ConnectionService {
         receiveMaximum: data.receiveMaximum,
         maximumPacketSize: data.maximumPacketSize,
         topicAliasMaximum: data.topicAliasMaximum,
-        requestResponseInformation: data.topicAliasMaximum,
+        requestResponseInformation: data.requestResponseInformation,
         requestProblemInformation: data.requestProblemInformation,
         userProperties: data.userProperties ? JSON.parse(data.userProperties) : undefined,
         authenticationMethod: data.authenticationMethod,

--- a/src/views/connections/ConnectionForm.vue
+++ b/src/views/connections/ConnectionForm.vue
@@ -315,7 +315,7 @@
                     <el-input-number
                       size="mini"
                       type="number"
-                      :min="0"
+                      :min="1"
                       v-model="record.properties.receiveMaximum"
                       controls-position="right"
                     >

--- a/src/views/connections/index.vue
+++ b/src/views/connections/index.vue
@@ -132,9 +132,9 @@ export default class Connections extends Vue {
     this.$router.push({ path: '/recent_connections/0?oper=create' })
   }
 
-  private onConnect() {
+  private async onConnect() {
     this.isEmpty = false
-    this.loadData()
+    await this.loadData()
     setTimeout(() => {
       const connectionsDetailRef = this.$refs.connectionsDetail as ConnectionsDetail
       connectionsDetailRef.connect()


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

unsuccess mqtt5 connection.

#### Issue Number

Example: \#123

#### What is the new behavior?

直接新建连接能够成功连接到 mqtt5 因为 mqtt5 props 字段为空，即加载了默认值。不会导致错误

而在路径新建 -> 连接 -> 修改页 -> 连接 的路径下，加载了 receiveMaximum 最小值 min = 0 导致了错误。
其合法最小值为 1

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
