### PR TITLE
fix(connection): fix console error of timed message [temp]

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -1092,8 +1092,11 @@ export default class ConnectionsDetail extends Vue {
         }
         return
       }
-      const { messageService } = useServices()
-      await messageService.pushToConnection({ ...receivedMessage }, id)
+      // Fixme: The retain message is not displayed when the connection is closed
+      setTimeout(async () => {
+        const { messageService } = useServices()
+        await messageService.pushToConnection({ ...receivedMessage }, id)
+      }, 500)
       if (id === this.curConnectionId) {
         this.record.messages.push({ ...receivedMessage })
         // Filter by conditions (topic, payload, etc)


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/master/.github/CONTRIBUTING.md)

#### What is the current behavior?

After receiving the `Retain Message` and disconnecting, the `Retain Message` disappeared. It was found that the stored retain message was not associated with the `connection id`, but normal messages sent and received can be associated with the `connection id`, so this is a temporary solution, adding setTimeout function.

<img width="774" alt="image" src="https://user-images.githubusercontent.com/21299158/194833514-307c9fa8-95b9-4ca5-a087-0a706632d862.png">

#### Issue Number

Example: \#123

#### What is the new behavior?

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
