### PR TITLE
feat(copilot): support custom copilot api

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -144,6 +144,7 @@ async function createWindow() {
         multiTopics: setting.multiTopics,
         jsonHighlight: setting.jsonHighlight,
         enableCopilot: setting.enableCopilot,
+        openAIAPIHost: setting.openAIAPIHost,
         openAIAPIKey: setting.openAIAPIKey,
         model: setting.model,
         logLevel: setting.logLevel,

--- a/src/components/Copilot.vue
+++ b/src/components/Copilot.vue
@@ -107,6 +107,7 @@ export default class Copilot extends Vue {
   @Prop({ required: true }) public mode!: 'connections' | 'scripts' | 'help'
   @Action('SET_INSERT_BUTTON_ADDED') private setisPrismButtonAdded!: (payload: { isPrismButtonAdded: boolean }) => void
 
+  @Getter('openAIAPIHost') private openAIAPIHost!: string
   @Getter('openAIAPIKey') private openAIAPIKey!: string
   @Getter('model') private model!: AIModel
   @Getter('isPrismButtonAdded') private isPrismButtonAdded!: boolean
@@ -232,7 +233,7 @@ export default class Copilot extends Vue {
       }
 
       this.isResponseStream = true
-      const response = await fetch('https://api.openai.com/v1/chat/completions', fetchOptions)
+      const response = await fetch(`${this.openAIAPIHost}/chat/completions`, fetchOptions)
       if (response && response.status === 200 && response.ok) {
         this.isSending = false
         const throttledScroll = throttle(() => {

--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -44,6 +44,7 @@ import { aiTables1701936842016 } from './migration/1701936842016-aiTables'
 import { enableCopilot1703659148195 } from './migration/1703659148195-enableCopilot'
 import { logLevel1704941582350 } from './migration/1704941582350-logLevel'
 import { updatePayloadTypeToVarchar1630403733965 } from './migration/1705478422620-updatePayloadTypeToVarchar'
+import { supportOpenAIAPIHost1716044120271 } from './migration/1716044120271-supportOpenAIAPIHost'
 
 const STORE_PATH = getAppDataPath('MQTTX')
 try {
@@ -94,6 +95,7 @@ const ORMConfig = {
     enableCopilot1703659148195,
     logLevel1704941582350,
     updatePayloadTypeToVarchar1630403733965,
+    supportOpenAIAPIHost1716044120271,
   ],
   migrationsTableName: 'temp_migration_table',
   entities: [

--- a/src/database/migration/1716044120271-supportOpenAIAPIHost.ts
+++ b/src/database/migration/1716044120271-supportOpenAIAPIHost.ts
@@ -1,0 +1,226 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class supportOpenAIAPIHost1716044120271 implements MigrationInterface {
+  name = 'supportOpenAIAPIHost1716044120271'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TABLE "temporary_historyMessagePayloadEntity" (
+                "id" uuid PRIMARY KEY NOT NULL,
+                "payload" varchar NOT NULL,
+                "payloadType" varchar NOT NULL DEFAULT ('JSON'),
+                "createAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "temporary_historyMessagePayloadEntity"("id", "payload", "payloadType", "createAt")
+            SELECT "id",
+                "payload",
+                "payloadType",
+                "createAt"
+            FROM "historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "temporary_historyMessagePayloadEntity"
+                RENAME TO "historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "temporary_SettingEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "width" integer NOT NULL DEFAULT (1025),
+                "height" integer NOT NULL DEFAULT (749),
+                "autoCheck" boolean NOT NULL DEFAULT (1),
+                "currentLang" varchar CHECK(currentLang IN ('zh', 'en', 'ja', 'tr', 'hu')) NOT NULL DEFAULT ('en'),
+                "currentTheme" varchar CHECK(currentTheme IN ('light', 'dark', 'night')) NOT NULL DEFAULT ('light'),
+                "maxReconnectTimes" integer NOT NULL DEFAULT (10),
+                "autoResub" boolean NOT NULL DEFAULT (1),
+                "syncOsTheme" boolean NOT NULL DEFAULT (0),
+                "multiTopics" boolean NOT NULL DEFAULT (1),
+                "jsonHighlight" boolean NOT NULL DEFAULT (1),
+                "openAIAPIKey" varchar NOT NULL DEFAULT (''),
+                "model" varchar NOT NULL DEFAULT ('gpt-3.5-turbo'),
+                "enableCopilot" boolean NOT NULL DEFAULT (1),
+                "logLevel" varchar CHECK(logLevel IN ('debug', 'info', 'warn', 'error')) NOT NULL DEFAULT ('info'),
+                "openAIAPIHost" varchar NOT NULL DEFAULT ('https://api.openai.com/v1')
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "temporary_SettingEntity"(
+                    "id",
+                    "width",
+                    "height",
+                    "autoCheck",
+                    "currentLang",
+                    "currentTheme",
+                    "maxReconnectTimes",
+                    "autoResub",
+                    "syncOsTheme",
+                    "multiTopics",
+                    "jsonHighlight",
+                    "openAIAPIKey",
+                    "model",
+                    "enableCopilot",
+                    "logLevel"
+                )
+            SELECT "id",
+                "width",
+                "height",
+                "autoCheck",
+                "currentLang",
+                "currentTheme",
+                "maxReconnectTimes",
+                "autoResub",
+                "syncOsTheme",
+                "multiTopics",
+                "jsonHighlight",
+                "openAIAPIKey",
+                "model",
+                "enableCopilot",
+                "logLevel"
+            FROM "SettingEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "SettingEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "temporary_SettingEntity"
+                RENAME TO "SettingEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "temporary_historyMessagePayloadEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "payload" varchar NOT NULL,
+                "payloadType" varchar NOT NULL DEFAULT ('JSON'),
+                "createAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "temporary_historyMessagePayloadEntity"("id", "payload", "payloadType", "createAt")
+            SELECT "id",
+                "payload",
+                "payloadType",
+                "createAt"
+            FROM "historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "temporary_historyMessagePayloadEntity"
+                RENAME TO "historyMessagePayloadEntity"
+        `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "historyMessagePayloadEntity"
+                RENAME TO "temporary_historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "historyMessagePayloadEntity" (
+                "id" uuid PRIMARY KEY NOT NULL,
+                "payload" varchar NOT NULL,
+                "payloadType" varchar NOT NULL DEFAULT ('JSON'),
+                "createAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "historyMessagePayloadEntity"("id", "payload", "payloadType", "createAt")
+            SELECT "id",
+                "payload",
+                "payloadType",
+                "createAt"
+            FROM "temporary_historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "temporary_historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "SettingEntity"
+                RENAME TO "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "SettingEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "width" integer NOT NULL DEFAULT (1025),
+                "height" integer NOT NULL DEFAULT (749),
+                "autoCheck" boolean NOT NULL DEFAULT (1),
+                "currentLang" varchar CHECK(currentLang IN ('zh', 'en', 'ja', 'tr', 'hu')) NOT NULL DEFAULT ('en'),
+                "currentTheme" varchar CHECK(currentTheme IN ('light', 'dark', 'night')) NOT NULL DEFAULT ('light'),
+                "maxReconnectTimes" integer NOT NULL DEFAULT (10),
+                "autoResub" boolean NOT NULL DEFAULT (1),
+                "syncOsTheme" boolean NOT NULL DEFAULT (0),
+                "multiTopics" boolean NOT NULL DEFAULT (1),
+                "jsonHighlight" boolean NOT NULL DEFAULT (1),
+                "openAIAPIKey" varchar NOT NULL DEFAULT (''),
+                "model" varchar NOT NULL DEFAULT ('gpt-3.5-turbo'),
+                "enableCopilot" boolean NOT NULL DEFAULT (1),
+                "logLevel" varchar CHECK(logLevel IN ('debug', 'info', 'warn', 'error')) NOT NULL DEFAULT ('info')
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "SettingEntity"(
+                    "id",
+                    "width",
+                    "height",
+                    "autoCheck",
+                    "currentLang",
+                    "currentTheme",
+                    "maxReconnectTimes",
+                    "autoResub",
+                    "syncOsTheme",
+                    "multiTopics",
+                    "jsonHighlight",
+                    "openAIAPIKey",
+                    "model",
+                    "enableCopilot",
+                    "logLevel"
+                )
+            SELECT "id",
+                "width",
+                "height",
+                "autoCheck",
+                "currentLang",
+                "currentTheme",
+                "maxReconnectTimes",
+                "autoResub",
+                "syncOsTheme",
+                "multiTopics",
+                "jsonHighlight",
+                "openAIAPIKey",
+                "model",
+                "enableCopilot",
+                "logLevel"
+            FROM "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "historyMessagePayloadEntity"
+                RENAME TO "temporary_historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "historyMessagePayloadEntity" (
+                "id" uuid PRIMARY KEY NOT NULL,
+                "payload" varchar NOT NULL,
+                "payloadType" varchar NOT NULL DEFAULT ('JSON'),
+                "createAt" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "historyMessagePayloadEntity"("id", "payload", "payloadType", "createAt")
+            SELECT "id",
+                "payload",
+                "payloadType",
+                "createAt"
+            FROM "temporary_historyMessagePayloadEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "temporary_historyMessagePayloadEntity"
+        `)
+  }
+}

--- a/src/database/models/SettingEntity.ts
+++ b/src/database/models/SettingEntity.ts
@@ -38,6 +38,9 @@ export default class SettingEntity {
   @Column({ type: 'boolean', default: true })
   enableCopilot!: boolean
 
+  @Column({ type: 'varchar', default: 'https://api.openai.com/v1' })
+  openAIAPIHost!: string
+
   @Column({ type: 'varchar', default: '' })
   openAIAPIKey!: string
 

--- a/src/store/getter.ts
+++ b/src/store/getter.ts
@@ -16,6 +16,7 @@ const getters = {
   multiTopics: (state: State) => state.app.multiTopics,
   jsonHighlight: (state: State) => state.app.jsonHighlight,
   enableCopilot: (state: State) => state.app.enableCopilot,
+  openAIAPIHost: (state: State) => state.app.openAIAPIHost,
   openAIAPIKey: (state: State) => state.app.openAIAPIKey,
   model: (state: State) => state.app.model,
   isPrismButtonAdded: (state: State) => state.app.isPrismButtonAdded,

--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -20,6 +20,7 @@ const SET_CURRENT_CONNECTION_ID = 'SET_CURRENT_CONNECTION_ID'
 const TOGGLE_SYNC_OS_THEME = 'TOGGLE_SYNC_OS_THEME'
 const TOGGLE_MULTI_TOPICS = 'TOGGLE_MULTI_TOPICS'
 const TOGGLE_JSON_HIGHLIGHT = 'TOGGLE_JSON_HIGHLIGHT'
+const SET_OPEN_AI_HOST = 'SET_OPEN_AI_HOST'
 const SET_OPEN_AI_API_KEY = 'SET_OPEN_AI_API_KEY'
 const SET_MODEL = 'SET_MODEL'
 const SET_INSERT_BUTTON_ADDED = 'SET_INSERT_BUTTON_ADDED'
@@ -56,6 +57,7 @@ const app = {
     currentScript: null,
     currentConnectionId: null,
     enableCopilot: settingData.enableCopilot,
+    openAIAPIHost: settingData.openAIAPIHost || 'https://api.openai.com/v1',
     openAIAPIKey: settingData.openAIAPIKey || '',
     model: settingData.model || 'gpt-3.5-turbo',
     isPrismButtonAdded: false,
@@ -140,6 +142,9 @@ const app = {
     },
     [SET_CURRENT_CONNECTION_ID](state: App, currentConnectionId: string) {
       state.currentConnectionId = currentConnectionId
+    },
+    [SET_OPEN_AI_HOST](state: App, openAIHost: string) {
+      state.openAIAPIHost = openAIHost
     },
     [SET_OPEN_AI_API_KEY](state: App, openAIAPIKey: string) {
       state.openAIAPIKey = openAIAPIKey
@@ -244,6 +249,12 @@ const app = {
       const { settingService } = useServices()
       commit(TOGGLE_ENABLE_COPILOT, payload.enableCopilot)
       settingData.enableCopilot = payload.enableCopilot
+      await settingService.update(payload)
+    },
+    async SET_OPEN_AI_HOST({ commit }: any, payload: App) {
+      const { settingService } = useServices()
+      commit(SET_OPEN_AI_HOST, payload.openAIAPIHost)
+      settingData.openAIAPIHost = payload.openAIAPIHost
       await settingService.update(payload)
     },
     async SET_OPEN_AI_API_KEY({ commit }: any, payload: App) {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -105,6 +105,7 @@ declare global {
     connectionTreeState: ConnectionTreeStateMap
     jsonHighlight: boolean
     enableCopilot: boolean
+    openAIAPIHost: string
     openAIAPIKey: string
     model: AIModel
     isPrismButtonAdded: boolean
@@ -388,6 +389,7 @@ declare global {
     | 'gpt-4-32k-0613'
     | 'gpt-4-turbo'
     | 'gpt-4o'
+    | string
 
   interface AreaLineSeriesData {
     xData: string[]


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Currently, the copilot API interface only supports OpenAI's host and model.

#### Issue Number

#1542 

#### What is the new behavior?

The API interface of Copilot supports setting all request addresses and models that are compatible with the OpenAI API protocol.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Supporting third-party large model interfaces has two main benefits:

1. Supporting API calls for large models such as [ChatGLM](https://open.bigmodel.cn/dev/api#openai_sdk) and [DeepSeek](https://platform.deepseek.com/api-docs/) can provide cheaper and faster services, and can be deployed in regions where OpenAI cannot be directly used (such as China).
2. Companies using MQTTX can privatize their own large model services, compatible with OpenAI's API protocol through methods like [One-API](https://github.com/songquanpeng/one-api) which is beneficial for internal data security and review.

#### Other information
