### PR TITLE
fix(update): fix typo

### DIFF
--- a/src/lang/update.ts
+++ b/src/lang/update.ts
@@ -57,7 +57,7 @@ export default {
   },
   install: {
     zh: '安装并重启',
-    en: 'Install and Relunch',
+    en: 'Install and Relaunch',
     ja: 'インストールして再起動',
     tr: 'Kur ve Tekrar Başlat',
     hu: 'Telepítés és újraindítás',


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

Currently, in the MQTTX installer for version v1.9.6, there's a typo in the final dialog button. The button text reads "Install and Relunch" instead of the intended "Install and Relaunch".

#### Issue Number

#1500

#### What is the new behavior?

This PR corrects the typo in the installer dialog. The button now correctly states "Install and Relaunch". This change enhances the professionalism of the interface and eliminates any confusion caused by the typo.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Specific Instructions

No specific instructions. The change is a simple text update and does not affect any functionality or other aspects of the MQTTX application.

#### Other information

The fix is straightforward and was tested to ensure that no other parts of the application are impacted. This change will be included in the upcoming v1.9.7 release of MQTTX.
