### PR TITLE
feat(copilot): change to gpt-4o to default model

### DIFF
--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -46,6 +46,7 @@ import { logLevel1704941582350 } from './migration/1704941582350-logLevel'
 import { updatePayloadTypeToVarchar1630403733965 } from './migration/1705478422620-updatePayloadTypeToVarchar'
 import { supportOpenAIAPIHost1716044120271 } from './migration/1716044120271-supportOpenAIAPIHost'
 import { ignoreQoS0Message1724839386732 } from './migration/1724839386732-ignoreQoS0Message'
+import { changeDefaultLLMModel1727111519962 } from './migration/1727111519962-changeDefaultLLMModel'
 
 const STORE_PATH = getAppDataPath('MQTTX')
 try {
@@ -98,6 +99,7 @@ const ORMConfig = {
     updatePayloadTypeToVarchar1630403733965,
     supportOpenAIAPIHost1716044120271,
     ignoreQoS0Message1724839386732,
+    changeDefaultLLMModel1727111519962,
   ],
   migrationsTableName: 'temp_migration_table',
   entities: [

--- a/src/database/migration/1727111519962-changeDefaultLLMModel.ts
+++ b/src/database/migration/1727111519962-changeDefaultLLMModel.ts
@@ -1,0 +1,145 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class changeDefaultLLMModel1727111519962 implements MigrationInterface {
+  name = 'changeDefaultLLMModel1727111519962'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TABLE "temporary_SettingEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "width" integer NOT NULL DEFAULT (1025),
+                "height" integer NOT NULL DEFAULT (749),
+                "autoCheck" boolean NOT NULL DEFAULT (1),
+                "currentLang" varchar CHECK(currentLang IN ('zh', 'en', 'ja', 'tr', 'hu')) NOT NULL DEFAULT ('en'),
+                "currentTheme" varchar CHECK(currentTheme IN ('light', 'dark', 'night')) NOT NULL DEFAULT ('light'),
+                "maxReconnectTimes" integer NOT NULL DEFAULT (10),
+                "autoResub" boolean NOT NULL DEFAULT (1),
+                "syncOsTheme" boolean NOT NULL DEFAULT (0),
+                "multiTopics" boolean NOT NULL DEFAULT (1),
+                "jsonHighlight" boolean NOT NULL DEFAULT (1),
+                "openAIAPIKey" varchar NOT NULL DEFAULT (''),
+                "model" varchar NOT NULL DEFAULT ('gpt-4o'),
+                "enableCopilot" boolean NOT NULL DEFAULT (1),
+                "logLevel" varchar CHECK(logLevel IN ('debug', 'info', 'warn', 'error')) NOT NULL DEFAULT ('info'),
+                "openAIAPIHost" varchar NOT NULL DEFAULT ('https://api.openai.com/v1'),
+                "ignoreQoS0Message" boolean NOT NULL DEFAULT (0)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "temporary_SettingEntity"(
+                    "id",
+                    "width",
+                    "height",
+                    "autoCheck",
+                    "currentLang",
+                    "currentTheme",
+                    "maxReconnectTimes",
+                    "autoResub",
+                    "syncOsTheme",
+                    "multiTopics",
+                    "jsonHighlight",
+                    "openAIAPIKey",
+                    "model",
+                    "enableCopilot",
+                    "logLevel",
+                    "openAIAPIHost",
+                    "ignoreQoS0Message"
+                )
+            SELECT "id",
+                "width",
+                "height",
+                "autoCheck",
+                "currentLang",
+                "currentTheme",
+                "maxReconnectTimes",
+                "autoResub",
+                "syncOsTheme",
+                "multiTopics",
+                "jsonHighlight",
+                "openAIAPIKey",
+                "model",
+                "enableCopilot",
+                "logLevel",
+                "openAIAPIHost",
+                "ignoreQoS0Message"
+            FROM "SettingEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "SettingEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "temporary_SettingEntity"
+                RENAME TO "SettingEntity"
+        `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "SettingEntity"
+                RENAME TO "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "SettingEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "width" integer NOT NULL DEFAULT (1025),
+                "height" integer NOT NULL DEFAULT (749),
+                "autoCheck" boolean NOT NULL DEFAULT (1),
+                "currentLang" varchar CHECK(currentLang IN ('zh', 'en', 'ja', 'tr', 'hu')) NOT NULL DEFAULT ('en'),
+                "currentTheme" varchar CHECK(currentTheme IN ('light', 'dark', 'night')) NOT NULL DEFAULT ('light'),
+                "maxReconnectTimes" integer NOT NULL DEFAULT (10),
+                "autoResub" boolean NOT NULL DEFAULT (1),
+                "syncOsTheme" boolean NOT NULL DEFAULT (0),
+                "multiTopics" boolean NOT NULL DEFAULT (1),
+                "jsonHighlight" boolean NOT NULL DEFAULT (1),
+                "openAIAPIKey" varchar NOT NULL DEFAULT (''),
+                "model" varchar NOT NULL DEFAULT ('gpt-3.5-turbo'),
+                "enableCopilot" boolean NOT NULL DEFAULT (1),
+                "logLevel" varchar CHECK(logLevel IN ('debug', 'info', 'warn', 'error')) NOT NULL DEFAULT ('info'),
+                "openAIAPIHost" varchar NOT NULL DEFAULT ('https://api.openai.com/v1'),
+                "ignoreQoS0Message" boolean NOT NULL DEFAULT (0)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "SettingEntity"(
+                    "id",
+                    "width",
+                    "height",
+                    "autoCheck",
+                    "currentLang",
+                    "currentTheme",
+                    "maxReconnectTimes",
+                    "autoResub",
+                    "syncOsTheme",
+                    "multiTopics",
+                    "jsonHighlight",
+                    "openAIAPIKey",
+                    "model",
+                    "enableCopilot",
+                    "logLevel",
+                    "openAIAPIHost",
+                    "ignoreQoS0Message"
+                )
+            SELECT "id",
+                "width",
+                "height",
+                "autoCheck",
+                "currentLang",
+                "currentTheme",
+                "maxReconnectTimes",
+                "autoResub",
+                "syncOsTheme",
+                "multiTopics",
+                "jsonHighlight",
+                "openAIAPIKey",
+                "model",
+                "enableCopilot",
+                "logLevel",
+                "openAIAPIHost",
+                "ignoreQoS0Message"
+            FROM "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "temporary_SettingEntity"
+        `)
+  }
+}

--- a/src/database/models/SettingEntity.ts
+++ b/src/database/models/SettingEntity.ts
@@ -44,7 +44,7 @@ export default class SettingEntity {
   @Column({ type: 'varchar', default: '' })
   openAIAPIKey!: string
 
-  @Column({ type: 'varchar', default: 'gpt-3.5-turbo' })
+  @Column({ type: 'varchar', default: 'gpt-4o' })
   model!: string
 
   @Column({ type: 'simple-enum', enum: ['debug', 'info', 'warn', 'error'], default: 'info' })

--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -61,7 +61,7 @@ const app = {
     enableCopilot: settingData.enableCopilot,
     openAIAPIHost: settingData.openAIAPIHost || 'https://api.openai.com/v1',
     openAIAPIKey: settingData.openAIAPIKey || '',
-    model: settingData.model || 'gpt-3.5-turbo',
+    model: settingData.model || 'gpt-4o',
     isPrismButtonAdded: false,
     logLevel: settingData.logLevel || 'info',
     showConnectionList: getShowConnectionList(),

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -429,6 +429,9 @@ declare global {
     | 'gpt-4-32k-0613'
     | 'gpt-4-turbo'
     | 'gpt-4o'
+    | 'gpt-4o-mini'
+    | 'o1-preview'
+    | 'o1-mini'
     | string
 
   interface AreaLineSeriesData {

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -401,7 +401,7 @@
           <el-input
             size="mini"
             v-model.trim="aiConfig.model"
-            placeholder="gpt-3.5-turbo"
+            placeholder="gpt-4o"
             type="text"
             clearable
             :disabled="!enableCopilot"
@@ -496,6 +496,9 @@ export default class Settings extends Vue {
         { value: 'gpt-4-32k-0613' },
         { value: 'gpt-4-turbo' },
         { value: 'gpt-4o' },
+        { value: 'gpt-4o-mini' },
+        { value: 'o1-preview' },
+        { value: 'o1-mini' },
       ],
     },
     {
@@ -588,7 +591,7 @@ export default class Settings extends Vue {
         this.actionSetOpenAIAPIKey({ openAIAPIKey: encryptedKey })
         break
       case 'model':
-        this.actionSetModel({ model: this.aiConfig.model || 'gpt-3.5-turbo' })
+        this.actionSetModel({ model: this.aiConfig.model || 'gpt-4o' })
         break
       case 'host':
         this.actionSetOpenAIAPIHost({ openAIAPIHost: this.aiConfig.openAIAPIHost || 'https://api.openai.com/v1' })

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -505,6 +505,10 @@ export default class Settings extends Vue {
       value: 'Moonshot',
       children: [{ value: 'moonshot-v1-8k' }, { value: 'moonshot-v1-32k' }, { value: 'moonshot-v1-128k' }],
     },
+    {
+      value: 'DeepSeek',
+      children: [{ value: 'deepseek-chat' }, { value: 'deepseek-coder' }],
+    },
   ]
   private AIAPIHostOptions = [
     {
@@ -512,6 +516,9 @@ export default class Settings extends Vue {
     },
     {
       value: 'https://api.moonshot.cn/v1',
+    },
+    {
+      value: 'https://api.deepseek.com/v1',
     },
   ]
   private showImportData = false


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Please describe the current behavior and link to a relevant issue.

#### Issue Number

Example: #1763 

#### What is the new behavior?

More GPT models, such as GPT-4o-mini and o1-preview, are supported. Among them, GPT-4o-mini is relatively more affordable. It would be great to update the default model to GPT-4o since it is undoubtedly the most useful GPT model available.

<img width="416" alt="image" src="https://github.com/user-attachments/assets/d2823aba-7e5e-4000-a783-60bc011e751e">

DeepSeek is one of the most affordable large language models for users in China. We have built it with support for various features to meet your diverse needs.

<img width="415" alt="image" src="https://github.com/user-attachments/assets/cbae8da2-89aa-4a95-9d6e-e04bb34508b9">


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
