### PR TITLE
refactor(deskop): session expriy default to 7200

### DIFF
--- a/src/views/connections/ConnectionForm.vue
+++ b/src/views/connections/ConnectionForm.vue
@@ -821,7 +821,7 @@ export default class ConnectionForm extends Vue {
     if (val && this.record.properties) {
       this.$set(this.record.properties, 'sessionExpiryInterval', 0)
     } else if (!val && this.record.properties) {
-      this.$set(this.record.properties, 'sessionExpiryInterval', null)
+      this.$set(this.record.properties, 'sessionExpiryInterval', 7200)
     }
   }
 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Currently, for MQTT v5 with a clean start set to false, the Session Expiry Interval is set to never expire by default. This can lead to persistent connections that may unnecessarily consume resources, especially in Serverless environments where it can affect billing.

#### Issue Number

Example: #123

#### What is the new behavior?

This PR proposes to change the default Session Expiry Interval from never expire to 7200 seconds (2 hours, keep with EMQX default config) when using MQTT v5 with clean start set to false. This change aims to balance connection persistence with resource management.

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/19c2b4ae-7e17-48cf-90e1-e007565a8a4f">

Proposed changes:
- Modify the default Session Expiry Interval to 7200 seconds for MQTT v5 when clean start is false.
- Update relevant documentation to reflect this change.

#### Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This change may affect existing connections that rely on indefinite session persistence.

#### Specific Instructions

1. Update the `handleClean` method or equivalent to set the new default value.
2. Test thoroughly with various MQTT v5 scenarios to ensure compatibility.
3. Update user documentation to explain the new default behavior an