### PR TITLE
feat(desktop): add save button for new & edit connection

### DIFF
--- a/src/lang/common.ts
+++ b/src/lang/common.ts
@@ -111,6 +111,13 @@ export default {
     ja: '削除に失敗しました',
     hu: 'Sikertelen törlés',
   },
+  saveSuccess: {
+    zh: '保存成功',
+    en: 'Save Success',
+    tr: 'Kaydetme Başarılı',
+    ja: '保存に成功しました',
+    hu: 'Sikeres mentés'
+  },
   warning: {
     zh: '提示',
     en: 'Warning',

--- a/src/views/connections/index.vue
+++ b/src/views/connections/index.vue
@@ -24,7 +24,7 @@
           :click-method="toCreateConnection"
         />
         <template v-else>
-          <ConnectionForm v-if="oper" ref="connectionForm" :oper="oper" @connect="onConnect" />
+          <ConnectionForm v-if="oper" ref="connectionForm" :oper="oper" @connect="onConnect" @refresh="loadData" />
           <ConnectionsDetail
             v-show="!oper"
             ref="connectionsDetail"

--- a/web/src/lang/common.ts
+++ b/web/src/lang/common.ts
@@ -79,6 +79,11 @@ export default {
     en: 'Delete Failed',
     ja: '削除に失敗しました',
   },
+  saveSuccess: {
+    zh: '保存成功',
+    en: 'Save Success',
+    ja: '保存に成功しました',
+  },
   warning: {
     zh: '提示',
     en: 'Warning',

--- a/web/src/views/connections/index.vue
+++ b/web/src/views/connections/index.vue
@@ -13,7 +13,7 @@
         :click-method="toCreateConnection"
       />
       <template v-else>
-        <ConnectionForm v-if="oper" ref="connectionForm" :oper="oper" @connect="onConnect" />
+        <ConnectionForm v-if="oper" ref="connectionForm" :oper="oper" @connect="onConnect" @refresh="loadData" />
         <ConnectionsDetail
           v-show="!oper"
           ref="ConnectionsDetail"


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When you want to make a new connection and fill in some (but not necessarly all) fields you can't temporailty save it and complement it later on. You can only choose Connect which is not always what you want. The same goes for editing connections.

#### Issue Number

#735

#### What is the new behavior?

When creating or editing connection information, the current information can be saved. Instead of clicking the `Connect` button to establish a connection.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information


![屏幕录制2024-03-25 10 19 26](https://github.com/emqx/MQTTX/assets/119273236/174177f5-d396-4078-a4b5-443638985c75)

