### PR TITLE
fix(desktop): share one message event

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -1417,10 +1417,12 @@ export default class ConnectionsDetail extends Vue {
 
     const SYSMessageSubject$ = messageSubject$.pipe(
       filter((m: MessageModel) => this.showBytes && id === this.curConnectionId && m.topic.includes('$SYS')),
+      shareReplay(1),
     )
 
     const nonSYSMessageSubject$ = messageSubject$.pipe(
       filter((m: MessageModel) => !(this.showBytes && id === this.curConnectionId && m.topic.includes('$SYS'))),
+      shareReplay(1),
     )
 
     // Print message log


### PR DESCRIPTION
#### What is the current behavior?

The current subscribers of the observer repeatedly process a message multiple times.

![image](https://github.com/emqx/MQTTX/assets/21299158/f77a2d00-af9d-427e-99cf-376274e397a5)

#### What is the new behavior?

By using shareReplay(1), the message processing results are cached and shared, avoiding duplicate processing while ensuring all subscribers can correctly handle different messages. These changes ensure that each message is processed only once without affecting the original business logic and functionality.
Please describe the new behavior or provide screenshots.

![image](https://github.com/emqx/MQTTX/assets/21299158/366c5ed1-37e0-4933-9da1-02d73b2ca96a)

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

