### PR TITLE
fix(cli): fix can not display split default value

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -501,7 +501,10 @@ export class Commander {
         'load the parameters from the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-config.json',
       )
       .option('--file-read <PATH>', 'read the message body from the file', parseFileRead)
-      .option('--split [CHARACTER]', 'split the input message in a single file by a specified character, default is \n')
+      .option(
+        '--split [CHARACTER]',
+        'split the input message in a single file by a specified character, default is "\\n"',
+      )
       .allowUnknownOption(false)
       .action(benchPub)
 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

<img width="1075" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/3cfcb142-9f1f-4807-8f0b-b1f94a308a8c">

Please describe the current behavior and link to a relevant issue.

#### Issue Number

Example: \#123

#### What is the new behavior?

<img width="1090" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/1ad5cc8d-d41a-4530-8458-62b489994aec">

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
