### PR TITLE
feat(desktop): support setup cli to windows path

### DIFF
--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -25,8 +25,8 @@ async function checkInstalledMqttxCLI(win: BrowserWindow, isWindows: boolean): P
   }
   return new Promise((resolve) => {
     exec('mqttx --version', (error, stdout, stderr) => {
-      if (error) {
-        // MQTTX CLI is not installed
+      if (error || stderr) {
+        dialog.showErrorBox('Error', `Failed to check MQTTX CLI version: ${stderr || error?.message}`)
         resolve(false)
       } else {
         // Extract the version from the stdout

--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -19,7 +19,10 @@ const MQTTX_VERSION = `v${version}`
  * @param win - The BrowserWindow instance.
  * @returns A promise that resolves to a boolean indicating whether the MQTTX CLI is installed and up to date.
  */
-async function checkInstalledMqttxCLI(win: BrowserWindow): Promise<boolean> {
+async function checkInstalledMqttxCLI(win: BrowserWindow, isWindows: boolean): Promise<boolean> {
+  if (isWindows) {
+    return Promise.resolve(false)
+  }
   return new Promise((resolve) => {
     exec('mqttx --version', (error, stdout, stderr) => {
       if (error) {
@@ -220,20 +223,20 @@ function getArchSuffix(arch: string, isWindows: boolean): string {
  * @returns A Promise that resolves when the installation is complete.
  */
 export default async function installCLI(win: BrowserWindow) {
-  const isInstalled = await checkInstalledMqttxCLI(win)
-  if (isInstalled) {
-    win.webContents.send('installedCLI')
-    return
-  }
-
-  const lang = await getCurrentLang()
-
   const { platform, arch } = {
     platform: os.platform(),
     arch: os.arch(),
   }
   const isWindows = platform === 'win32'
   const isMacOS = platform === 'darwin'
+
+  const isInstalled = await checkInstalledMqttxCLI(win, isWindows)
+  if (isInstalled) {
+    win.webContents.send('installedCLI')
+    return
+  }
+
+  const lang = await getCurrentLang()
   const suffix = isWindows ? 'win' : isMacOS ? 'macos' : 'linux'
   let archSuffix = getArchSuffix(arch, isWindows)
   const fileName = `mqttx-cli-${suffix}-${archSuffix}`


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Windows users can only run `mqttx.exe` manually. They should find the CLI exe file first on the system.

#### Issue Number

Example: None

#### What is the new behavior?

 Add `${downloadPath}/mqttx.exe` to the PATH to run `mqttx.exe` anywhere.

https://stackoverflow.com/questions/59560042/how-to-append-values-to-the-path-environment-variable-in-nodejs

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
