### PR TITLE
fix(desktop): improve MQTT wildcard topic matching for '#'

### DIFF
--- a/src/database/services/MessageService.ts
+++ b/src/database/services/MessageService.ts
@@ -63,7 +63,7 @@ export default class MessageService {
     if (topic && topic !== '#') {
       topic = topic.replace(/[\\%_]/g, '\\$&')
       if (topic.startsWith('$share/')) topic = topic.split('/').slice(2).join('/')
-      if (topic.includes('#')) topic = topic.replace('/#', '%')
+      if (topic.includes('#') && topic.endsWith('/#')) topic = topic.replace('#', '%')
       /*
         Known Issue: '+' wildcard handling in MQTT topics is incorrect.
         '+' is replaced with '%' for SQL LIKE, causing multi-level match.
@@ -127,7 +127,7 @@ export default class MessageService {
     if (topic && topic !== '#') {
       topic = topic.replace(/[\\%_]/g, '\\$&')
       if (topic.startsWith('$share/')) topic = topic.split('/').slice(2).join('/')
-      if (topic.includes('#')) topic = topic.replace('/#', '%')
+      if (topic.includes('#') && topic.endsWith('/#')) topic = topic.replace('#', '%')
       if (topic.includes('+')) topic = topic.replace('+', '%')
       query.andWhere('msg.topic LIKE :topic ESCAPE "\\"', { topic })
     }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The topic matching with '#' has an issue. For example, 'foo/#' can incorrectly match 'foobar/#' messages.

#### Issue Number

Example: #1734

#### What is the new behavior?

Fix this issue.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
