### PR TITLE
fix(cli): fix pub the wrong base64 formart message

### DIFF
--- a/cli/src/utils/convertPayload.ts
+++ b/cli/src/utils/convertPayload.ts
@@ -1,24 +1,36 @@
 import chalk from 'chalk'
 
-const convertJSON = (value: Buffer) => {
+const convertJSON = (value: Buffer | string, action: 'encode' | 'decode') => {
   try {
-    return JSON.stringify(JSON.parse(value.toString()), null, 2)
+    if (action === 'decode') {
+      return JSON.stringify(JSON.parse(value.toString()), null, 2)
+    } else {
+      return Buffer.from(JSON.stringify(JSON.parse(value.toString())))
+    }
   } catch (err) {
     return chalk.red(err)
   }
 }
 
-const convertPayload = (payload: Buffer, to?: FormatType) => {
-  switch (to) {
-    case 'base64':
-      return payload.toString('base64')
-    case 'json':
-      return convertJSON(payload)
-    case 'hex':
-      return payload.toString('hex').replace(/(.{4})/g, '$1 ')
-    default:
-      return payload.toString('utf-8')
+const convertPayload = (payload: Buffer | string, format?: FormatType, action: 'encode' | 'decode' = 'decode') => {
+  const actions = {
+    encode: {
+      base64: () => Buffer.from(payload.toString(), 'base64'),
+      json: () => convertJSON(payload, 'encode'),
+      hex: () => Buffer.from(payload.toString().replace(/\s+/g, ''), 'hex'),
+      default: () => Buffer.from(payload.toString(), 'utf-8'),
+    },
+    decode: {
+      base64: () => payload.toString('base64'),
+      json: () => convertJSON(payload, 'decode'),
+      hex: () => payload.toString('hex').replace(/(.{4})/g, '$1 '),
+      default: () => payload.toString('utf-8'),
+    },
   }
+  const actionSet = actions[action]
+  const runAction = actionSet[format || 'default']
+
+  return runAction ? runAction() : payload
 }
 
 export default convertPayload

--- a/cli/src/utils/protobuf.ts
+++ b/cli/src/utils/protobuf.ts
@@ -2,78 +2,53 @@ import protobuf from 'protobufjs'
 import signale from './signale'
 import { transformPBJSError } from './protobufErrors'
 
-const convertObject = (raw: string | Buffer, format?: FormatType | undefined) => {
-  switch (format) {
-    case 'base64':
-      return Buffer.from(raw.toString('utf-8'), 'base64').toString('utf-8')
-    case 'hex':
-      return Buffer.from(raw.toString('utf-8').replaceAll(' ', ''), 'hex').toString('utf-8')
-    case 'json':
-      return JSON.stringify(JSON.parse(raw.toString('utf-8')), null, 2)
-    default:
-      return raw.toString('utf-8')
-  }
-}
-
 export const serializeProtobufToBuffer = (
   raw: string | Buffer,
-  protobufPath: string | undefined,
-  protobufMessageName: string | undefined,
-  format?: FormatType | undefined,
+  protobufPath: string,
+  protobufMessageName: string,
 ): Buffer => {
-  let rawData
-  try {
-    rawData = convertObject(raw, format)
-  } catch (error: unknown) {
-    signale.error(`Message format type error : ${(error as Error).message.split('\n')[0]}`)
-    process.exit(1)
-  }
-
+  let rawData = raw.toString('utf-8')
   let bufferMessage = Buffer.from(rawData)
-  if (protobufPath && protobufMessageName) {
-    try {
-      const root = protobuf.loadSync(protobufPath)
-      const Message = root.lookupType(protobufMessageName)
-      const err = Message.verify(JSON.parse(rawData))
-      if (err) {
-        signale.error(`Message serialization error: ${err}`)
-        process.exit(1)
-      }
-      const data = Message.create(JSON.parse(rawData))
-      const serializedMessage = Message.encode(data).finish()
-      bufferMessage = Buffer.from(serializedMessage)
-    } catch (error: unknown) {
-      signale.error(`Message serialization error: ${(error as Error).message.split('\n')[0]}`)
+  try {
+    const root = protobuf.loadSync(protobufPath)
+    const Message = root.lookupType(protobufMessageName)
+    const err = Message.verify(JSON.parse(rawData))
+    if (err) {
+      signale.error(`Message serialization error: ${err}`)
       process.exit(1)
     }
+    const data = Message.create(JSON.parse(rawData))
+    const serializedMessage = Message.encode(data).finish()
+    bufferMessage = Buffer.from(serializedMessage)
+  } catch (error: unknown) {
+    signale.error(`Message serialization error: ${(error as Error).message.split('\n')[0]}`)
+    process.exit(1)
   }
   return bufferMessage
 }
 
 export const deserializeBufferToProtobuf = (
   payload: Buffer,
-  protobufPath: string | undefined,
-  protobufMessageName: string | undefined,
-  to?: FormatType,
+  protobufPath: string,
+  protobufMessageName: string,
+  needFormat: FormatType | undefined,
 ): any => {
-  if (protobufPath && protobufMessageName) {
-    try {
-      const root = protobuf.loadSync(protobufPath)
-      const Message = root.lookupType(protobufMessageName)
-      const MessageData = Message.decode(payload)
-      const err = Message.verify(MessageData)
-      if (err) {
-        signale.error(`Message deserialization error: ${err}`)
-        process.exit(1)
-      }
-      if (to) {
-        return Buffer.from(JSON.stringify(MessageData.toJSON()))
-      }
-      return MessageData
-    } catch (error: unknown) {
-      let err = transformPBJSError(error as Error)
-      signale.error(err.message.split('\n')[0])
+  try {
+    const root = protobuf.loadSync(protobufPath)
+    const Message = root.lookupType(protobufMessageName)
+    const MessageData = Message.decode(payload)
+    const err = Message.verify(MessageData)
+    if (err) {
+      signale.error(`Message deserialization error: ${err}`)
       process.exit(1)
     }
+    if (needFormat) {
+      return Buffer.from(JSON.stringify(MessageData.toJSON()))
+    }
+    return MessageData
+  } catch (error: unknown) {
+    let err = transformPBJSError(error as Error)
+    signale.error(err.message.split('\n')[0])
+    process.exit(1)
   }
 }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

```shell
mqttx pub -t testtopic/protobuf -h 127.0.0.1 -m 'A00340168F4' --format hex
```

![image](https://github.com/emqx/MQTTX/assets/21299158/68fc5428-b263-4bfb-8ddb-253e9eb88a58)


#### Issue Number

https://askemq.com/t/topic/5820

#### What is the new behavior?

<img width="382" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/15cfa81e-9286-4e3f-8f0e-8bb4df4a0c52">

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
