### PR TITLE
feat(web): add env file to support configuration of BASE_URL

### DIFF
--- a/.github/workflows/deploy_web.yaml
+++ b/.github/workflows/deploy_web.yaml
@@ -19,12 +19,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: set env
-        run: |
-          cd web
-          echo "VUE_APP_PAGE_TITLE=Easy-to-Use Online MQTT Client | Try Now" > .env.local
-          echo "VUE_APP_PAGE_DESCRIPTION=Online MQTT 5.0 client on the web, using MQTT over WebSocket to connect to the MQTT Broker and test message publishing and receiving in the browser." >> .env.local
-
       - name: build
         run: |
           cd web
@@ -48,12 +42,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-
-      - name: set env
-        run: |
-          cd web
-          echo "VUE_APP_PAGE_TITLE=Easy-to-Use Online MQTT Client | Try Now" > .env.local
-          echo "VUE_APP_PAGE_DESCRIPTION=Online MQTT 5.0 client on the web, using MQTT over WebSocket to connect to the MQTT Broker and test message publishing and receiving in the browser." >> .env.local
 
       - name: build
         run: |

--- a/web/.env
+++ b/web/.env
@@ -1,0 +1,7 @@
+VUE_APP_PAGE_TITLE=Easy-to-Use Online MQTT Client | Try Now
+VUE_APP_PAGE_DESCRIPTION=Online MQTT 5.0 client on the web, using MQTT over WebSocket to connect to the MQTT Broker and test message publishing and receiving in the browser.
+
+VUE_APP_DEFAULT_HOST=broker.emqx.io
+
+BASE_URL=/online-mqtt-client/
+VUE_APP_OUTPUT_DIR=dist/online-mqtt-client

--- a/web/.env.docker
+++ b/web/.env.docker
@@ -1,0 +1,7 @@
+VUE_APP_PAGE_TITLE=Easy-to-Use Online MQTT Client | Try Now
+VUE_APP_PAGE_DESCRIPTION=Online MQTT 5.0 client on the web, using MQTT over WebSocket to connect to the MQTT Broker and test message publishing and receiving in the browser.
+
+VUE_APP_DEFAULT_HOST=broker.emqx.io
+
+BASE_URL=/
+VUE_APP_OUTPUT_DIR=dist

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "build:docker": "export BUILD_MODE=docker && vue-cli-service build",
+    "build:docker": "vue-cli-service build --mode docker",
     "start": "vue-cli-service build && http-server dist -o /online-mqtt-client",
     "test:e2e": "vue-cli-service test:e2e",
     "lint": "vue-cli-service lint"

--- a/web/src/utils/mqttUtils.ts
+++ b/web/src/utils/mqttUtils.ts
@@ -156,7 +156,7 @@ export const getDefaultRecord = (): ConnectionModel => {
     name: '',
     clean: true,
     protocol: 'ws',
-    host: 'broker.emqx.io',
+    host: process.env.VUE_APP_DEFAULT_HOST ?? 'broker.emqx.io',
     keepalive: 60,
     connectTimeout: 10,
     reconnect: true,

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -2,11 +2,9 @@ const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 
 process.env.VUE_APP_VERSION = require('./package.json').version
 
-const buildMode = process.env.BUILD_MODE
-
 module.exports = {
-  publicPath: buildMode === 'docker' ? '/' : '/online-mqtt-client/',
-  outputDir: buildMode === 'docker' ? 'dist' : 'dist/online-mqtt-client',
+  publicPath: process.env.BASE_URL,
+  outputDir: process.env.VUE_APP_OUTPUT_DIR,
   configureWebpack: {
     plugins: [
       new MonacoWebpackPlugin({


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Currently, `BASE_URL` is set in `vue.config.js`, and users may not be able to quickly find out how to modify `BASE_URL`.

#### Issue Number

#1575

#### What is the new behavior?

Support to modify configuration by exposing env files.
Distinguishing between the build environment and the docker environment.
Remove related useless step from ci.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

[Modes and Environment Variables | Vue CLI](https://cli.vuejs.org/guide/mode-and-env.html)

#### Other information

Later, I will update readme to improve user-friendliness.
