### PR TITLE
feat(cli):support input formatted messages to publish

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -197,11 +197,7 @@ export class Commander {
       )
       .option('-Pp, --protobuf-path <PATH>', 'the .proto file that defines the message format of protobuf')
       .option('-Pmn, --protobuf-message-name <NAME>', 'the name of the protobuf message type')
-      .option(
-        '-Pft, --protobuf-format-type <TYPE>',
-        'the format type of message body, support base64, json, hex',
-        parseFormat,
-      )
+      .option('-f, --format <TYPE>', 'the format type of the input message, support base64, json, hex', parseFormat)
       .allowUnknownOption(false)
       .action(pub)
 

--- a/cli/src/lib/pub.ts
+++ b/cli/src/lib/pub.ts
@@ -18,7 +18,7 @@ const send = (
     message: string | Buffer
     protobufPath: string | undefined
     protobufMessageName: string | undefined
-    protobufFormatType: FormatType | undefined
+    format: FormatType | undefined
     opts: IClientPublishOptions
   },
 ) => {
@@ -26,9 +26,9 @@ const send = (
   basicLog.connecting(config, connOpts.hostname!, connOpts.port, pubOpts.topic, pubOpts.message.toString())
   client.on('connect', () => {
     basicLog.connected()
-    const { topic, message, protobufPath, protobufMessageName, protobufFormatType } = pubOpts
+    const { topic, message, protobufPath, protobufMessageName, format } = pubOpts
     basicLog.publishing()
-    let bufferMessage = serializeProtobufToBuffer(message, protobufPath, protobufMessageName, protobufFormatType)
+    let bufferMessage = serializeProtobufToBuffer(message, protobufPath, protobufMessageName, format)
     client.publish(topic, bufferMessage, pubOpts.opts, (err) => {
       if (err) {
         signale.warn(err)
@@ -59,7 +59,7 @@ const multisend = (
     message: string | Buffer
     protobufPath: string | undefined
     protobufMessageName: string | undefined
-    protobufFormatType: FormatType | undefined
+    format: FormatType | undefined
     opts: IClientPublishOptions
   },
   maximumReconnectTimes: number,
@@ -72,9 +72,9 @@ const multisend = (
     objectMode: true,
   })
   sender._write = (line, _enc, cb) => {
-    const { topic, opts, protobufPath, protobufMessageName, protobufFormatType } = pubOpts
+    const { topic, opts, protobufPath, protobufMessageName, format } = pubOpts
 
-    let bufferMessage = serializeProtobufToBuffer(line.trim(), protobufPath, protobufMessageName, protobufFormatType)
+    let bufferMessage = serializeProtobufToBuffer(line.trim(), protobufPath, protobufMessageName, format)
     client.publish(topic, bufferMessage, opts, cb)
   }
 

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -74,7 +74,7 @@ declare global {
     connUserProperties?: Record<string, string | string[]>
     protobufPath?: string
     protobufMessageName?: string
-    protobufFormatType?: FormatType
+    format?: FormatType
   }
 
   interface SubscribeOptions extends ConnectOptions {
@@ -100,7 +100,7 @@ declare global {
 
   type OmitPublishOptions = Omit<
     PublishOptions,
-    'stdin' | 'multiline' | 'protobufPath' | 'protobufMessageName' | 'protobufFormatType'
+    'stdin' | 'multiline' | 'protobufPath' | 'protobufMessageName' | 'format'
   >
 
   interface BenchPublishOptions extends OmitPublishOptions {

--- a/cli/src/utils/parse.ts
+++ b/cli/src/utils/parse.ts
@@ -291,7 +291,7 @@ const parsePublishOptions = (options: PublishOptions) => {
     contentType,
     protobufPath,
     protobufMessageName,
-    protobufFormatType,
+    format,
   } = options
 
   const publishOptions: IClientPublishOptions = {
@@ -317,7 +317,7 @@ const parsePublishOptions = (options: PublishOptions) => {
     )
   }
 
-  return { topic, message, protobufPath, protobufMessageName, protobufFormatType, opts: publishOptions }
+  return { topic, message, protobufPath, protobufMessageName, format, opts: publishOptions }
 }
 
 const parseSubscribeOptions = (options: SubscribeOptions) => {

--- a/cli/src/utils/protobufErrors.ts
+++ b/cli/src/utils/protobufErrors.ts
@@ -1,3 +1,6 @@
+/**
+ * @reference https://github.com/spluxx/Protoman/blob/master/src/core/protobuf/pbjsErrors.ts
+ */
 function prepend(msg: string): string {
   return `Message deserialization error: ${msg}`
 }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?


#### Issue Number

[#1328 ](https://github.com/emqx/MQTTX/issues/1328)

#### What is the new behavior?

feat(cli):support input formatted messages to publish

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions
mqttx pub
```
.option('-f, --format <TYPE>', 'the format type of the input message, support base64, json, hex', parseFormat)
```

#### Other information
