### PR TITLE
feat(cli): custom ws headers support

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,7 +6,7 @@ import {
   parseNumber,
   parseProtocol,
   parseMQTTVersion,
-  parseUserProperties,
+  parseKeyValues,
   parseQoS,
   parseVariadicOfBooleanType,
   parsePubTopic,
@@ -71,6 +71,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -98,7 +103,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -112,11 +117,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',
@@ -155,7 +156,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       .option('-si, --subscription-identifier <NUMBER>', 'the identifier of the subscription', parseNumber)
       .option('-ct, --content-type <TYPE>', 'a description of the content of the publish message')
@@ -180,6 +181,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -207,7 +213,7 @@ export class Commander {
       .option(
         '-Cup, --conn-user-properties <USERPROPERTIES...>',
         'the connect user properties of MQTT 5.0 (e.g. -Cup "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -221,11 +227,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',
@@ -264,7 +266,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       .option('-f, --format <TYPE>', 'format the message body, support base64, json, hex, binary and cbor', parseFormat)
       .option('-v, --verbose', 'turn on verbose mode to display incoming MQTT packets')
@@ -290,6 +292,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -317,7 +324,7 @@ export class Commander {
       .option(
         '-Cup, --conn-user-properties <USERPROPERTIES...>',
         'the connect user properties of MQTT 5.0 (e.g. -Cup "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -331,11 +338,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',
@@ -390,6 +393,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -417,7 +425,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -431,11 +439,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',
@@ -484,7 +488,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       .option('-si, --subscription-identifier <NUMBER>', 'the identifier of the subscription', parseNumber)
       .option('-ct, --content-type <TYPE>', 'a description of the content of the publish message')
@@ -505,6 +509,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -532,7 +541,7 @@ export class Commander {
       .option(
         '-Cup, --conn-user-properties <USERPROPERTIES...>',
         'the connect user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -546,11 +555,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',
@@ -589,7 +594,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       .option('-v, --verbose', 'print history received messages and rate')
       // connect options
@@ -608,6 +613,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -635,7 +645,7 @@ export class Commander {
       .option(
         '-Cup, --conn-user-properties <USERPROPERTIES...>',
         'the connect user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -649,11 +659,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',
@@ -704,7 +710,7 @@ export class Commander {
       .option(
         '-up, --user-properties <USERPROPERTIES...>',
         'the user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       .option('-si, --subscription-identifier <NUMBER>', 'the identifier of the subscription', parseNumber)
       .option('-ct, --content-type <TYPE>', 'a description of the content of the publish message')
@@ -725,6 +731,11 @@ export class Commander {
         state.getConfig('protocol'),
       )
       .option('--path <PATH>', 'the path of websocket', '/mqtt')
+      .option(
+        '-wh, --ws-headers <WSHEADERS...>',
+        'headers for WebSocket options (only works with MQTT over WebSocket connections, e.g. -wh "Authorization: Bearer token")',
+        parseKeyValues,
+      )
       .option('--key <PATH>', 'path to the key file')
       .option('--cert <PATH>', 'path to the cert file')
       .option('--ca <PATH>', 'path to the ca certificate')
@@ -747,7 +758,7 @@ export class Commander {
       .option(
         '-Cup, --conn-user-properties <USERPROPERTIES...>',
         'the connect user properties of MQTT 5.0 (e.g. -up "name: mqttx cli")',
-        parseUserProperties,
+        parseKeyValues,
       )
       // will message options
       .option('-Wt, --will-topic <TOPIC>', 'the will topic')
@@ -761,11 +772,7 @@ export class Commander {
       .option('-Wct, --will-content-type <CONTENTTYPE>', 'description of the will message’s content')
       .option('-Wrt, --will-response-topic <TOPIC>', 'topic name for a response message')
       .option('-Wcd, --will-correlation-data <DATA>', 'correlation data for the response message')
-      .option(
-        '-Wup, --will-user-properties <USERPROPERTIES...>',
-        'the user properties of will message',
-        parseUserProperties,
-      )
+      .option('-Wup, --will-user-properties <USERPROPERTIES...>', 'the user properties of will message', parseKeyValues)
       .option(
         '-so, --save-options [PATH]',
         'save the parameters to the local configuration file, which supports json and yaml format, default path is ./mqttx-cli-options.json',

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -22,6 +22,7 @@ declare global {
     password?: string
     protocol?: Protocol
     path?: string
+    wsHeaders?: Record<string, string>
     key?: string
     cert?: string
     ca?: string


### PR DESCRIPTION
I apologize for the misunderstanding. Here's the PR information in English:

### PR Checklist
If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?
Currently, the MQTTX command-line tool does not allow customization of WebSocket headers when using WebSocket connections.

#### Issue Number
Example: #1722 

#### What is the new behavior?
Added the ability to customize WebSocket headers through the `-wh` parameter in the command line. For example:

```shell
mqttx sub -t test -wh "hello: test" -wh "auth: token" -l ws -p 8083
```

#### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

#### Specific Instructions
When reviewing this PR, please note the following:
1. This feature is implemented only in the command-line tool running in a Node.js environment.
2. Test scenarios with multiple `-wh` parameters to ensure multiple headers are correctly added.
3. Verify that the parameter is properly ignored for non-WebSocket connections.

#### Other information
This feature comes from user requests, allowing users to customize headers when using WebSocket connections, increasing connection flexibility. For example, users can add authentication information or other custom data.

It's important to note that this feature is only supported in the command-line tool running in a Node.js environment. Due to browser security restrictions, the Desktop and Web versions of MQTTX cannot modify WebSocket headers, and therefore cannot implement this feature. This is a known limitation, and detailed information can be found in the related discussion in the MQTT.js project: https://github.com/mqttjs/MQTT.js/issues/856

This new feature will provide more connection options for command-line users, especially useful in WebSocket connection scenarios that require special authentication or custom headers.