### PR TITLE
fix(cli): fix options handler of file write

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -311,8 +311,8 @@ export class Commander {
         'load the parameters from the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-config.json',
       )
       // https://github.com/tj/commander.js/blob/master/examples/options-conflicts.js
-      .addOption(new Option('--file-write <PATH>', 'append received messages to a specified file').default(parseFileWrite).conflicts('fileSave'))
-      .addOption(new Option('--file-save <PATH>', 'save each received message to a new file').default(parseFileSave).conflicts('fileWrite'))
+      .addOption(new Option('--file-write <PATH>', 'append received messages to a specified file').argParser(parseFileWrite).conflicts('fileSave'))
+      .addOption(new Option('--file-save <PATH>', 'save each received message to a new file').argParser(parseFileSave).conflicts('fileWrite'))
       .option(
         '-Pp, --protobuf-path <PATH>',
         'the path to the .proto file that defines the message format for Protocol Buffers (protobuf)',

--- a/cli/src/lib/sub.ts
+++ b/cli/src/lib/sub.ts
@@ -4,7 +4,7 @@ import { parseConnectOptions, parseSubscribeOptions, checkTopicExists } from '..
 import delay from '../utils/delay'
 import convertPayload from '../utils/convertPayload'
 import { saveConfig, loadConfig } from '../utils/config'
-import { writeFile, appendFile, getPathExtname } from '../utils/fileUtils'
+import { writeFile, appendFile, getPathExtname, createNextNumberedFileName } from '../utils/fileUtils'
 import { deserializeBufferToProtobuf } from '../utils/protobuf'
 import isSupportedBinaryFormatForMQTT from '../utils/binaryFormats'
 import * as Debug from 'debug'
@@ -114,7 +114,7 @@ const sub = (options: SubscribeOptions) => {
 
     const receivedMessage = processReceivedMessage(payload, protobufPath, protobufMessageName, format)
 
-    const savePath = fileSave ?? fileWrite
+    const savePath = fileSave ? createNextNumberedFileName(fileSave) : fileWrite
     if(savePath) {
       fileSave && writeFile(savePath, receivedMessage)
       fileWrite && appendFile(savePath, receivedMessage)

--- a/cli/src/utils/parse.ts
+++ b/cli/src/utils/parse.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs'
 import signale from '../utils/signale'
 import { getSpecialTypesOption } from '../utils/generator'
-import { createNextNumberedFileName, readFile, processPath, getPathExtname } from '../utils/fileUtils'
+import { readFile, processPath } from '../utils/fileUtils'
 
 import { IClientOptions, IClientPublishOptions, IClientSubscribeOptions } from 'mqtt'
 import { getLocalScenarioList, getScenarioFilePath } from './simulate'
@@ -116,7 +116,7 @@ const parseFileRead = (value: string) => {
 }
 
 const parseFileSave = (value: string) => {
-  const filePath = createNextNumberedFileName(processPath(value))
+  const filePath = processPath(value)
   if(!filePath) {
     signale.error('A valid file path is required when saving to file.')
     process.exit(1)


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The CLI incorrectly handles the `--file-write` option make subscribe error.

#### Issue Number

NONE

#### What is the new behavior?

The CLI tool correctly handles the `--file-write` option, ensuring that received messages are properly appended to the specified file.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions


#### Other information
