### PR TITLE
fix(Topic Aliases): not able to receive messages with Topic Alias set

### DIFF
--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -124,7 +124,14 @@ const getUrl = (record: ConnectionModel): string => {
 export const createClient = (record: ConnectionModel): { curConnectClient: MqttClient; connectUrl: string } => {
   const options: IClientOptions = getClientOptions(record)
   const url = getUrl(record)
-  const curConnectClient: MqttClient = mqtt.connect(url, options)
+
+  // Map options.properties.topicAliasMaximum to options.topicAliasMaximum, as that is where MQTT.js looks for it.
+  // TODO: remove after bug fixed in MQTT.js.
+  const optionsTempWorkAround = Object.assign(
+    { topicAliasMaximum: options.properties ? options.properties.topicAliasMaximum : undefined },
+    options,
+  )
+  const curConnectClient: MqttClient = mqtt.connect(url, optionsTempWorkAround)
 
   return { curConnectClient, connectUrl: url }
 }

--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -127,11 +127,11 @@ export const createClient = (record: ConnectionModel): { curConnectClient: MqttC
 
   // Map options.properties.topicAliasMaximum to options.topicAliasMaximum, as that is where MQTT.js looks for it.
   // TODO: remove after bug fixed in MQTT.js.
-  const optionsTempWorkAround = Object.assign(
-    { topicAliasMaximum: options.properties ? options.properties.topicAliasMaximum : undefined },
-    options,
-  )
-  const curConnectClient: MqttClient = mqtt.connect(url, optionsTempWorkAround)
+  const tempOptions = {
+    ...options,
+    topicAliasMaximum: options.properties ? options.properties.topicAliasMaximum : undefined,
+  }
+  const curConnectClient: MqttClient = mqtt.connect(url, tempOptions)
 
   return { curConnectClient, connectUrl: url }
 }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

Not able to receive Publish messages from broker with Topic Alias set after connecting with non-zero Topic Alias Maximum in CONNECT.

#### Issue Number

1036

#### What is the new behavior?

Temp workaround until bug is fixed in upstream MQTT.js, or their API is changes with new future version.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
https://github.com/mqttjs/MQTT.js/pull/1519

https://github.com/emqx/MQTTX/issues/1036
