### PR TITLE
feat(cli): add ls command

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "chalk": "~4.1.2",
+    "cli-table3": "^0.6.3",
     "commander": "^9.3.0",
     "compare-versions": "^5.0.1",
     "concat-stream": "^2.0.0",
@@ -53,6 +54,9 @@
       "node16-win-arm64",
       "node16-alpine-arm64"
     ],
-    "outputPath": "release"
+    "outputPath": "release",
+    "scripts": [
+      "dist/src/scenarios/**/*"
+    ]
   }
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
 import { conn, benchConn } from './lib/conn'
 import { pub, benchPub, simulatePub } from './lib/pub'
 import { sub, benchSub } from './lib/sub'
+import ls from './lib/ls'
 import { version } from '../package.json'
 
 export class Commander {
@@ -622,6 +623,12 @@ export class Commander {
         'load the parameters from the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-config.json',
       )
       .action(simulatePub)
+
+    this.program
+      .command('ls')
+      .description('List information based on the provided options.')
+      .option('-sc, --scenarios', 'List all built-in scenarios')
+      .action(ls)
   }
 }
 

--- a/cli/src/lib/ls.ts
+++ b/cli/src/lib/ls.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import Table from 'cli-table3'
+
+interface Scenario {
+  name: string
+  description: string
+}
+
+async function listScenarios(): Promise<Scenario[]> {
+  const scenariosDir = path.join(__dirname, '../scenarios')
+  const scenarios: Scenario[] = []
+  try {
+    const dir = await fs.promises.readdir(scenariosDir)
+    for (const file of dir) {
+      if (path.extname(file) === '.js') {
+        // Use dynamic import
+        const scenario = await import(path.join(scenariosDir, file))
+        scenarios.push({
+          name: scenario.name,
+          description: scenario.description,
+        })
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading scenarios directory: ${error}`)
+  }
+  return scenarios
+}
+
+const ls = async (options: LsOptions) => {
+  if (options.scenarios) {
+    try {
+      const list = await listScenarios()
+      // Create a new table
+      const table = new Table({
+        head: ['Scenario Name', 'Description'],
+      })
+      // Push each scenario to the table
+      list.forEach((scenario) => {
+        table.push([scenario.name, scenario.description])
+      })
+      // Log the usage
+      console.log('You can use any of the above scenario names as a parameter to run the scenario.')
+      // Log the table
+      console.log(table.toString())
+    } catch (err) {
+      console.log(err)
+    }
+  }
+}
+
+export default ls

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -136,6 +136,10 @@ declare global {
       | SimulatePubOptions
       | Simulator
   }
+
+  interface LsOptions {
+    scenarios: boolean
+  }
 }
 
 export {}

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
 "@faker-js/faker@^7.6.0":
   version "7.6.0"
   resolved "https://registry.npmmirror.com/@faker-js/faker/-/faker-7.6.0.tgz#9ea331766084288634a9247fcd8b84f16ff4ba07"
@@ -54,6 +59,11 @@
   integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
   dependencies:
     "@types/node" "*"
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -138,6 +148,15 @@ chalk@~4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+cli-table3@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.3.tgz#61ab765aac156b52f222954ffc607a6f01dbeeb2"
+  integrity sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==
+  dependencies:
+    string-width "^4.2.0"
+  optionalDependencies:
+    "@colors/colors" "1.5.0"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -229,6 +248,11 @@ duplexify@^4.1.1:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
     stream-shift "^1.0.0"
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
@@ -339,6 +363,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 js-sdsl@^2.1.2:
   version "2.1.4"
@@ -569,12 +598,28 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+string-width@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Currently, MQTTX CLI does not allow users to list all the available built-in scenarios. This creates a usability issue since users may not be aware of all the available scenarios they can use.

#### Issue Number

Example: \#123

#### What is the new behavior?

This PR adds a new ls command to the MQTTX CLI. When used with the --scenarios option, this command will list all the available built-in scenarios and their descriptions. This will make it easier for users to discover and use the built-in scenarios.

Please describe the new behavior or provide screenshots.

<img width="904" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/9c69209f-a7a8-4654-8063-6e2f7c837059">

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
