### PR TITLE
feat(topicMatch): support shared subscription marker topic colors

### DIFF
--- a/src/utils/topicMatch.ts
+++ b/src/utils/topicMatch.ts
@@ -1,8 +1,19 @@
+/**
+ * Topic matching algorithm
+ * @return Return matched result, true or false
+ * @param filter - type: topic string, subscription list topics
+ * @param topic - type: topic string, real send-receive topics
+ */
 export const matchTopicMethod = (filter: string, topic: string): boolean => {
-  // Topic matching algorithm
-  const filterArray: string[] = filter.split('/')
+  let _filter = filter
+  let _topic = topic
+  if (filter.includes('$share')) {
+    // shared subscription format: $share/{ShareName}/{filter}
+    _filter = filter.split('/').slice(2).join('/')
+  }
+  const filterArray: string[] = _filter.split('/')
   const length: number = filterArray.length
-  const topicArray: string[] = topic.split('/')
+  const topicArray: string[] = _topic.split('/')
   for (let i = 0; i < length; i += 1) {
     const left: string = filterArray[i]
     const right: string = topicArray[i]


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

Shared subscriptions do not display the topic colors markers

#### Issue Number

Example: \#123

#### What is the new behavior?

Support shared subscription marker topic colors

![image](https://user-images.githubusercontent.com/21299158/150365652-e6bfdccd-b499-44b6-ae45-5373e06cc607.png)


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
