### PR TITLE
fix(desktop): support show load data errors

### DIFF
--- a/src/views/connections/index.vue
+++ b/src/views/connections/index.vue
@@ -111,27 +111,33 @@ export default class Connections extends Vue {
   }
 
   private async loadData(loadLatest: boolean = false, firstLoad: boolean = false, callback?: () => {}): Promise<void> {
-    if (firstLoad) {
-      this.isLoadingData = true
-    }
-    const { connectionService } = useServices()
-    const connections: ConnectionModel[] | [] = (await connectionService.getAll()) ?? []
-    this.refreshConnectionList()
-    this.isLoadingData = false
-    if (connections.length && loadLatest) {
-      const leatestId = await connectionService.getLeatestId()
-      this.$router.push({ path: `/recent_connections/${leatestId}` })
-    }
-    if (connections.length && this.connectionId !== 'create') {
-      this.isEmpty = false
-      await this.loadDetail(this.connectionId)
-    } else {
-      if (this.oper === 'edit') {
-        this.$router.push({ path: '/recent_connections' })
+    try {
+      if (firstLoad) {
+        this.isLoadingData = true
       }
-      this.isEmpty = true
+      const { connectionService } = useServices()
+      const connections: ConnectionModel[] | [] = (await connectionService.getAll()) ?? []
+      this.refreshConnectionList()
+      this.isLoadingData = false
+      if (connections.length && loadLatest) {
+        const latestId = await connectionService.getLeatestId()
+        this.$router.push({ path: `/recent_connections/${latestId}` })
+      }
+      if (connections.length && this.connectionId !== 'create') {
+        this.isEmpty = false
+        await this.loadDetail(this.connectionId)
+      } else {
+        if (this.oper === 'edit') {
+          this.$router.push({ path: '/recent_connections' })
+        }
+        this.isEmpty = true
+      }
+    } catch (error) {
+      this.$message.error(`Failed to load data: ${error}`)
+      this.$log.error(`Failed to load data: ${JSON.stringify(error)}`)
+    } finally {
+      callback && callback()
     }
-    callback && callback()
   }
 
   private toCreateConnection() {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

No one can see all the errors when loading data error.

#### Issue Number

Example: \#123

#### What is the new behavior?

Show the error messages on the page and logs

<img width="1137" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/e2ae983c-568e-4528-a6f9-20ba51858869">

<img width="1137" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/57053ee5-bfb7-4b02-8f45-badf9fac4984">


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
