### PR TITLE
refactor(cli): using built-in fetch instead of axios

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^5.0.3",
-    "axios": "^0.27.2",
     "cbor": "^9.0.1",
     "chalk": "~4.1.2",
     "cli-table3": "^0.6.3",

--- a/cli/src/utils/checkUpdate.ts
+++ b/cli/src/utils/checkUpdate.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import chalk from 'chalk'
 import { compareVersions } from 'compare-versions'
 import { version } from '../../package.json'
@@ -6,25 +5,39 @@ import ora from 'ora'
 
 const spinner = ora()
 
+interface TagsResponse {
+  code: number
+  data: string[]
+  success: boolean
+}
+
+/**
+ * Checks for version updates of MQTTX CLI.
+ * @returns {Promise<void>} A promise that resolves when the update check is complete.
+ */
 const checkUpdate = async () => {
   try {
     spinner.start('Checking for updates...')
     const tagsUrl = 'https://community-sites.emqx.com/api/v1/all_version?product=MQTTX'
-    const tagsRes = await axios.get(tagsUrl)
-    if (tagsRes.status === 200) {
-      const latestVersion = tagsRes.data.data[0].replace('v', '')
-      if (compareVersions(latestVersion, version) > 0) {
-        spinner.stop()
-        console.log(
-          chalk.yellow(
-            `A new version of MQTTX CLI is available: ${chalk.cyan(version)} ${chalk.reset('→')} ${chalk.cyan(
-              latestVersion,
-            )}\nhttps://github.com/emqx/MQTTX/releases/tag/v${latestVersion}`,
-          ),
-        )
-      } else {
-        spinner.succeed('There are currently no updates available.')
-      }
+    // Using `fetch` here with adding `DOM` lib in `tsconfig.json` is not correct. See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924
+    // Update to Node.js 20 to resolve fetch global type issue.
+    const response = await fetch(tagsUrl)
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+    const tagsRes = (await response.json()) as TagsResponse
+    const latestVersion = tagsRes.data[0].replace('v', '')
+    if (compareVersions(latestVersion, version) > 0) {
+      spinner.stop()
+      console.log(
+        chalk.yellow(
+          `A new version of MQTTX CLI is available: ${chalk.cyan(version)} ${chalk.reset('→')} ${chalk.cyan(
+            latestVersion,
+          )}\nhttps://github.com/emqx/MQTTX/releases/tag/v${latestVersion}`,
+        ),
+      )
+    } else {
+      spinner.succeed('There are currently no updates available.')
     }
   } catch (error) {
     const err = error as Error

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES5",
     "module": "commonjs",
     "outDir": "./dist",
-    "lib": ["ESNext", "ScriptHost"],
+    "lib": ["ESNext", "ScriptHost", "DOM"],
     "strict": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -317,19 +317,6 @@ argparse@^2.0.1:
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
@@ -459,13 +446,6 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commander@^9.3.0:
   version "9.3.0"
   resolved "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz"
@@ -517,11 +497,6 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 duplexify@^4.1.1:
   version "4.1.2"
@@ -579,20 +554,6 @@ find-up@^2.0.0:
   integrity sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==
   dependencies:
     locate-path "^2.0.0"
-
-follow-redirects@^1.14.9:
-  version "1.15.6"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz"
-  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -755,18 +716,6 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
-
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
#### What is the current behavior?
Currently, MQTTX CLI uses Axios for HTTP requests. This introduces an additional dependency that is not heavily utilized within the project.

#### Issue Number
N/A (or reference the relevant issue if one exists)

#### What is the new behavior?
This PR replaces Axios with the built-in Fetch API for HTTP requests in MQTTX CLI. This change aims to:

1. Reduce project dependencies
2. Decrease bundle size
3. Potentially improve performance for HTTP operations
4. Utilize modern, native JavaScript features

#### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

#### Specific Instructions
Important note regarding TypeScript configuration:

Using `fetch` here with adding `DOM` lib in `tsconfig.json` is not correct. See: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/60924. Update to Node.js 20 to resolve fetch global type issue.

To properly implement this change, we need to ensure that the project is using Node.js version 20 or later, which includes proper type definitions for the global `fetch` API without relying on the DOM lib.

#### Other information
1. The switch to the Fetch API is particularly beneficial for MQTTX CLI as it doesn't heavily rely on complex HTTP operations, making the full feature set of Axios unnecessary.
2. This change aligns the project with modern JavaScript practices and reduces external dependencies.
3. Reviewers should pay special attention to the TypeScript configurations and ensure that the Fetch API is correctly typed without introducing DOM-related issues.