### PR TITLE
fix:throw an error for invaild json string

### DIFF
--- a/cli/src/utils/jsonUtils.ts
+++ b/cli/src/utils/jsonUtils.ts
@@ -5,10 +5,15 @@ export const jsonParse: typeof JSON.parse = (...args: any[]) => {
   try {
     // When JSON only contains integers, use the native bigint type.
     return JSONBigInt.parse(...args)
-  } catch (_error) {
-    // When JSON contains floating-point numbers, use the bignumber library.
-    // The numbers in the parsed JSON Object will be represented as BigNumber Objects.
-    return JSONBigNumber.parse(...args)
+  } catch {
+    try {
+      // When JSON contains floating-point numbers, use the bignumber library.
+      // The numbers in the parsed JSON Object will be represented as BigNumber Objects.
+      return JSONBigNumber.parse(...args)
+    } catch {
+      // To verify the validity of the JSON string and throw an error if it's invalid.
+      return JSON.parse(args[0], args[1])
+    }
   }
 }
 

--- a/src/utils/jsonUtils.ts
+++ b/src/utils/jsonUtils.ts
@@ -5,10 +5,15 @@ export const jsonParse: typeof JSON.parse = (...args: any[]) => {
   try {
     // When JSON only contains integers, use the native bigint type.
     return JSONBigInt.parse(...args)
-  } catch (_error) {
-    // When JSON contains floating-point numbers, use the bignumber library.
-    // The numbers in the parsed JSON Object will be represented as BigNumber Objects.
-    return JSONBigNumber.parse(...args)
+  } catch {
+    try {
+      // When JSON contains floating-point numbers, use the bignumber library.
+      // The numbers in the parsed JSON Object will be represented as BigNumber Objects.
+      return JSONBigNumber.parse(...args)
+    } catch {
+      // To verify the validity of the JSON string and throw an error if it's invalid.
+      return JSON.parse(args[0], args[1])
+    }
   }
 }
 

--- a/web/src/utils/jsonUtils.ts
+++ b/web/src/utils/jsonUtils.ts
@@ -5,10 +5,15 @@ export const jsonParse: typeof JSON.parse = (...args: any[]) => {
   try {
     // When JSON only contains integers, use the native bigint type.
     return JSONBigInt.parse(...args)
-  } catch (_error) {
-    // When JSON contains floating-point numbers, use the bignumber library.
-    // The numbers in the parsed JSON Object will be represented as BigNumber Objects.
-    return JSONBigNumber.parse(...args)
+  } catch {
+    try {
+      // When JSON contains floating-point numbers, use the bignumber library.
+      // The numbers in the parsed JSON Object will be represented as BigNumber Objects.
+      return JSONBigNumber.parse(...args)
+    } catch {
+      // To verify the validity of the JSON string and throw an error if it's invalid.
+      return JSON.parse(args[0], args[1])
+    }
   }
 }
 


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

Please describe the current behavior and link to a relevant issue.

The functions JSONBigInt.parse() and JSONBigNumber.parse() generate an error when encountering an invalid JSON string, but do not properly throw it.

![img1](https://github.com/emqx/MQTTX/assets/56543214/e8d39a3b-d97a-4eb6-85bc-0cba10ef3727)

#### Issue Number

#### What is the new behavior?
![img2](https://github.com/emqx/MQTTX/assets/56543214/7808fb8e-ffc4-4e82-b6cc-8f48041c014d)


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions


#### Other information
