### PR TITLE
fix(cli): fix sub error logic with multi topics

### DIFF
--- a/cli/src/lib/pub.ts
+++ b/cli/src/lib/pub.ts
@@ -97,10 +97,6 @@ const send = (
     }
   })
 
-  client.on('close', () => {
-    basicLog.close()
-  })
-
   client.on('disconnect', (packet: IDisconnectPacket) => {
     basicLog.disconnect(packet)
   })

--- a/cli/src/utils/logWrapper.ts
+++ b/cli/src/utils/logWrapper.ts
@@ -69,7 +69,7 @@ const basicLog = {
   subscribing: (t: string) => logWrapper.await(`Subscribing to ${t}...`),
   subscribed: (t: string) => logWrapper.success(`Subscribed to ${t}`),
   subscriptionNegated: (sub: { topic: string; qos: number }) =>
-    logWrapper.fail(`Subscription negated to ${sub.topic} with code ${sub.qos}`),
+    logWrapper.fail(`Subscription negated to "${sub.topic}" with code ${sub.qos}`),
   publishing: () => logWrapper.await('Message publishing...'),
   published: () => logWrapper.success('Message published'),
   enterToPublish: () => logWrapper.success('Connected, press Enter to publish, press Ctrl+C to exit'),


### PR DESCRIPTION
#### What is the current behavior?

<img width="615" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/0caf7eae-f853-45bc-8dd4-a2feb4c6d818">

#### What is the new behavior?

<img width="491" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/c6ae85ae-bacf-48cd-b549-866f7a832424">

Handle individual topic subscription success and failure separately

- Refactor to use `Promise.all` for concurrent subscription handling
- Log each topic's subscription status independently
- Ensure individual topic failures do not affect others
- Explicitly define return types for subscription promises
- Improve performance by reducing redundant checks

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No