### PR TITLE
fix(connection): fix sync auto resub issue

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -236,7 +236,6 @@ declare global {
     keepalive: number
     connectTimeout: number
     reconnect: boolean
-    resubscribe?: boolean
     username: string
     password: string
     path: string

--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -1,4 +1,5 @@
 import mqtt, { MqttClient, IClientOptions } from 'mqtt'
+import Store from '@/store'
 import { getClientId } from '@/utils/idGenerator'
 import time from '@/utils/time'
 import { getSSLFile } from '@/utils/getFiles'
@@ -39,7 +40,6 @@ const getClientOptions = (record: ConnectionModel): IClientOptions => {
     will,
     rejectUnauthorized,
     clientIdWithTime,
-    resubscribe,
   } = record
   // reconnectPeriod = 0 disabled automatic reconnection in the client
   const reconnectPeriod = reconnect ? 4000 : 0
@@ -104,10 +104,8 @@ const getClientOptions = (record: ConnectionModel): IClientOptions => {
       }
     }
   }
-  // Auto Resubscribe
-  if (resubscribe) {
-    options.resubscribe = resubscribe
-  }
+  // Auto Resubscribe, Valid only when reconnecting
+  options.resubscribe = Store.getters.autoResub
   return options
 }
 
@@ -151,7 +149,6 @@ export const getDefaultRecord = (): ConnectionModel => {
     keepalive: 60,
     connectTimeout: 10,
     reconnect: false,
-    resubscribe: true,
     username: '',
     password: '',
     path: '/mqtt',

--- a/src/views/about/index.vue
+++ b/src/views/about/index.vue
@@ -44,7 +44,7 @@
               <i class="iconfont icon-cloud-logo"></i> EMQ X Cloud <i class="iconfont icon-right"></i>
             </el-button>
             <el-button class="link-btn github" type="primary" plain @click="goToLink('https://github.com/emqx/MQTTX')">
-              <i class="iconfont icon-github"></i> {{ $t('about.followGithub') }}
+              <i class="iconfont icon-github"></i> {{ $t('about.followGithub') }} <i class="iconfont icon-right"></i>
             </el-button>
           </div>
         </div>

--- a/src/views/connections/ConnectionForm.vue
+++ b/src/views/connections/ConnectionForm.vue
@@ -551,7 +551,6 @@ export default class ConnectionForm extends Vue {
   @Getter('willMessageVisible') private getterWillMessageVisible!: boolean
   @Getter('currentTheme') private theme!: Theme
   @Getter('allConnections') private allConnections!: ConnectionModel[] | []
-  @Getter('autoResub') private autoResub!: boolean
 
   @Action('CHANGE_ACTIVE_CONNECTION') private changeActiveConnection!: (payload: Client) => void
   @Action('TOGGLE_ADVANCED_VISIBLE') private toggleAdvancedVisible!: (payload: { advancedVisible: boolean }) => void
@@ -766,11 +765,6 @@ export default class ConnectionForm extends Vue {
     }
   }
 
-  // Fetch record default data from setting page, storage at vuex
-  private initFromSetting() {
-    this.record.resubscribe = this.autoResub
-  }
-
   private async created() {
     await this.loadData()
     const { id } = this.$route.params
@@ -779,7 +773,6 @@ export default class ConnectionForm extends Vue {
     }
     this.advancedVisible = this.getterAdvancedVisible
     this.willMessageVisible = this.getterWillMessageVisible
-    this.initFromSetting()
   }
 }
 </script>


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

Will trigger two resub.

#### Issue Number

Example: none

#### What is the new behavior?

@oceanlvr PTAL

Auto resub is a global state that should not be present in the connection. Make sure that resubscribing only triggers once

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
