### PR TITLE
fix(web):fix topic-alias-maximum error in connect

### DIFF
--- a/web/src/utils/mqttUtils.ts
+++ b/web/src/utils/mqttUtils.ts
@@ -128,7 +128,13 @@ const getUrl = (record: ConnectionModel): string => {
 export const createClient = (record: ConnectionModel): { curConnectClient: MqttClient; connectUrl: string } => {
   const options: IClientOptions = getClientOptions(record)
   const url = getUrl(record)
-  const curConnectClient: MqttClient = mqtt.connect(url, options)
+  // Map options.properties.topicAliasMaximum to options.topicAliasMaximum, as that is where MQTT.js looks for it.
+  // TODO: remove after bug fixed in MQTT.js v5.
+  const optionsTempWorkAround = Object.assign(
+    { topicAliasMaximum: options.properties ? options.properties.topicAliasMaximum : undefined },
+    options,
+  )
+  const curConnectClient: MqttClient = mqtt.connect(url, optionsTempWorkAround)
 
   return { curConnectClient, connectUrl: url }
 }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When using topic alias maximum during connect, it will cause an error when receiving messages.

#### Issue Number

#1398 

#### What is the new behavior?

fix topic-alias-maximum bug

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
