### PR TITLE
feat(cli): support output mode for the sub command

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -11,6 +11,7 @@ import {
   parseVariadicOfBooleanType,
   parsePubTopic,
   parseFormat,
+  parseOutputMode,
 } from './utils/parse'
 import { conn, benchConn } from './lib/conn'
 import { pub, benchPub } from './lib/pub'
@@ -211,6 +212,12 @@ export class Commander {
       )
       .option('-f, --format <TYPE>', 'format the message body, support base64, json, hex', parseFormat)
       .option('-v, --verbose', 'print the topic before the message')
+      .option(
+        '--output-mode <default/clean>',
+        'choose between the default format and the clean mode, the clean mode outputs the complete packet data, allowing users to pipe the output freely',
+        parseOutputMode,
+        'default',
+      )
       // connect options
       .option('-V, --mqtt-version <5/3.1.1/3.1>', 'the MQTT version', parseMQTTVersion, 5)
       .option('-h, --hostname <HOST>', 'the broker host', 'localhost')

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -9,6 +9,8 @@ declare global {
 
   type FormatType = 'base64' | 'json' | 'hex'
 
+  type OutputMode = 'clean' | 'default'
+
   interface ConnectOptions {
     mqttVersion: MQTTVersion
     hostname: string
@@ -78,6 +80,7 @@ declare global {
     retainHandling?: QoS[]
     subscriptionIdentifier?: number[]
     format?: FormatType
+    outputMode?: OutputMode
     verbose: boolean
     connUserProperties?: Record<string, string | string[]>
   }
@@ -96,7 +99,7 @@ declare global {
     verbose: boolean
   }
 
-  type OmitSubscribeOptions = Omit<SubscribeOptions, 'format'>
+  type OmitSubscribeOptions = Omit<SubscribeOptions, 'format' | 'outputMode'>
 
   interface BenchSubscribeOptions extends OmitSubscribeOptions {
     count: number

--- a/cli/src/utils/parse.ts
+++ b/cli/src/utils/parse.ts
@@ -104,6 +104,14 @@ const parseFormat = (value: string) => {
   return value
 }
 
+const parseOutputMode = (value: string) => {
+  if (!['clean', 'default'].includes(value)) {
+    signale.error('Not a valid output mode.')
+    process.exit(1)
+  }
+  return value
+}
+
 const parseConnectOptions = (
   options: ConnectOptions | PublishOptions | SubscribeOptions,
   commandType?: CommandType,
@@ -326,6 +334,7 @@ export {
   checkTopicExists,
   parsePubTopic,
   parseFormat,
+  parseOutputMode,
   parseConnectOptions,
   parsePublishOptions,
   parseSubscribeOptions,


### PR DESCRIPTION
### PR Checklist

#### Issue Number

https://www.emqx.io/forum/t/can-mqttx-sub-write-to-stdout-the-payload-without-decorations/139

#### What is the new behavior?

<img width="754" alt="image" src="https://user-images.githubusercontent.com/38158783/216910029-2e8f600d-f655-4372-8c0f-e7aad31f98e6.png">

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
