### PR TITLE
chore(dockerfile): use alpine images to reduce the size of Docker images

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-alpine
 
 WORKDIR /app
 COPY . ./

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:16-alpine
 
 RUN npm i -g http-server
 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Please describe the current behavior and link to a relevant issue.

#### Issue Number

Example: \#123

#### What is the new behavior?

Please describe the new behavior or provide screenshots.

Use the alpine image, a lighter base image to build the MQTTX CLI Docker, and be able to reduce the size by 600MB.

<img width="1038" alt="image" src="https://github.com/emqx/MQTTX/assets/25006774/ad447722-5518-4efa-890d-e88d312be34f">

In the future we could consider putting the pkg compiled binary package into an alpine image that does not contain the nodejs runtime.
The image would then be only 60MB in size.
The reason for not implementing this now is that it requires a more complex build step

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
