### PR TITLE
feat(cli): config support max reconnect times

### DIFF
--- a/cli/src/configs/common.ts
+++ b/cli/src/configs/common.ts
@@ -13,6 +13,7 @@ const DEFAULT_CONFIG: ConfigModel = {
   mqtt: {
     host: 'localhost',
     port: 1883,
+    maxReconnectTimes: 10,
   },
 }
 

--- a/cli/src/configs/load.ts
+++ b/cli/src/configs/load.ts
@@ -20,6 +20,7 @@ const parseConfigFile = (content: string): ConfigModel => {
     mqtt: {
       host: config.mqtt?.host || DEFAULT_CONFIG.mqtt.host,
       port: parseInt(config.mqtt?.port, 10) || DEFAULT_CONFIG.mqtt.port,
+      maxReconnectTimes: parseInt(config.mqtt?.max_reconnect_times, 10) || DEFAULT_CONFIG.mqtt.maxReconnectTimes,
       username: config.mqtt?.username || DEFAULT_CONFIG.mqtt.username,
       password: config.mqtt?.password || DEFAULT_CONFIG.mqtt.password,
     },

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -77,7 +77,12 @@ export class Commander {
         parseNumber,
         1000,
       )
-      .option('--maximum-reconnect-times <NUMBER>', 'the maximum reconnect times', parseNumber, 10)
+      .option(
+        '--maximum-reconnect-times <NUMBER>',
+        'the maximum reconnect times',
+        parseNumber,
+        state.getConfig('maxReconnectTimes'),
+      )
       // properties options of MQTT 5.0
       .option('-se, --session-expiry-interval <SECONDS>', 'the session expiry interval in seconds', parseNumber)
       .option('--rcv-max, --receive-maximum <NUMBER>', 'the receive maximum value', parseNumber)
@@ -176,7 +181,12 @@ export class Commander {
         parseNumber,
         1000,
       )
-      .option('--maximum-reconnect-times <NUMBER>', 'the maximum reconnect times', parseNumber, 10)
+      .option(
+        '--maximum-reconnect-times <NUMBER>',
+        'the maximum reconnect times',
+        parseNumber,
+        state.getConfig('maxReconnectTimes'),
+      )
       // connect properties options of MQTT 5.0
       .option('-se, --session-expiry-interval <SECONDS>', 'the session expiry interval in seconds', parseNumber)
       .option('--rcv-max, --receive-maximum <NUMBER>', 'the receive maximum value', parseNumber)
@@ -276,7 +286,12 @@ export class Commander {
         parseNumber,
         1000,
       )
-      .option('--maximum-reconnect-times <NUMBER>', 'the maximum reconnect times', parseNumber, 10)
+      .option(
+        '--maximum-reconnect-times <NUMBER>',
+        'the maximum reconnect times',
+        parseNumber,
+        state.getConfig('maxReconnectTimes'),
+      )
       // connect properties options of MQTT 5.0
       .option('-se, --session-expiry-interval <SECONDS>', 'the session expiry interval in seconds', parseNumber)
       .option('--rcv-max, --receive-maximum <NUMBER>', 'the receive maximum value', parseNumber)
@@ -366,7 +381,12 @@ export class Commander {
         parseNumber,
         1000,
       )
-      .option('--maximum-reconnect-times <NUMBER>', 'the maximum reconnect times', parseNumber, 10)
+      .option(
+        '--maximum-reconnect-times <NUMBER>',
+        'the maximum reconnect times',
+        parseNumber,
+        state.getConfig('maxReconnectTimes'),
+      )
       // properties options of MQTT 5.0
       .option('-se, --session-expiry-interval <SECONDS>', 'the session expiry interval in seconds', parseNumber)
       .option('--rcv-max, --receive-maximum <NUMBER>', 'the receive maximum value', parseNumber)
@@ -471,7 +491,12 @@ export class Commander {
         parseNumber,
         1000,
       )
-      .option('--maximum-reconnect-times <NUMBER>', 'the maximum reconnect times', parseNumber, 10)
+      .option(
+        '--maximum-reconnect-times <NUMBER>',
+        'the maximum reconnect times',
+        parseNumber,
+        state.getConfig('maxReconnectTimes'),
+      )
       // connect properties options of MQTT 5.0
       .option('-se, --session-expiry-interval <SECONDS>', 'the session expiry interval in seconds', parseNumber)
       .option('--rcv-max, --receive-maximum <NUMBER>', 'the receive maximum value', parseNumber)
@@ -564,7 +589,12 @@ export class Commander {
         parseNumber,
         1000,
       )
-      .option('--maximum-reconnect-times <NUMBER>', 'the maximum reconnect times', parseNumber, 10)
+      .option(
+        '--maximum-reconnect-times <NUMBER>',
+        'the maximum reconnect times',
+        parseNumber,
+        state.getConfig('maxReconnectTimes'),
+      )
       // connect properties options of MQTT 5.0
       .option('-se, --session-expiry-interval <SECONDS>', 'the session expiry interval in seconds', parseNumber)
       .option('--rcv-max, --receive-maximum <NUMBER>', 'the receive maximum value', parseNumber)

--- a/cli/src/lib/init.ts
+++ b/cli/src/lib/init.ts
@@ -10,7 +10,8 @@ import { CONFIG_FILE_PATH, DEFAULT_CONFIG, USER_HOME_DIR } from '../configs/comm
  */
 const generateConfigContent = (config: ConfigModel): string => {
   let mqttConfig = `host = ${config.mqtt.host}
-port = ${config.mqtt.port}`
+port = ${config.mqtt.port}
+max_reconnect_times = ${config.mqtt.maxReconnectTimes}`
 
   if (config.mqtt.username) {
     mqttConfig += `\nusername = ${config.mqtt.username}`
@@ -52,6 +53,12 @@ async function initConfig(): Promise<void> {
     validate: (input) => !isNaN(parseInt(input, 10)) || 'Port must be a number',
   })
 
+  const maxReconnectTimes = await input({
+    message: 'Enter the maximum reconnect times for MQTT connection',
+    default: DEFAULT_CONFIG.mqtt.maxReconnectTimes.toString(),
+    validate: (input) => !isNaN(parseInt(input, 10)) || 'Maximum reconnect times must be a number',
+  })
+
   const username = await input({
     message: 'Enter the default username for MQTT connection authentication',
     default: DEFAULT_CONFIG.mqtt.username,
@@ -67,6 +74,7 @@ async function initConfig(): Promise<void> {
     mqtt: {
       host,
       port: parseInt(port, 10),
+      maxReconnectTimes: parseInt(maxReconnectTimes, 10),
       username,
       password: passwordAnswer,
     },

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -176,6 +176,7 @@ declare global {
     mqtt: {
       host: string
       port: number
+      maxReconnectTimes: number
       username?: string
       password?: string
     }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Only can set the max-reconnect-times in the CLI options

#### What is the new behavior?

<img width="302" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/5102f798-2996-4a5c-9373-3cd8b04eb7c8">


Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
