### PR TITLE
feat(cli): add message limit option to bench pub command

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -390,6 +390,12 @@ export class Commander {
       .option('-i, --interval <MILLISECONDS>', 'interval of connecting to the broker', parseNumber, 10)
       .option('-im, --message-interval <MILLISECONDS>', 'interval of publishing messages', parseNumber, 1000)
       .option(
+        '-L, --limit <NUMBER>',
+        'The maximum number of messages to publish. A value of 0 means no limit on the number of messages',
+        parseNumber,
+        0,
+      )
+      .option(
         '-t, --topic <TOPIC>',
         'the message topic, support %u (username), %c (client id), %i (index) variables',
         parsePubTopic,

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -111,6 +111,7 @@ declare global {
     count: number
     interval: number
     messageInterval: number
+    limit: number
     verbose: boolean
   }
 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The `bench pub` command cannot limit the total number of messages sent.

#### Issue Number

\#1360

#### What is the new behavior?

- The message will not be sent until all connections are established.
- Support limiting the total number of messages.

<img width="1347" alt="image" src="https://github.com/emqx/MQTTX/assets/38158783/7d31a0c8-26a9-4cfa-a06e-8a5a8af77530">


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
