### PR TITLE
fix(meta): fix meta data saving issue requiring two clicks

### DIFF
--- a/src/components/MsgPublish.vue
+++ b/src/components/MsgPublish.vue
@@ -251,18 +251,20 @@ export default class MsgPublish extends Vue {
 
   private topicRequired = false
 
+  private isValidProp(value: any) {
+    return value !== null && value !== undefined && value !== false
+  }
+
   private getHasMqtt5PropState() {
-    return (
-      Object.entries(this.MQTT5PropsForm).filter(([_, v]) => v !== null && v !== undefined && v !== false).length > 0
-    )
+    return Object.values(this.MQTT5PropsForm).some(this.isValidProp)
   }
 
   private async saveMeta() {
-    this.hasMqtt5Prop = this.getHasMqtt5PropState()
     this.saveMetaLoading = true
     await this.updatePushProp()
     this.saveMetaLoading = false
     this.showMetaCard = false
+    this.hasMqtt5Prop = this.getHasMqtt5PropState()
   }
 
   private changeVisable() {
@@ -391,7 +393,6 @@ export default class MsgPublish extends Vue {
     this.MQTT5PropsSend = _.cloneDeep(this.MQTT5PropsForm)
     const propRecords = Object.entries(this.MQTT5PropsForm).filter(([_, v]) => v !== null && v !== undefined && v !== 0)
     const props = Object.fromEntries(propRecords)
-
     const { connectionService } = useServices()
     return await connectionService.addPushProp(props, this.$route.params.id)
   }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

![image](https://user-images.githubusercontent.com/21299158/233825694-49f4c22f-b567-402e-9416-74a3d4936825.png)

#### Issue Number

Example: \#123

#### What is the new behavior?

This Pull Request resolves an issue where users must click the "Save" button twice to save meta data successfully. The changes in this PR streamline the process, allowing users to save the metadata with a single click and improve code readability and maintainability.

1. Refactored and introduced isValidProp() function for better code reusability.
2. Updated getHasMqtt5PropState() function to use isValidProp() and Object.values() for better performance and readability.
3. Modified saveMeta() function to update hasMqtt5Prop after calling updatePushProp().

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
