### PR TITLE
fix(theme): add unit to avoid deprecation warning

### DIFF
--- a/src/assets/scss/theme/custom/prism-one-light.scss
+++ b/src/assets/scss/theme/custom/prism-one-light.scss
@@ -381,7 +381,7 @@ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
 /* Border around popup */
 .prism-previewer.prism-previewer:before,
 .prism-previewer-gradient.prism-previewer-gradient div {
-  border-color: hsl(0, 0, 95%);
+  border-color: hsl(0, 0%, 95%);
 }
 
 /* Angle and time should remain as circles and are hence not included */
@@ -393,11 +393,11 @@ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
 
 /* Triangles pointing to the code */
 .prism-previewer.prism-previewer:after {
-  border-top-color: hsl(0, 0, 95%);
+  border-top-color: hsl(0, 0%, 95%);
 }
 
 .prism-previewer-flipped.prism-previewer-flipped.after {
-  border-bottom-color: hsl(0, 0, 95%);
+  border-bottom-color: hsl(0, 0%, 95%);
 }
 
 /* Background colour within the popup */


### PR DESCRIPTION
#### What is the current behavior?

Build throws warnings.

> DEPRECATION WARNING: $saturation: Passing a number without unit % (0) is deprecated.


#### Issue Number

none

#### What is the new behavior?

No warning.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

none

#### Other information

none