### PR TITLE
feat(desktop): add database reset page to fix blank screen from corrupted file

### DIFF
--- a/src/components/DatabaseError.vue
+++ b/src/components/DatabaseError.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="connect-database-error-page">
+    <div class="page-content">
+      <p class="info">A corruption has been detected in the database file, preventing the software from launching properly. To fix this, please click 'Rebuild Database'.</p>
+      <p class="error">Error - {{ connectDatabaseFailMessage }}</p>
+    </div>
+    <el-button class="rebuild-database-btn" type="primary" @click="confirmRebuild">
+      Rebuild Database
+    </el-button>
+  </div>
+</template>
+
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator'
+import { Getter } from 'vuex-class'
+import { ipcRenderer } from 'electron'
+
+@Component
+export default class DatabaseError extends Vue {
+  @Getter('connectDatabaseFailMessage') private connectDatabaseFailMessage!: string
+
+  private rebuildDatabase() {
+    ipcRenderer.send('rebuildDatabase')
+  }
+
+  private confirmRebuild() {
+    this.$confirm(
+      'Proceed with database rebuild now? All data will be lost and cannot be undone',
+      {
+        title:'Database Rebuild Confirmation',
+        showClose: false,
+        closeOnClickModal:false,
+        confirmButtonText: 'Confirm',
+        cancelButtonText: 'Cancel',
+        type: 'warning',
+        beforeClose: (action, instance, done) => {
+          if (action === 'confirm') {
+            instance.confirmButtonLoading = true
+            instance.confirmButtonText = 'Loading...'
+          }
+          done()
+        }
+      }
+    )
+    .then(() => {
+      try {
+        this.rebuildDatabase()
+        this.$log.info('Database rebuild completed. The application will restart')
+      } catch (error) {
+        this.$log.error(`Failed to rebuilding database: ${error}`)
+      }
+    })
+  }
+
+  private mounted() {
+    this.$log.error(`Database connect error - ${this.connectDatabaseFailMessage}`)
+  }
+}
+</script>
+
+<style lang="scss">
+.connect-database-error-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  .page-content {
+    text-align: center;
+    width: 60%;
+    font-size: 20px;
+    margin-bottom: 24px;
+    .info {
+      margin-bottom: 14px;
+    }
+    .error {
+      color: var(--color-minor-red);
+    }
+  }
+  .rebuild-database-btn {
+    padding: 10px 16px;
+    border: none;
+    border-radius: 8px;
+  }
+}
+</style>

--- a/src/store/getter.ts
+++ b/src/store/getter.ts
@@ -21,6 +21,7 @@ const getters = {
   isPrismButtonAdded: (state: State) => state.app.isPrismButtonAdded,
   logLevel: (state: State) => state.app.logLevel,
   showConnectionList: (state: State) => state.app.showConnectionList,
+  connectDatabaseFailMessage: (state: State) => state.app.connectDatabaseFailMessage,
 }
 
 export default getters

--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -61,6 +61,7 @@ const app = {
     isPrismButtonAdded: false,
     logLevel: settingData.logLevel || 'info',
     showConnectionList: getShowConnectionList(),
+    connectDatabaseFailMessage: settingData.connectDatabaseFailMessage || '',
   },
   mutations: {
     [TOGGLE_THEME](state: App, currentTheme: Theme) {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -110,6 +110,7 @@ declare global {
     isPrismButtonAdded: boolean
     logLevel: LogLevel
     showConnectionList: boolean
+    connectDatabaseFailMessage: string
   }
 
   interface State {

--- a/src/utils/rebuildDatabase.ts
+++ b/src/utils/rebuildDatabase.ts
@@ -1,0 +1,13 @@
+import fs from 'fs'
+
+const rebuildDatabase = (filePath: string) => {
+  fs.writeFile(filePath, '', (error) => {
+    if (error) {
+      console.error('Error rebuilding database:', error)
+    } else {
+      console.log('Database rebuilt successfully.')
+    }
+  })
+}
+
+export default rebuildDatabase

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="home-view">
+  <DatabaseError v-if="connectDatabaseFailMessage" />
+  <div class="home-view" v-else>
     <Leftbar />
     <RouterView />
     <Ipc @setTheme="setTheme" @setLang="setLang" />
@@ -13,18 +14,21 @@ import { Getter, Action } from 'vuex-class'
 import { remote } from 'electron'
 import Ipc from '@/components/Ipc.vue'
 import Leftbar from '@/components/Leftbar.vue'
+import DatabaseError from '@/components/DatabaseError.vue'
 
 @Component({
   components: {
     Ipc,
     Leftbar,
     Update: () => import('@/views/update/index.vue'),
+    DatabaseError,
   },
 })
 export default class Home extends Vue {
   @Getter('currentTheme') private getterTheme!: Theme
   @Getter('currentLang') private getterLang!: Language
   @Getter('syncOsTheme') private syncOsTheme!: boolean
+  @Getter('connectDatabaseFailMessage') private connectDatabaseFailMessage!: string
   @Action('TOGGLE_THEME') private actionTheme!: (payload: { currentTheme: string }) => void
   @Action('TOGGLE_LANG') private actionLang!: (payload: { currentLang: string }) => void
   private updateActive: boolean = false


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The current behavior is that the application displays a blank screen when the database file is corrupted, preventing users from interacting with the application.

#### Issue Number

#1370

#### What is the new behavior?

The new behavior is that upon detecting a database corruption, the application will redirect the user to an error page where they can initiate a database reset. This resolves the white screen issue and allows the user to restore the application to a working state.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

If you wish to conduct testing, you can do so by altering the fields within the `MQTTX.db` file in the application data to make them non-conforming to the schema.

#### Other information

The UI and UX for the error page and database reset feature are still a work in progress and will be refined in future updates.
This change has been tested on macOS and Windows platforms to confirm that it resolves the white screen issue caused by database corruption.