### PR TITLE
fix(keyvalue): trigger change event with null

### DIFF
--- a/src/components/KeyValueEditor.vue
+++ b/src/components/KeyValueEditor.vue
@@ -64,6 +64,11 @@ export default class KeyValueEditor extends Vue {
   private handleInputChange() {
     const checkedList = this.dataList.filter((pair) => pair.checked)
     const objData: ClientPropertiesModel['userProperties'] = {}
+    if (checkedList.length === 0) {
+      // When checkedList is empty, trigger the change event and pass null
+      this.$emit('change', null)
+      return
+    }
     checkedList.forEach(({ key, value }) => {
       if (key === '') return
       const objValue = objData[key]
@@ -99,12 +104,12 @@ export default class KeyValueEditor extends Vue {
   }
 
   private processObjToArry() {
-    if (this.value === undefined || this.value === null) {
+    if (_.isEmpty(this.value)) {
       this.dataList = [{ key: '', value: '', checked: true }]
       return
     }
     this.dataList = []
-    Object.entries(this.value).forEach(([key, value]) => {
+    Object.entries(this.value as { [key: string]: string | string[] }).forEach(([key, value]) => {
       if (typeof value === 'string') {
         this.dataList.push({ key, value, checked: true })
       } else {

--- a/src/components/KeyValueEditor.vue
+++ b/src/components/KeyValueEditor.vue
@@ -6,10 +6,6 @@
     </div>
     <div class="editor-row" :style="{ 'max-height': maxHeight }">
       <div v-for="(item, index) in dataList" class="editor-row" :key="index">
-        <a v-if="!disabled" class="btn-check" @click="checkItem(index)">
-          <i v-if="item.checked" class="iconfont el-icon-check"></i>
-          <i v-else class="iconfont el-icon-check disable-icon"></i>
-        </a>
         <el-input
           placeholder="Key"
           size="mini"
@@ -39,7 +35,6 @@ import _ from 'lodash'
 interface KeyValueObj {
   key: string
   value: string
-  checked: boolean
 }
 
 @Component
@@ -62,14 +57,12 @@ export default class KeyValueEditor extends Vue {
   }
 
   private handleInputChange() {
-    const checkedList = this.dataList.filter((pair) => pair.checked)
-    const objData: ClientPropertiesModel['userProperties'] = {}
-    if (checkedList.length === 0) {
-      // When checkedList is empty, trigger the change event and pass null
+    if (this.dataList.length === 0) {
       this.$emit('change', null)
       return
     }
-    checkedList.forEach(({ key, value }) => {
+    const objData: ClientPropertiesModel['userProperties'] = {}
+    this.dataList.forEach(({ key, value }) => {
       if (key === '') return
       const objValue = objData[key]
       if (objValue) {
@@ -87,34 +80,30 @@ export default class KeyValueEditor extends Vue {
   }
 
   private addItem() {
-    this.dataList.push({ key: '', value: '', checked: true })
+    this.dataList.push({ key: '', value: '' })
   }
   private deleteItem(index: number) {
     if (this.dataList.length > 1) {
       this.dataList.splice(index, 1)
       this.handleInputChange()
     } else if (this.dataList.length === 1) {
-      this.dataList = [{ key: '', value: '', checked: true }]
+      this.dataList = [{ key: '', value: '' }]
       this.$emit('change', null)
     }
-  }
-  private checkItem(index: number) {
-    this.dataList[index].checked = !this.dataList[index].checked
-    this.handleInputChange()
   }
 
   private processObjToArry() {
     if (_.isEmpty(this.value)) {
-      this.dataList = [{ key: '', value: '', checked: true }]
+      this.dataList = [{ key: '', value: '' }]
       return
     }
     this.dataList = []
     Object.entries(this.value as { [key: string]: string | string[] }).forEach(([key, value]) => {
       if (typeof value === 'string') {
-        this.dataList.push({ key, value, checked: true })
+        this.dataList.push({ key, value })
       } else {
         value.forEach((item) => {
-          this.dataList.push({ key, value: item, checked: true })
+          this.dataList.push({ key, value: item })
         })
       }
     })
@@ -149,16 +138,6 @@ export default class KeyValueEditor extends Vue {
       .input-prop {
         padding: 0px;
         margin-right: 10px;
-      }
-      .btn-check {
-        cursor: pointer;
-        .el-icon-check {
-          font-size: 14px;
-          margin-right: 10px;
-        }
-        .disable-icon {
-          color: dimgray;
-        }
       }
     }
   }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When the checkedList is empty, the KeyValueEditor component does not trigger the change event with null as the value.

#### Issue Number

Example: #1246 

#### What is the new behavior?

With this PR, the KeyValueEditor component will now trigger the change event with null as the value when the checkedList is empty.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
