### PR TITLE
feat(cli): add message limit option to simulate command

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -391,7 +391,7 @@ export class Commander {
       .option('-im, --message-interval <MILLISECONDS>', 'interval of publishing messages', parseNumber, 1000)
       .option(
         '-L, --limit <NUMBER>',
-        'The maximum number of messages to publish. A value of 0 means no limit on the number of messages',
+        'the maximum number of messages to publish. a value of 0 means no limit on the number of messages',
         parseNumber,
         0,
       )
@@ -584,6 +584,12 @@ export class Commander {
       .option('-c, --count <NUMBER>', 'the number of connections', parseNumber, 1000)
       .option('-i, --interval <MILLISECONDS>', 'interval of connecting to the broker', parseNumber, 10)
       .option('-im, --message-interval <MILLISECONDS>', 'interval of publishing messages', parseNumber, 1000)
+      .option(
+        '-L, --limit <NUMBER>',
+        'the maximum number of messages to publish. a value of 0 means no limit on the number of messages',
+        parseNumber,
+        0,
+      )
       .option(
         '-t, --topic <TOPIC>',
         'the message topic, support %u (username), %c (client id), %i (index), %sc (scenario) variables',


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The "simulate" command cannot limit the total number of messages sent.

#### Issue Number

\#1597

#### What is the new behavior?

<img width="1347" alt="image" src="https://github.com/emqx/MQTTX/assets/38158783/6ee88bd2-744d-405a-bbb2-f8ef0d7ddc66">


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
