### PR TITLE
fix(connections-detail):use event listeners instead of onsize events

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -1670,16 +1670,18 @@ export default class ConnectionsDetail extends Vue {
 
   private mounted() {
     this.setMessageListHeight()
-    window.onresize = () => {
+    window.addEventListener('resize', () => {
       this.setMessageListHeight()
-    }
+    })
   }
 
   private beforeDestroy() {
     ipcRenderer.removeAllListeners('searchContent')
     this.removeClinetsMessageListener()
     this.stopTimedSend()
-    window.onresize = null
+    window.removeEventListener('resize', () => {
+      this.setMessageListHeight()
+    })
   }
 }
 </script>

--- a/src/views/update/index.vue
+++ b/src/views/update/index.vue
@@ -161,7 +161,15 @@ export default class Update extends Vue {
     if (this.autoCheck) {
       await this.updateCheck(true)
     }
-    window.onresize = () => this.setDialogSize()
+    window.addEventListener('resize', () => {
+      this.setDialogSize()
+    })
+  }
+
+  private beforeDestroy() {
+    window.removeEventListener('resize', () => {
+      this.setDialogSize()
+    })
   }
 }
 </script>


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

window.onresize  events can bind only one event at a time, causing overrides
（multiple components use window.onresize events）

#### Issue Number

#1354 

#### What is the new behavior?
use event listeners instead of onsize events

refer link: https://www.cnblogs.com/wangweizhang/p/12874679.html

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
