### PR TITLE
feat(deps): add engines

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -17,6 +17,9 @@
     "mqttx": "./bin/index.js"
   },
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "axios": "^0.27.2",
     "chalk": "~4.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "db:diagram": "TS_NODE_PROJECT=tsconfig.commonjs.json ts-node ./node_modules/.bin/typeorm-uml ormconfig.ts -d ./src/database/database.png"
   },
   "main": "background.js",
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "appdata-path": "^1.0.0",
     "axios": "^0.21.2",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,9 @@
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint"
   },
+  "engines": {
+    "node": ">=16"
+  },
   "dependencies": {
     "@gtm-support/vue2-gtm": "^1.3.0",
     "axios": "^0.21.2",


### PR DESCRIPTION
#### What is the current behavior?

No warning if installed on old outdated nodejs.

#### Issue Number

none

#### What is the new behavior?

Not installable on old outdated nodejs without extra ignore flag.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

Removes nodejs <16.

#### Specific Instructions

none

#### Other information

none