### PR TITLE
style(connections):modify left-panel width

### DIFF
--- a/src/components/LeftPanel.vue
+++ b/src/components/LeftPanel.vue
@@ -20,7 +20,7 @@ export default class LeftPanel extends Vue {}
     position: fixed;
     left: 341px;
     z-index: 1;
-    width: 230px;
+    width: 240px;
     background: var(--color-bg-normal);
     border-radius: 0;
     top: 0;

--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -1831,11 +1831,11 @@ export default class ConnectionsDetail extends Vue {
           @include flex-space-between;
           .received-type-select {
             width: 95px;
-            margin-left: 245px;
+            margin-left: 255px;
           }
           .icon-tip {
             position: absolute;
-            left: 245px;
+            left: 255px;
             font-size: 16px;
             color: var(--color-text-tips);
           }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

On different devices, the Qos word may have a different width, due to some rendering differences, and will be displayed on the second line.

#### Issue Number

#1319 

#### What is the new behavior?

Leave more width to make it less compact

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
