### PR TITLE
 feat(desktop): support install mqttx cli one click

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "6.2.0",
     "sqlite3": "^5.0.4",
+    "sudo-prompt": "^9.2.1",
     "typedi": "^0.8.0",
     "typeorm": "^0.2.34",
     "typeorm-typedi-extensions": "^0.2.3",

--- a/src/background.ts
+++ b/src/background.ts
@@ -111,7 +111,6 @@ function handleIpcMessages() {
     }
   })
   ipcMain.on('installCLI', () => {
-    console.log('Install CLI from settings')
     if (win) {
       installCLI(win)
     }

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,6 +11,7 @@ import getMenuTemplate from './main/getMenuTemplate'
 import saveFile from './main/saveFile'
 import saveExcel from './main/saveExcel'
 import newWindow from './main/newWindow'
+import installCLI from './main/installCLI'
 import { onSystemThemeChanged } from './main/systemTheme'
 import useConnection, { initOptionModel } from '@/database/useConnection'
 import useServices from '@/database/useServices'
@@ -107,6 +108,12 @@ function handleIpcMessages() {
         message: 'An error occurred while rebuilding the database.',
         detail: err.message,
       })
+    }
+  })
+  ipcMain.on('installCLI', () => {
+    console.log('Install CLI from settings')
+    if (win) {
+      installCLI(win)
     }
   })
 }

--- a/src/components/Ipc.vue
+++ b/src/components/Ipc.vue
@@ -29,10 +29,6 @@ export default class Ipc extends Vue {
     ipcRenderer.on('newConnections', () => {
       this.$router.push({ path: '/recent_connections/0?oper=create' })
     })
-    ipcRenderer.on('showProgress', (event, args) => {
-      const percentValue: any = args[0]
-      console.log(percentValue)
-    })
   }
 
   private unbindIpcEvents(): void {

--- a/src/components/Ipc.vue
+++ b/src/components/Ipc.vue
@@ -29,6 +29,10 @@ export default class Ipc extends Vue {
     ipcRenderer.on('newConnections', () => {
       this.$router.push({ path: '/recent_connections/0?oper=create' })
     })
+    ipcRenderer.on('showProgress', (event, args) => {
+      const percentValue: any = args[0]
+      console.log(percentValue)
+    })
   }
 
   private unbindIpcEvents(): void {
@@ -53,6 +57,7 @@ export default class Ipc extends Vue {
   }
 
   private created(): void {
+    console.log(123)
     this.bindIpcEvents()
   }
 

--- a/src/components/Ipc.vue
+++ b/src/components/Ipc.vue
@@ -57,7 +57,6 @@ export default class Ipc extends Vue {
   }
 
   private created(): void {
-    console.log(123)
     this.bindIpcEvents()
   }
 

--- a/src/lang/menu.ts
+++ b/src/lang/menu.ts
@@ -300,4 +300,11 @@ export default {
     tr: 'EMQX Web Sitesi',
     hu: 'EMQX weboldal',
   },
+  installCLI: {
+    en: 'Install MQTTX CLI',
+    zh: 'MQTTX 安装 CLI',
+    ja: 'MQTTX CLI をインストール',
+    tr: 'MQTTX CLI Yükleyin',
+    hu: 'MQTTX CLI telepítése',
+  },
 }

--- a/src/lang/settings.ts
+++ b/src/lang/settings.ts
@@ -188,4 +188,25 @@ export default {
     ja: '進捗をインポート',
     hu: 'Importálás folyamatban',
   },
+  extends: {
+    zh: '扩展',
+    en: 'Extensions',
+    tr: 'Uzantılar',
+    ja: '拡張',
+    hu: 'Kiterjesztések',
+  },
+  downloadingCLI: {
+    zh: '下载 MQTTX CLI 中...',
+    en: 'Downloading MQTTX CLI...',
+    tr: 'MQTTX CLI indiriliyor...',
+    ja: 'MQTTX CLIをダウンロード中...',
+    hu: 'MQTTX CLI letöltése...',
+  },
+  installCLITips: {
+    zh: '一键安装 MQTTX CLI，您将被提示需要管理员权限。安装后，可在终端运行 MQTTX。',
+    en: 'One-click installation of MQTTX CLI. You will be prompted for administrator access. After installation, you can run MQTTX in the terminal.',
+    tr: "MQTTX CLI'yi tek tıklama ile kurun. Kurulum sırasında yönetici erişimi için uyarılacaksınız. Kurulumdan sonra, MQTTX'i terminalde çalıştırabilirsiniz.",
+    ja: 'MQTTX CLIをワンクリックでインストールします。インストール中に管理者アクセスのプロンプトが表示されます。インストール後、ターミナルでMQTTXを実行できます。',
+    hu: 'Egy kattintással telepítheti az MQTTX CLI-t. Telepítés közben rendszergazdai hozzáférésre vonatkozó kérést fog kapni. Telepítés után a terminálban futtathatja az MQTTX-et.',
+  },
 }

--- a/src/main/getMenuTemplate.ts
+++ b/src/main/getMenuTemplate.ts
@@ -1,5 +1,6 @@
 import { app, shell, BrowserWindow } from 'electron'
 import translations from '../lang/menu'
+import installCLI from './installCLI'
 
 const isMac = process.platform === 'darwin'
 
@@ -35,6 +36,12 @@ const getMenuTemplate = (win: BrowserWindow, lang?: Language): $TSFixed => {
                 label: labels.checkForUpdate,
                 click: () => {
                   win.webContents.send('clickUpdate')
+                },
+              },
+              {
+                label: labels.installCLI,
+                click: () => {
+                  installCLI(win)
                 },
               },
               { type: 'separator' },

--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -6,75 +6,161 @@ import { BrowserWindow, dialog } from 'electron'
 import { getAppDataPath } from 'appdata-path'
 import sudo from 'sudo-prompt'
 import version from '@/version'
+import { exec } from 'child_process'
+import { compareVersions } from 'compare-versions'
+import { getCurrentLang } from './updateChecker'
 
 const STORE_PATH = getAppDataPath('MQTTX')
+const MQTTX_VERSION = `v${version}`
 
+/**
+ * Checks if the MQTTX CLI is installed and up to date.
+ *
+ * @param win - The BrowserWindow instance.
+ * @returns A promise that resolves to a boolean indicating whether the MQTTX CLI is installed and up to date.
+ */
+async function checkInstalledMqttxCLI(win: BrowserWindow): Promise<boolean> {
+  return new Promise((resolve) => {
+    exec('mqttx --version', (error, stdout, stderr) => {
+      if (error) {
+        // MQTTX CLI is not installed
+        resolve(false)
+      } else {
+        // Extract the version from the stdout
+        const lines = stdout.trim().split('\n')
+        const installedVersion = `v${lines[0]}`
+
+        if (compareVersions(installedVersion, MQTTX_VERSION) >= 0) {
+          dialog.showMessageBox(win, {
+            type: 'info',
+            title: 'Check Existing Installation',
+            message: `MQTTX CLI is already installed and up to date (version: ${installedVersion}).`,
+          })
+          resolve(true)
+        } else {
+          dialog
+            .showMessageBox(win, {
+              type: 'question',
+              buttons: ['Yes', 'No'],
+              title: 'Found Older Version',
+              message: `Installed version: ${installedVersion}\nNew version: ${MQTTX_VERSION}\n\nDo you want to upgrade?`,
+            })
+            .then((response) => {
+              if (response.response === 0) {
+                // User chose 'Yes' to upgrade
+                resolve(false)
+              } else {
+                // User chose 'No' to cancel the upgrade
+                resolve(true)
+              }
+            })
+        }
+      }
+    })
+  })
+}
+
+/**
+ * Downloads a file from the specified URL and saves it to the specified output path.
+ * Also updates the download progress on the UI.
+ *
+ * @param downloadUrl - The URL of the file to download.
+ * @param outputPath - The path where the downloaded file will be saved.
+ * @param win - The BrowserWindow instance used to send progress updates to the UI.
+ * @returns A Promise that resolves when the download is complete.
+ */
+async function downloadMqttxCLI(downloadUrl: string, outputPath: string, win: BrowserWindow): Promise<void> {
+  const response = await axios({
+    method: 'get',
+    url: downloadUrl,
+    responseType: 'stream',
+  })
+
+  if (!fs.existsSync(STORE_PATH)) {
+    fs.mkdirSync(STORE_PATH, { recursive: true })
+  }
+
+  const writer = fs.createWriteStream(outputPath)
+  response.data.pipe(writer)
+
+  await new Promise<void>((resolve, reject) => {
+    const totalLength = parseInt(response.headers['content-length'])
+    let downloadedLength = 0
+
+    response.data.on('data', (chunk: string | any[]) => {
+      downloadedLength += chunk.length
+      const percent = ((downloadedLength / totalLength) * 100).toFixed(2)
+      console.log(`Downloading... ${percent}%`)
+      win.webContents.send('showProgress', percent) // Send progress to UI
+    })
+
+    writer.on('finish', () => {
+      console.log(`${outputPath} downloaded.`)
+      resolve()
+    })
+
+    writer.on('error', (err) => {
+      console.error(`Error downloading the file: ${err.message}`)
+      writer.close()
+      fs.unlink(outputPath, () => {})
+      reject(err)
+    })
+  })
+}
+
+/**
+ * Installs MQTTX CLI by executing a sudo command.
+ * @param outputPath - The path of the downloaded file to be installed.
+ * @param win - The BrowserWindow instance.
+ * @returns A Promise that resolves when the installation is completed.
+ */
+async function sudoInstall(outputPath: string, win: BrowserWindow): Promise<void> {
+  const installCommand = `install "${outputPath}" /usr/local/bin/mqttx`
+  const options = {
+    name: 'MQTTX',
+  }
+
+  sudo.exec(installCommand, options, (error: any, stdout: any, stderr: any) => {
+    if (error) {
+      dialog.showErrorBox('Installation Error', `An error occurred during the installation of MQTTX CLI: ${stderr}`)
+    } else {
+      dialog.showMessageBox({
+        type: 'info',
+        title: 'Installation Completed',
+        message: 'MQTTX CLI installed successfully.',
+      })
+      fs.unlink(outputPath, () => console.log('Downloaded file deleted.'))
+    }
+  })
+}
+
+/**
+ * Installs MQTTX CLI if it is not already installed.
+ *
+ * @param win - The BrowserWindow object.
+ * @returns A Promise that resolves when the installation is complete.
+ */
 export default async function installCLI(win: BrowserWindow) {
+  const isInstalled = await checkInstalledMqttxCLI(win)
+  if (isInstalled) {
+    return
+  }
+
   const { platform, arch } = {
     platform: os.platform(),
     arch: os.arch(),
   }
-  const mqttxVersion = `v${version}`
+  const lang = await getCurrentLang()
   const suffix = platform === 'darwin' ? 'macos' : 'linux'
   const binarySuffix = arch === 'x64' ? '-x64' : '-arm64'
   const fileName = `mqttx-cli-${suffix}${binarySuffix}`
-  const downloadUrl = `https://www.emqx.com/en/downloads/MQTTX/${mqttxVersion}/${fileName}`
+  const downloadUrl = `https://www.emqx.com/${lang}/downloads/MQTTX/${version}/${fileName}`
   const outputPath = path.join(STORE_PATH, fileName)
 
   try {
-    const response = await axios({
-      method: 'get',
-      url: downloadUrl,
-      responseType: 'stream',
-    })
-
-    if (!fs.existsSync(STORE_PATH)) {
-      fs.mkdirSync(STORE_PATH, { recursive: true })
-    }
-
-    const writer = fs.createWriteStream(outputPath)
-    response.data.pipe(writer)
-
-    await new Promise<void>((resolve, reject) => {
-      const totalLength = parseInt(response.headers['content-length'])
-      let downloadedLength = 0
-
-      response.data.on('data', (chunk: string | any[]) => {
-        downloadedLength += chunk.length
-        const percent = ((downloadedLength / totalLength) * 100).toFixed(2)
-        console.log(`Downloading... ${percent}%`)
-      })
-
-      writer.on('finish', () => {
-        console.log(`${fileName} downloaded.`)
-        resolve()
-      })
-
-      writer.on('error', (err) => {
-        console.error(`Error downloading the file: ${err.message}`)
-        writer.close()
-        fs.unlink(outputPath, () => {})
-        reject(err)
-      })
-    })
-
-    const installCommand = `install "${outputPath}" /usr/local/bin/mqttx`
-    const options = {
-      name: 'MQTTX',
-    }
-    sudo.exec(installCommand, options, (error: any, stdout: any, stderr: any) => {
-      if (error) {
-        dialog.showErrorBox('Installation Error', `An error occurred during the installation of MQTTX CLI: ${stderr}`)
-      } else {
-        dialog.showMessageBox({
-          type: 'info',
-          title: 'Installation Completed',
-          message: 'MQTTX CLI installed successfully.',
-        })
-        fs.unlink(outputPath, () => console.log('Downloaded file deleted.'))
-      }
-    })
+    await downloadMqttxCLI(downloadUrl, outputPath, win)
+    await sudoInstall(outputPath, win)
   } catch (error) {
-    dialog.showErrorBox('Download Error', `Failed to download: ${error}`)
+    dialog.showErrorBox('Error', `Failed to install MQTTX CLI: ${error}`)
   }
 }

--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -89,16 +89,18 @@ async function downloadMqttxCLI(downloadUrl: string, outputPath: string, win: Br
 
     response.data.on('data', (chunk: string | any[]) => {
       downloadedLength += chunk.length
-      const percent = ((downloadedLength / totalLength) * 100).toFixed(2)
-      // Send progress to UI
-      win.webContents.send('showProgress', percent)
+      const percent = (downloadedLength / totalLength).toFixed(2)
+      win.setProgressBar(parseFloat(percent))
     })
 
     writer.on('finish', () => {
+      win.webContents.send('showProgress', false)
+      win.setProgressBar(-1)
       resolve()
     })
 
     writer.on('error', (err) => {
+      win.setProgressBar(-1)
       writer.close()
       fs.unlink(outputPath, () => {})
       reject(err)
@@ -125,7 +127,7 @@ async function sudoInstall(outputPath: string, win: BrowserWindow): Promise<void
       dialog.showMessageBox({
         type: 'info',
         title: 'Installation Completed',
-        message: 'MQTTX CLI has been successfully installed. You can run "mqttx" commands in the terminal now.',
+        message: 'MQTTX CLI has been successfully installed.\n\nYou can run "mqttx" commands in the terminal now.',
       })
       fs.unlink(outputPath, () => console.log('Downloaded file deleted.'))
     }
@@ -136,7 +138,7 @@ function showDownloadedWindowsCLI(outputPath: string, fileName: string) {
   dialog.showMessageBox({
     type: 'info',
     title: 'Download Completed',
-    message: `MQTTX CLI has been successfully downloaded. Please manually run '${fileName}' located at: ${outputPath} to use it.`,
+    message: `MQTTX CLI has been successfully downloaded.\n\nPlease manually run '${fileName}' located at: ${outputPath} to use it.`,
   })
 }
 

--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -125,10 +125,18 @@ async function sudoInstall(outputPath: string, win: BrowserWindow): Promise<void
       dialog.showMessageBox({
         type: 'info',
         title: 'Installation Completed',
-        message: 'MQTTX CLI installed successfully.',
+        message: 'MQTTX CLI has been successfully installed. You can run "mqttx" commands in the terminal now.',
       })
       fs.unlink(outputPath, () => console.log('Downloaded file deleted.'))
     }
+  })
+}
+
+function showDownloadedWindowsCLI(outputPath: string, fileName: string) {
+  dialog.showMessageBox({
+    type: 'info',
+    title: 'Download Completed',
+    message: `MQTTX CLI has been successfully downloaded. Please manually run '${fileName}' located at: ${outputPath} to use it.`,
   })
 }
 
@@ -185,6 +193,8 @@ export default async function installCLI(win: BrowserWindow) {
     await downloadMqttxCLI(downloadUrl, outputPath, win)
     if (!isWindows) {
       await sudoInstall(outputPath, win)
+    } else {
+      showDownloadedWindowsCLI(outputPath, fileName)
     }
   } catch (error) {
     dialog.showErrorBox('Error', `Failed to install MQTTX CLI: ${error}`)

--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -1,0 +1,80 @@
+import * as os from 'os'
+import * as fs from 'fs'
+import * as path from 'path'
+import axios from 'axios'
+import { BrowserWindow, dialog } from 'electron'
+import { getAppDataPath } from 'appdata-path'
+import sudo from 'sudo-prompt'
+import version from '@/version'
+
+const STORE_PATH = getAppDataPath('MQTTX')
+
+export default async function installCLI(win: BrowserWindow) {
+  const { platform, arch } = {
+    platform: os.platform(),
+    arch: os.arch(),
+  }
+  const mqttxVersion = `v${version}`
+  const suffix = platform === 'darwin' ? 'macos' : 'linux'
+  const binarySuffix = arch === 'x64' ? '-x64' : '-arm64'
+  const fileName = `mqttx-cli-${suffix}${binarySuffix}`
+  const downloadUrl = `https://www.emqx.com/en/downloads/MQTTX/${mqttxVersion}/${fileName}`
+  const outputPath = path.join(STORE_PATH, fileName)
+
+  try {
+    const response = await axios({
+      method: 'get',
+      url: downloadUrl,
+      responseType: 'stream',
+    })
+
+    if (!fs.existsSync(STORE_PATH)) {
+      fs.mkdirSync(STORE_PATH, { recursive: true })
+    }
+
+    const writer = fs.createWriteStream(outputPath)
+    response.data.pipe(writer)
+
+    await new Promise<void>((resolve, reject) => {
+      const totalLength = parseInt(response.headers['content-length'])
+      let downloadedLength = 0
+
+      response.data.on('data', (chunk: string | any[]) => {
+        downloadedLength += chunk.length
+        const percent = ((downloadedLength / totalLength) * 100).toFixed(2)
+        console.log(`Downloading... ${percent}%`)
+      })
+
+      writer.on('finish', () => {
+        console.log(`${fileName} downloaded.`)
+        resolve()
+      })
+
+      writer.on('error', (err) => {
+        console.error(`Error downloading the file: ${err.message}`)
+        writer.close()
+        fs.unlink(outputPath, () => {})
+        reject(err)
+      })
+    })
+
+    const installCommand = `install "${outputPath}" /usr/local/bin/mqttx`
+    const options = {
+      name: 'MQTTX',
+    }
+    sudo.exec(installCommand, options, (error: any, stdout: any, stderr: any) => {
+      if (error) {
+        dialog.showErrorBox('Installation Error', `An error occurred during the installation of MQTTX CLI: ${stderr}`)
+      } else {
+        dialog.showMessageBox({
+          type: 'info',
+          title: 'Installation Completed',
+          message: 'MQTTX CLI installed successfully.',
+        })
+        fs.unlink(outputPath, () => console.log('Downloaded file deleted.'))
+      }
+    })
+  } catch (error) {
+    dialog.showErrorBox('Download Error', `Failed to download: ${error}`)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11577,6 +11577,11 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
+sudo-prompt@^9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.2.1.tgz#77efb84309c9ca489527a4e749f287e6bdd52afd"
+  integrity sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==
+
 sumchecker@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/sumchecker/-/sumchecker-3.0.1.tgz#6377e996795abb0b6d348e9b3e1dfb24345a8e42"


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The desktop version and the CLI version installations are relatively independent, and users need to download them separately in different scenarios.

#### Issue Number

Example: None

#### What is the new behavior?

After downloading the desktop version, allow users to directly install MQTTX CLI with one click if needed.

<img width="940" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/887eab84-8eee-4703-a88a-62f28ba8576c">

<img width="1093" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/ee0c6cd2-6ba0-432f-9561-eae80fc30e09">

<img width="472" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/b3a733a2-f49e-452c-b75b-bc445e016465">

<img width="334" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/934b6bc3-5b41-4d16-89b4-67dacde01426">

![image](https://github.com/emqx/MQTTX/assets/21299158/b6151348-4f09-4ad2-b294-515b638a1ace)

<img width="125" alt="image" src="https://github.com/emqx/MQTTX/assets/21299158/8c717336-28b8-41b7-83ae-4512c96da40e">


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
