### PR TITLE
fix(mqtt):  handle missing username with password

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -521,7 +521,7 @@ export default class ConnectionsDetail extends Vue {
   }
 
   // Connect
-  public connect(): boolean | void {
+  public async connect(): Promise<boolean | void> {
     this.isReconnect = false
     if (this.client.connected || this.connectLoading) {
       return false
@@ -529,7 +529,7 @@ export default class ConnectionsDetail extends Vue {
     this.connectLoading = true
     // new client
     try {
-      const { curConnectClient, connectUrl } = createClient(this.record)
+      const { curConnectClient, connectUrl } = await createClient(this.record)
       this.client = curConnectClient
       const { id } = this.record
       if (id && this.client.on) {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Please describe the current behavior and link to a relevant issue.

#### Issue Number

Example: \#123

#### What is the new behavior?

Update and fix client authentication for MQTT 3.1.1 and 5.0

This PR aims to address the differences in handling usernames and passwords between MQTT protocol versions 3.1.1 and 5.0 and ensure the correct usage of EMQX's ClientID authentication. The changes will improve the compatibility and user experience when connecting to different MQTT brokers and protocol versions.

![image](https://user-images.githubusercontent.com/21299158/233422949-5e68fa41-7370-4974-9c4a-ea0fe4a86be9.png)

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/21299158/233423050-092f1e98-15d6-4db7-a0e5-4fadf545160d.png">


Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
