### PR TITLE
feat(cil): support for reading messages from files in bench

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -497,6 +497,10 @@ export class Commander {
         '--config [PATH]',
         'load the parameters from the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-config.json',
       )
+      .option(
+        '--file-read <PATH>',
+        'read the message body from the file',
+      )
       .allowUnknownOption(false)
       .action(benchPub)
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,5 +1,5 @@
 import 'core-js'
-import { Command } from 'commander'
+import { Command, Option } from 'commander'
 import { getClientId } from './utils/generator'
 import { checkUpdate } from './utils/checkUpdate'
 import {
@@ -10,6 +10,9 @@ import {
   parseQoS,
   parseVariadicOfBooleanType,
   parsePubTopic,
+  parseFileRead,
+  parseFileSave,
+  parseFileWrite,
   parseFormat,
   parseOutputMode,
 } from './utils/parse'
@@ -144,7 +147,7 @@ export class Commander {
       .option('-p, --port <PORT>', 'the broker port', parseNumber)
       .option(
         '-f, --format <TYPE>',
-        'the format type of the input message, support base64, json, hex and cbor',
+        'the format type of the input message, support base64, json, hex, binary and cbor',
         parseFormat,
       )
       .option('-i, --client-id <ID>', 'the client id', getClientId())
@@ -206,6 +209,7 @@ export class Commander {
       .option(
         '--file-read <PATH>',
         'read the message body from the file',
+        parseFileRead
       )
       .option(
         '-Pp, --protobuf-path <PATH>',
@@ -238,7 +242,7 @@ export class Commander {
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
         parseUserProperties,
       )
-      .option('-f, --format <TYPE>', 'format the message body, support base64, json, hex and cbor', parseFormat)
+      .option('-f, --format <TYPE>', 'format the message body, support base64, json, hex, binary and cbor', parseFormat)
       .option('-v, --verbose', 'turn on verbose mode to display incoming MQTT packets')
       .option(
         '--output-mode <default/clean>',
@@ -306,14 +310,9 @@ export class Commander {
         '--config [PATH]',
         'load the parameters from the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-config.json',
       )
-      .option(
-        '--file-write <PATH>',
-        'append received messages to a specified file',
-      )
-      .option(
-        '--file-save <PATH>',
-        'save each received message to a new file',
-      )
+      // https://github.com/tj/commander.js/blob/master/examples/options-conflicts.js
+      .addOption(new Option('--file-write <PATH>', 'append received messages to a specified file').default(parseFileWrite).conflicts('fileSave'))
+      .addOption(new Option('--file-save <PATH>', 'save each received message to a new file').default(parseFileSave).conflicts('fileWrite'))
       .option(
         '-Pp, --protobuf-path <PATH>',
         'the path to the .proto file that defines the message format for Protocol Buffers (protobuf)',
@@ -500,6 +499,7 @@ export class Commander {
       .option(
         '--file-read <PATH>',
         'read the message body from the file',
+        parseFileRead
       )
       .allowUnknownOption(false)
       .action(benchPub)

--- a/cli/src/lib/pub.ts
+++ b/cli/src/lib/pub.ts
@@ -14,8 +14,6 @@ import { readFile, processPath } from '../utils/fileUtils'
 import convertPayload from '../utils/convertPayload'
 import * as Debug from 'debug'
 
-const MQTT_SINGLE_MESSAGE_BYTE_LIMIT = 256 * 1024 * 1024;
-
 const processPublishMessage = (
   message: string | Buffer,
   protobufPath?: string,
@@ -151,22 +149,13 @@ const multisend = (
 }
 
 const handleFileRead = (filePath: string) => {
-  if (!filePath) {
-    signale.error('File path is required when reading from file.')
-    process.exit(1)
-  }
-
   try {
     basicLog.fileReading()
     const bufferData = readFile(filePath)
-    if (bufferData.length >= MQTT_SINGLE_MESSAGE_BYTE_LIMIT) {
-      signale.error('File size over 256MB not supported by MQTT.')
-      process.exit(1)
-    }
     basicLog.fileReadSuccess()
     return bufferData
-  } catch(error) {
-    signale.error('Failed to read file:', error)
+  } catch (err) {
+    signale.error('Failed to read file:', err)
     process.exit(1)
   }
 }

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -118,7 +118,7 @@ declare global {
 
   type OmitSubscribeOptions = Omit<
     SubscribeOptions,
-    'format' | 'outputMode' | 'protobufPath' | 'protobufMessageName' | 'debug'
+    'format' | 'outputMode' | 'protobufPath' | 'protobufMessageName' | 'debug' | 'fileWrite' | 'fileSave'
   >
 
   interface BenchSubscribeOptions extends OmitSubscribeOptions {

--- a/cli/src/utils/fileUtils.ts
+++ b/cli/src/utils/fileUtils.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import YAML from 'js-yaml'
 import signale from 'signale'
 
-export const processPath = (savePath: boolean | string, defaultPath?: string) => {
+const processPath = (savePath: boolean | string, defaultPath?: string) => {
   let filePath = ''
   if (savePath === true && defaultPath) {
     filePath = defaultPath
@@ -16,24 +16,24 @@ export const processPath = (savePath: boolean | string, defaultPath?: string) =>
   return filePath
 }
 
-export const getPathExtname = (filePath: string): string => path.extname(filePath)
+const getPathExtname = (filePath: string): string => path.extname(filePath)
 
-export const fileExists = (filePath: string): boolean => fs.existsSync(filePath)
+const fileExists = (filePath: string): boolean => fs.existsSync(filePath)
 
-export const isYaml = (filePath: string): boolean => {
+const isYaml = (filePath: string): boolean => {
   const fileExtension = getPathExtname(filePath)
   return fileExtension === '.yaml' || fileExtension === '.yml'
 }
 
-export const parseYamlOrJson = (data: string, isYaml: boolean): Config => {
+const parseYamlOrJson = (data: string, isYaml: boolean): Config => {
   return isYaml ? YAML.load(data) : JSON.parse(data)
 }
 
-export const stringifyToYamlOrJson = (data: Config, isYaml: boolean): string => {
+const stringifyToYamlOrJson = (data: Config, isYaml: boolean): string => {
   return isYaml ? YAML.dump(data) : JSON.stringify(data, null, 2)
 }
 
-export const readFile = (filePath: string): Buffer => {
+const readFile = (filePath: string): Buffer => {
   try {
     return fs.readFileSync(filePath)
   } catch (error) {
@@ -42,7 +42,7 @@ export const readFile = (filePath: string): Buffer => {
   }
 }
 
-export const writeFile = (filePath: string, data: string | Buffer): void => {
+const writeFile = (filePath: string, data: string | Buffer): void => {
   try {
     fs.writeFileSync(filePath, data)
   } catch (error) {
@@ -51,7 +51,7 @@ export const writeFile = (filePath: string, data: string | Buffer): void => {
   }
 }
 
-export const appendFile = (filePath: string, data: string | Buffer): void => {
+const appendFile = (filePath: string, data: string | Buffer): void => {
   try {
     fs.appendFileSync(filePath, `${data}\n`)
   } catch (error) {
@@ -60,7 +60,7 @@ export const appendFile = (filePath: string, data: string | Buffer): void => {
   }
 }
 
-export const createNextNumberedFileName = (filePath: string): string => {
+const createNextNumberedFileName = (filePath: string): string => {
   const escapeRegExp = (string: string) => {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
@@ -90,4 +90,17 @@ export const createNextNumberedFileName = (filePath: string): string => {
     signale.error(`Error: Unable to create a new numbered file name for path '${filePath}'.`)
     process.exit(1)
   }
+}
+
+export {
+  processPath,
+  getPathExtname,
+  fileExists,
+  isYaml,
+  parseYamlOrJson,
+  stringifyToYamlOrJson,
+  readFile,
+  writeFile,
+  appendFile,
+  createNextNumberedFileName
 }

--- a/cli/src/utils/parse.ts
+++ b/cli/src/utils/parse.ts
@@ -1,9 +1,12 @@
 import * as fs from 'fs'
 import signale from '../utils/signale'
 import { getSpecialTypesOption } from '../utils/generator'
+import { createNextNumberedFileName, readFile, processPath, getPathExtname } from '../utils/fileUtils'
 
 import { IClientOptions, IClientPublishOptions, IClientSubscribeOptions } from 'mqtt'
 import { getLocalScenarioList, getScenarioFilePath } from './simulate'
+
+const MQTT_SINGLE_MESSAGE_BYTE_LIMIT = 256 * 1024 * 1024
 
 const parseNumber = (value: string) => {
   const parsedValue = Number(value)
@@ -95,6 +98,39 @@ const parsePubTopic = (value: string) => {
     process.exit(1)
   }
   return value
+}
+
+const parseFileRead = (value: string) => {
+  const filePath = processPath(value)
+  if(!filePath) {
+    signale.error('A valid file path is required when reading from file.')
+    process.exit(1)
+  }
+
+  const fileContent = readFile(filePath)
+  if(fileContent.length >= MQTT_SINGLE_MESSAGE_BYTE_LIMIT) {
+    signale.error('File size over 256MB not supported by MQTT.')
+    process.exit(1)
+  }
+  return value
+}
+
+const parseFileSave = (value: string) => {
+  const filePath = createNextNumberedFileName(processPath(value))
+  if(!filePath) {
+    signale.error('A valid file path is required when saving to file.')
+    process.exit(1)
+  }
+  return filePath
+}
+
+const parseFileWrite = (value: string) => {
+  const filePath = processPath(value)
+  if(!filePath) {
+    signale.error('A valid file path is required when writing to file.')
+    process.exit(1)
+  }
+  return filePath
 }
 
 const parseFormat = (value: string) => {
@@ -380,6 +416,9 @@ export {
   checkTopicExists,
   checkScenarioExists,
   parsePubTopic,
+  parseFileRead,
+  parseFileSave,
+  parseFileWrite,
   parseFormat,
   parseOutputMode,
   parseConnectOptions,

--- a/cli/src/utils/signale.ts
+++ b/cli/src/utils/signale.ts
@@ -52,7 +52,9 @@ const basicLog = {
     const { reasonCode } = packet
     const reason = reasonCode === 0 ? 'Normal disconnection' : getErrorReason(reasonCode)
     signale.warn(`${clientId ? `Client ID: ${clientId}, ` : ''}The Broker has actively disconnected, Reason: ${reason} (Code: ${reasonCode})`)
-  }
+  },
+  fileReading: () => signale.await('Reading file...'),
+  fileReadSuccess: () => signale.success('Read file successfully'),
 }
 
 const benchLog = {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The bench feature does not support reading messages from files.

#### Issue Number

#### What is the new behavior?

This PR adds support for reading messages from files in the bench feature, allowing users to send messages from file sources.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

#### Other information
