### PR TITLE
feat(desktop): remember the selected encode/decode type

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -230,7 +230,7 @@
       <div class="connections-body">
         <div ref="filterBar" class="filter-bar" :style="{ top: bodyTopValue, left: detailLeftValue }">
           <div class="message-type">
-            <el-select class="received-type-select" size="mini" v-model="receivedMsgType">
+            <el-select class="received-type-select" size="mini" v-model="receivedMsgType" @change="handleReceivedMsgTypeChange">
               <el-option-group :label="$t('connections.receivedPayloadDecodedBy')">
                 <el-option v-for="type in ['Plaintext', 'JSON', 'Base64', 'Hex', 'CBOR']" :key="type" :value="type">
                 </el-option>
@@ -435,7 +435,7 @@ export default class ConnectionsDetail extends Vue {
   private sendFrequency: number | undefined = undefined
   private sendTimeId: number | null = null
   private sendTimedMessageCount = 0
-  private receivedMsgType: PayloadType = 'Plaintext'
+  private receivedMsgType: PayloadType = this.getReceivedMsgType()
   private msgType: MessageType = 'all'
 
   private client: Partial<MqttClient> = {
@@ -907,6 +907,18 @@ export default class ConnectionsDetail extends Vue {
   private loadNewMsg() {
     this.msgType = 'all'
     this.handleMessages({ behavior: 'auto' })
+  }
+
+  private getReceivedMsgType(): PayloadType {
+    const _receivedMsgType = localStorage.getItem('receivedMsgType')
+    if (!_receivedMsgType) {
+      return 'Plaintext'
+    }
+    return _receivedMsgType as PayloadType
+  }
+
+  private handleReceivedMsgTypeChange(receivedMsgType: PayloadType) {
+    localStorage.setItem('receivedMsgType', receivedMsgType)
   }
 
   // Clear messages


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Restarting \ switching tools will change the default value of plaintext, resulting in other encoded messages will be garbled.

#### Issue Number

 \#903

#### What is the new behavior?

Remember the encoding/decoding type selected by the user.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
