### PR TITLE
feat(cli): add delimiter option for sub file write

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -317,6 +317,7 @@ export class Commander {
           .argParser(parseFileSave)
           .conflicts('fileWrite'),
       )
+      .option('--delimiter [CHARACTER]', 'append a delimiter to the end of each message, default is "\\n"')
       .option(
         '-Pp, --protobuf-path <PATH>',
         'the path to the .proto file that defines the message format for Protocol Buffers (protobuf)',

--- a/cli/src/lib/sub.ts
+++ b/cli/src/lib/sub.ts
@@ -108,7 +108,7 @@ const sub = (options: SubscribeOptions) => {
   })
 
   client.on('message', (topic, payload, packet) => {
-    const { format, protobufPath, protobufMessageName, fileSave, fileWrite } = options
+    const { format, protobufPath, protobufMessageName, fileSave, fileWrite, delimiter } = options
 
     const msgData: Record<string, unknown>[] = []
 
@@ -117,7 +117,7 @@ const sub = (options: SubscribeOptions) => {
     const savePath = fileSave ? createNextNumberedFileName(fileSave) : fileWrite
     if (savePath) {
       fileSave && writeFile(savePath, receivedMessage)
-      fileWrite && appendFile(savePath, receivedMessage)
+      fileWrite && appendFile(savePath, receivedMessage, delimiter)
     }
 
     options.verbose && msgData.push({ label: 'mqtt-packet', value: packet })

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -121,7 +121,7 @@ declare global {
 
   type OmitSubscribeOptions = Omit<
     SubscribeOptions,
-    'format' | 'outputMode' | 'protobufPath' | 'protobufMessageName' | 'debug' | 'fileWrite' | 'fileSave'
+    'format' | 'outputMode' | 'protobufPath' | 'protobufMessageName' | 'debug' | 'fileWrite' | 'fileSave' | 'delimiter'
   >
 
   interface BenchSubscribeOptions extends OmitSubscribeOptions {

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -81,17 +81,19 @@ declare global {
   interface SubscribeOptions extends ConnectOptions {
     topic: string[]
     qos?: QoS[]
-    // properties of MQTT 5.0
-    fileWrite?: string
-    fileSave?: string
+    // Start properties of MQTT 5.0
     no_local?: boolean[]
     retainAsPublished?: boolean[]
     retainHandling?: QoS[]
     subscriptionIdentifier?: number[]
+    connUserProperties?: Record<string, string | string[]>
+    // End properties of MQTT 5.0
+    fileWrite?: string
+    fileSave?: string
+    delimiter?: string
     format?: FormatType
     outputMode?: OutputMode
     verbose: boolean
-    connUserProperties?: Record<string, string | string[]>
     protobufPath?: string
     protobufMessageName?: string
   }

--- a/cli/src/utils/fileUtils.ts
+++ b/cli/src/utils/fileUtils.ts
@@ -52,9 +52,9 @@ const writeFile = (filePath: string, data: string | Buffer): void => {
   }
 }
 
-const appendFile = (filePath: string, data: string | Buffer): void => {
+const appendFile = (filePath: string, data: string | Buffer, delimiter = '\n'): void => {
   try {
-    fs.appendFileSync(filePath, `${data}\n`)
+    fs.appendFileSync(filePath, `${data}${delimiter}`)
   } catch (error) {
     signale.error(error)
     process.exit(1)


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

Users cannot change the delimiter for writing to a file because the default value is only the '\n.'

#### What is the new behavior?

```plaintext
{"temp":59,"hum":86}
{"temp":71,"hum":75}
{"temp":36,"hum":40}
{"temp":53,"hum":49}
```

```shell
mqttx bench pub -c 1 -h 127.0.0.1 -t 'smart_home' --file-read ./data-split-newline.txt --split -im 1000
```

```shell
mqttx sub -h 127.0.0.1 -p 1883 -t smart_home --file-write ./delimiter-file.txt --delimiter ','
```

```plaintext
{"temp":59,"hum":86},{"temp":71,"hum":75},{"temp":36,"hum":40},{"temp":53,"hum":49},
```