### PR TITLE
fix(cli):fix topic-alias-maximum error in cli connect

### DIFF
--- a/cli/src/lib/pub.ts
+++ b/cli/src/lib/pub.ts
@@ -95,10 +95,13 @@ const multisend = (
   const sender = new Writable({
     objectMode: true,
   })
+  let count = 0
   sender._write = (line, _enc, cb) => {
     const { topic, opts, protobufPath, protobufMessageName, format } = pubOpts
+    count++
+    let omitTopic = opts.properties?.topicAlias && count >= 2
     const publishMessage = processPublishMessage(line.trim(), protobufPath, protobufMessageName, format)
-    client.publish(topic, publishMessage, opts, cb)
+    client.publish(omitTopic ? '' : topic, publishMessage, opts, cb)
   }
 
   client.on('connect', () => {

--- a/cli/src/utils/parse.ts
+++ b/cli/src/utils/parse.ts
@@ -247,7 +247,7 @@ const parseConnectOptions = (
         Object.entries(willProperties).filter(([_, v]) => v !== null && v !== undefined),
       ))
   }
-
+  let optionsTempWorkAround
   if (mqttVersion === 3) {
     connectOptions.protocolId = 'MQIsdp'
   } else if (mqttVersion === 5) {
@@ -274,9 +274,15 @@ const parseConnectOptions = (
     connectOptions.properties = Object.fromEntries(
       Object.entries(properties).filter(([_, v]) => v !== null && v !== undefined),
     )
+    // Map options.properties.topicAliasMaximum to options.topicAliasMaximum, as that is where MQTT.js looks for it.
+    // TODO: remove after bug fixed in MQTT.js v5.
+    optionsTempWorkAround = Object.assign(
+      { topicAliasMaximum: connectOptions.properties ? connectOptions.properties.topicAliasMaximum : undefined },
+      connectOptions,
+    )
   }
 
-  return connectOptions
+  return optionsTempWorkAround || connectOptions
 }
 
 const parsePublishOptions = (options: PublishOptions) => {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

1. When using --topic-alias-maximum during sub and connect, it will cause an error when receiving messages.
It's normal to use --topic-alias-maximum when pub.
2. set a topic alias, and send multiple messages with the --multiline option, each message will contain both the topic and the topic alias.

#### Issue Number

#1398 

#### What is the new behavior?

1. fix topic-alias-maximum bug
2. only send once topic when multiline send and topic-alias is exist

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
