### PR TITLE
feat(simulation): add simulator to the bench

### DIFF
--- a/cli/README-CN.md
+++ b/cli/README-CN.md
@@ -355,6 +355,8 @@ mqttx bench pub --help
 | -im, --message-interval <MILLISECONDS> | 发布消息的间隔时间，单位为毫秒，默认为 1000ms                        |
 | -I, --client-id <ID>                   | 客户端 ID，支持 %i (索引) 占位符                                     |
 | -t, --topic <TOPIC...>                 | 需要订阅的 Topic, 支持 %u (用户名), %c (客户端 ID), %i (索引) 占位符 |
+| -m, --message <MSG>                               | 需要发布的 Payload 消息                                      |
+| -sim, --simulator <SIMULATOR>           | 使用模拟器生成特定场景的消息，会覆盖 -m 参数 |
 | -v, --verbose                          | 打印发送出的历史消息数量与消息速率                                   |
 | ~~-s, --stdin~~                        | ~~从 stdin 中读取信息体~~                                            |
 | ~~-M, --multiline~~                    | ~~可以通过多行发布多条消息~~                                         |

--- a/cli/README.md
+++ b/cli/README.md
@@ -354,6 +354,8 @@ mqttx bench pub --help
 | -im, --interval-message <MILLISECONDS> | interval of publishing message to the broker (default: 1000ms)                 |
 | -I, --client-id <ID>                   | the client id, support %i (index) variable                                     |
 | -t, --topic <TOPIC...>                 | the message topic, support %u (username), %c (client id), %i (index) variables |
+| -m, --message <MSG>                               | the message body (default: "Hello From MQTT X CLI")                                                                                |
+| -sim, --simulator <SIMULATOR> | Using the simulator to generate scenario-specific messages, it will override the -m parameter |
 | -v, --verbose                          | print history received messages and rate                                       |
 | ~~-s, --stdin~~                        | ~~read the message body from stdin~~                                           |
 | ~~-M, --multiline~~                    | ~~read lines from stdin as multiple messages~~                                 |

--- a/cli/package.json
+++ b/cli/package.json
@@ -24,6 +24,7 @@
     "compare-versions": "^5.0.1",
     "concat-stream": "^2.0.0",
     "core-js": "^3.26.0",
+    "faker": "^5.5.3",
     "mqtt": "^4.3.7",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
@@ -39,6 +40,7 @@
     "@types/signale": "^1.4.4",
     "@types/split2": "^3.2.1",
     "@types/ws": "^8.5.3",
+    "@types/faker": "^5.5.3",
     "typescript": "^4.7.3"
   },
   "pkg": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
   parsePubTopic,
   parseFormat,
   parseOutputMode,
+  parseSimulator,
 } from './utils/parse'
 import { conn, benchConn } from './lib/conn'
 import { pub, benchPub } from './lib/pub'
@@ -355,6 +356,7 @@ export class Commander {
         'the message topic, support %u (username), %c (client id), %i (index) variables',
         parsePubTopic,
       )
+      .option('-sim, --simulator <SIMULATOR>', 'message generation simulator', parseSimulator, '')
       .option('-m, --message <BODY>', 'the message body', 'Hello From MQTT X CLI')
       .option('-q, --qos <0/1/2>', 'the QoS of the message', parseNumber, 0)
       .option('-r, --retain', 'send a retained message')

--- a/cli/src/simulator/tesla.ts
+++ b/cli/src/simulator/tesla.ts
@@ -1,0 +1,76 @@
+import faker from 'faker'
+
+const dataCache: Record<string, any> = {}
+
+const generator = function (id: string = '') {
+  // Some fields will not change every time data is generated, so store them according to id 
+  if (!dataCache[id]) {
+    dataCache[id] = {
+      car_id: faker.vehicle.vin(),
+      display_name: faker.name.firstName() + "'s Tesla",
+      model: faker.random.arrayElement(['S', '3', 'X', 'Y']),
+      trim_badging: faker.lorem.word(),
+      exterior_color: faker.commerce.color(),
+      wheel_type: faker.lorem.word(),
+      spoiler_type: faker.lorem.word(),
+      geofence: faker.address.city(),
+    }
+  }
+
+  const data = {
+    ...dataCache[id],
+    state: faker.random.arrayElement(['online', 'asleep', 'charging']),
+    since: faker.date.recent().toISOString(),
+    healthy: faker.datatype.boolean(),
+    version: faker.system.semver(),
+    update_available: faker.datatype.boolean(),
+    update_version: faker.system.semver(),
+    latitude: faker.address.latitude(),
+    longitude: faker.address.longitude(),
+    shift_state: faker.random.arrayElement(['D', 'N', 'R', 'P']),
+    power: faker.datatype.number({ min: -10000, max: 10000 }),
+    speed: faker.datatype.number({ min: 0, max: 200 }),
+    heading: faker.datatype.number({ min: 0, max: 359 }),
+    elevation: faker.datatype.number({ min: -100, max: 5000 }),
+    locked: faker.datatype.boolean(),
+    sentry_mode: faker.datatype.boolean(),
+    windows_open: faker.datatype.boolean(),
+    doors_open: faker.datatype.boolean(),
+    trunk_open: faker.datatype.boolean(),
+    frunk_open: faker.datatype.boolean(),
+    is_user_present: faker.datatype.boolean(),
+    is_climate_on: faker.datatype.boolean(),
+    inside_temp: faker.datatype.number({ min: -20, max: 50, precision: 0.1 }),
+    outside_temp: faker.datatype.number({ min: -20, max: 50, precision: 0.1 }),
+    is_preconditioning: faker.datatype.boolean(),
+    odometer: faker.datatype.number({ min: 0, max: 1000000 }),
+    est_battery_range_km: faker.datatype.number({ min: 0, max: 1000, precision: 0.1 }),
+    rated_battery_range_km: faker.datatype.number({ min: 0, max: 1000, precision: 0.1 }),
+    ideal_battery_range_km: faker.datatype.number({ min: 0, max: 1000, precision: 0.1 }),
+    battery_level: faker.datatype.number({ min: 0, max: 100 }),
+    usable_battery_level: faker.datatype.number({ min: 0, max: 100 }),
+    plugged_in: faker.datatype.boolean(),
+    charge_energy_added: faker.datatype.number({ min: 0, max: 100, precision: 0.01 }),
+    charge_limit_soc: faker.datatype.number({ min: 0, max: 100 }),
+    charge_port_door_open: faker.datatype.boolean(),
+    charger_actual_current: faker.datatype.number({ min: 0, max: 100, precision: 0.01 }),
+    charger_power: faker.datatype.number({ min: 1, max: 100 }),
+    charger_voltage: faker.datatype.number({ min: 220, max: 240 }),
+    charge_current_request: faker.datatype.number({ min: 10, max: 50 }),
+    charge_current_request_max: faker.datatype.number({ min: 10, max: 50 }),
+    scheduled_charging_start_time: faker.date.between('2023-01-01', '2023-12-31').toISOString(),
+    time_to_full_charge: faker.datatype.number({ min: 0.5, max: 10, precision: 0.01 }),
+    tpms_pressure_fl: faker.datatype.number({ min: 2.0, max: 3.5, precision: 0.1 }),
+    tpms_pressure_fr: faker.datatype.number({ min: 2.0, max: 3.5, precision: 0.1 }),
+    tpms_pressure_rl: faker.datatype.number({ min: 2.0, max: 3.5, precision: 0.1 }),
+    tpms_pressure_rr: faker.datatype.number({ min: 2.0, max: 3.5, precision: 0.1 }),
+    timestamp: Date.now(),
+  }
+  return JSON.stringify(data)
+}
+
+const dataType = 'JSON'
+const version = '0.0.1'
+const description = 'Simulation to generate Tesla\'s data, reference form https://github.com/adriankumpf/teslamate'
+
+export { generator, dataType, version, description }

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -96,6 +96,7 @@ declare global {
     count: number
     interval: number
     messageInterval: number
+    simulator: string
     verbose: boolean
   }
 

--- a/cli/src/utils/parse.ts
+++ b/cli/src/utils/parse.ts
@@ -3,6 +3,7 @@ import signale from '../utils/signale'
 import { getSpecialTypesOption } from '../utils/generator'
 
 import { IClientOptions, IClientPublishOptions, IClientSubscribeOptions } from 'mqtt'
+import { getSimulatorList } from './simulator'
 
 const parseNumber = (value: string) => {
   const parsedValue = Number(value)
@@ -11,6 +12,15 @@ const parseNumber = (value: string) => {
     process.exit(1)
   }
   return parsedValue
+}
+
+const parseSimulator = (value: string) => {
+  const simulatorList = getSimulatorList()
+  if (!simulatorList.includes(value)) {
+    signale.error(`Simulator not found in ${simulatorList.join(',')}`, )
+    process.exit(1)
+  }
+  return value
 }
 
 const parseProtocol = (value: string) => {
@@ -338,4 +348,5 @@ export {
   parseConnectOptions,
   parsePublishOptions,
   parseSubscribeOptions,
+  parseSimulator,
 }

--- a/cli/src/utils/simulator.ts
+++ b/cli/src/utils/simulator.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+const SimulatorFolder = path.join(__dirname, '../simulator');
+
+interface Simulator {
+  version?: string
+  description?: string,
+  generator: Function,
+}
+
+const loadSimulator = function (name: string): Simulator {
+  try {
+    const filePath = path.join(SimulatorFolder, `${name}.js`);
+    const simulatorModule = require(filePath);
+    if (typeof simulatorModule.generator !== 'function') {
+      throw new Error('Not a valid simulator module')
+    }
+    return simulatorModule;
+  } catch (err) {
+    throw new Error(`Load simulator error: ${err}`);
+  }
+}
+
+const getSimulatorList = function (): string[] {
+  if (!fs.existsSync(SimulatorFolder)) {
+    return []
+  }
+  // Read the files in the Sense folder
+  const files = fs.readdirSync(SimulatorFolder).sort((a, b) => {
+    const statA = fs.statSync(SimulatorFolder + '/' + a);
+    const statB = fs.statSync(SimulatorFolder + '/' + b);
+    return statB.birthtime.getTime() - statA.birthtime.getTime();
+  });
+  return files.filter($ => $.endsWith('.js')).map($ => $.replace('.js', ''))
+}
+
+export { loadSimulator, getSimulatorList }

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/faker@^5.5.3":
+  version "5.5.9"
+  resolved "https://registry.npmmirror.com/@types/faker/-/faker-5.5.9.tgz#588ede92186dc557bff8341d294335d50d255f0c"
+  integrity sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==
+
 "@types/node@*", "@types/node@^17.0.43":
   version "17.0.43"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.43.tgz#7f16898cdd791c9d64069000ad448b47b3ca8353"
@@ -243,6 +248,11 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+faker@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.npmmirror.com/faker/-/faker-5.5.3.tgz#c57974ee484431b25205c2c8dc09fda861e51e0e"
+  integrity sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==
 
 figures@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### PR Checklist

#### What is the new behavior?

Users can place a custom script in the simulator directory and then use it to generate simulation data in the bench pub with the -sim option.

This helps you to achieve a simulated performance test that is closer to the production.

```bash
mqttx bench pub -sim tesla -t t/1 -c 1

mqttx sub -t t/1
{"car_id":"JK6ZSF1A59HS94294","display_name":"Ines's Tesla","model":"Y","trim_badging":"ullam","exterior_color":"purple","wheel_type":"repudiandae","spoiler_type":"placeat","geofence":"Longview","state":"charging","since":"2023-04-23T18:25:00.558Z","healthy":true,"version":"0.2.9","update_available":false,"update_version":"1.0.2","latitude":"-15.3417","longitude":"127.2175","shift_state":"P","power":-6046,"speed":189,"heading":50,"elevation":3851,"locked":true,"sentry_mode":true,"windows_open":false,"doors_open":true,"trunk_open":true,"frunk_open":false,"is_user_present":false,"is_climate_on":false,"inside_temp":38.4,"outside_temp":44.8,"is_preconditioning":true,"odometer":383942,"est_battery_range_km":653.7,"rated_battery_range_km":916.6,"ideal_battery_range_km":542.9,"battery_level":4,"usable_battery_level":87,"plugged_in":true,"charge_energy_added":74.07,"charge_limit_soc":42,"charge_port_door_open":true,"charger_actual_current":47.44,"charger_power":47,"charger_voltage":240,"charge_current_request":15,"charge_current_request_max":20,"scheduled_charging_start_time":"2023-01-25T02:10:33.559Z","time_to_full_charge":8.42,"tpms_pressure_fl":2.5,"tpms_pressure_fr":3.3,"tpms_pressure_rl":3.2,"tpms_pressure_rr":2.3,"timestamp":1682330389155}
```

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
