### PR TITLE
feat(client): allow client id empty

### DIFF
--- a/src/utils/mqttUtils.ts
+++ b/src/utils/mqttUtils.ts
@@ -53,6 +53,7 @@ export const getClientOptions = (record: ConnectionModel): IClientOptions => {
     clientIdWithTime,
   } = record
   const protocolVersion = mqttVersionDict[mqttVersion as '3.1' | '3.1.1' | '5.0']
+
   const options: IClientOptions = {
     clientId,
     keepalive,

--- a/src/views/connections/ConnectionForm.vue
+++ b/src/views/connections/ConnectionForm.vue
@@ -72,35 +72,6 @@
               </el-tooltip>
             </el-col>
             <el-col :span="22">
-              <el-form-item label-width="93px" label="Client ID" prop="clientId">
-                <el-input size="mini" v-model="record.clientId"></el-input>
-              </el-form-item>
-            </el-col>
-            <el-col :span="1">
-              <a href="javascript:;" class="icon-oper" @click="setClientID">
-                <i class="el-icon-refresh-right"></i>
-              </a>
-            </el-col>
-            <!-- add clientID timestamp check icon -->
-            <el-col :span="1">
-              <el-tooltip
-                placement="top"
-                :effect="theme !== 'light' ? 'light' : 'dark'"
-                :open-delay="500"
-                :offset="80"
-                :content="$t('connections.clientIdWithTimeTip')"
-              >
-                <a
-                  href="javascript:;"
-                  class="icon-oper-pure"
-                  @click="reverseClientIDWithTime"
-                  :class="{ 'icon-oper-active': clientIdWithTime }"
-                >
-                  <i class="el-icon-time"></i>
-                </a>
-              </el-tooltip>
-            </el-col>
-            <el-col :span="22">
               <el-form-item class="host-item" label-width="93px" :label="$t('connections.brokerIP')" prop="host">
                 <el-col :span="6">
                   <el-select size="mini" v-model="record.protocol" @change="handleProtocol">
@@ -129,7 +100,35 @@
                 </el-input-number>
               </el-form-item>
             </el-col>
-
+            <el-col :span="22">
+              <el-form-item label-width="93px" label="Client ID" prop="clientId">
+                <el-input size="mini" v-model="record.clientId" clearable></el-input>
+              </el-form-item>
+            </el-col>
+            <el-col :span="1">
+              <a href="javascript:;" class="icon-oper" @click="setClientID">
+                <i class="el-icon-refresh-right"></i>
+              </a>
+            </el-col>
+            <!-- add clientID timestamp check icon -->
+            <el-col :span="1">
+              <el-tooltip
+                placement="top"
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                :open-delay="500"
+                :offset="80"
+                :content="$t('connections.clientIdWithTimeTip')"
+              >
+                <a
+                  href="javascript:;"
+                  class="icon-oper-pure"
+                  @click="reverseClientIDWithTime"
+                  :class="{ 'icon-oper-active': clientIdWithTime }"
+                >
+                  <i class="el-icon-time"></i>
+                </a>
+              </el-tooltip>
+            </el-col>
             <template v-if="record.protocol === 'ws' || record.protocol === 'wss'">
               <el-col :span="22">
                 <el-form-item label-width="93px" label="Path" prop="path">
@@ -656,7 +655,6 @@ export default class ConnectionForm extends Vue {
         { required: true, message: this.$t('common.inputRequired') },
         { validator: this.validateName, trigger: 'blur' },
       ],
-      clientId: [{ required: true, message: this.$t('common.inputRequired') }],
       path: [{ required: true, message: this.$t('common.inputRequired') }],
       host: [{ required: true, message: this.$t('common.inputRequired') }],
       port: [{ required: true, message: this.$t('common.inputRequired') }],

--- a/src/views/connections/ConnectionInfo.vue
+++ b/src/views/connections/ConnectionInfo.vue
@@ -146,7 +146,6 @@ export default class ConnectionInfo extends Vue {
         { required: true, message: this.$t('common.inputRequired') },
         { validator: this.validateName, trigger: 'blur' },
       ],
-      clientId: [{ required: true, message: this.$t('common.inputRequired') }],
     }
   }
 

--- a/web/src/views/connections/ConnectionForm.vue
+++ b/web/src/views/connections/ConnectionForm.vue
@@ -62,35 +62,6 @@
               </el-tooltip>
             </el-col>
             <el-col :span="22">
-              <el-form-item label-width="93px" label="Client ID" prop="clientId">
-                <el-input size="mini" v-model="record.clientId"></el-input>
-              </el-form-item>
-            </el-col>
-            <el-col :span="1">
-              <a href="javascript:;" class="icon-oper" @click="setClientID">
-                <i class="el-icon-refresh-right"></i>
-              </a>
-            </el-col>
-            <!-- add clientID timestamp check icon -->
-            <el-col :span="1">
-              <el-tooltip
-                placement="top"
-                :effect="theme !== 'light' ? 'light' : 'dark'"
-                :open-delay="500"
-                :offset="80"
-                :content="$t('connections.clientIdWithTimeTip')"
-              >
-                <a
-                  href="javascript:;"
-                  class="icon-oper-pure"
-                  @click="reverseClientIDWithTime"
-                  :class="{ 'icon-oper-active': clientIdWithTime }"
-                >
-                  <i class="el-icon-time"></i>
-                </a>
-              </el-tooltip>
-            </el-col>
-            <el-col :span="22">
               <el-form-item class="host-item" label-width="93px" :label="$t('connections.brokerIP')" prop="host">
                 <el-col :span="6">
                   <el-select size="mini" v-model="record.protocol" popper-class="ws-protocol-select">
@@ -155,6 +126,35 @@
                 >
                 </el-input-number>
               </el-form-item>
+            </el-col>
+            <el-col :span="22">
+              <el-form-item label-width="93px" label="Client ID" prop="clientId">
+                <el-input size="mini" v-model="record.clientId" clearable></el-input>
+              </el-form-item>
+            </el-col>
+            <el-col :span="1">
+              <a href="javascript:;" class="icon-oper" @click="setClientID">
+                <i class="el-icon-refresh-right"></i>
+              </a>
+            </el-col>
+            <!-- add clientID timestamp check icon -->
+            <el-col :span="1">
+              <el-tooltip
+                placement="top"
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                :open-delay="500"
+                :offset="80"
+                :content="$t('connections.clientIdWithTimeTip')"
+              >
+                <a
+                  href="javascript:;"
+                  class="icon-oper-pure"
+                  @click="reverseClientIDWithTime"
+                  :class="{ 'icon-oper-active': clientIdWithTime }"
+                >
+                  <i class="el-icon-time"></i>
+                </a>
+              </el-tooltip>
             </el-col>
 
             <template v-if="record.protocol === 'ws' || record.protocol === 'wss'">
@@ -614,7 +614,6 @@ export default class ConnectionCreate extends Vue {
         { required: true, message: this.$t('common.inputRequired') },
         { validator: this.validateName, trigger: 'blur' },
       ],
-      clientId: [{ required: true, message: this.$t('common.inputRequired') }],
       path: [{ required: true, message: this.$t('common.inputRequired') }],
       host: [{ required: true, message: this.$t('common.inputRequired') }],
       port: [{ required: true, message: this.$t('common.inputRequired') }],

--- a/web/src/views/connections/ConnectionInfo.vue
+++ b/web/src/views/connections/ConnectionInfo.vue
@@ -131,7 +131,6 @@ export default class ConnectionInfo extends Vue {
         { required: true, message: this.$t('common.inputRequired') },
         { validator: this.validateName, trigger: 'blur' },
       ],
-      clientId: [{ required: true, message: this.$t('common.inputRequired') }],
     }
   }
 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

It is impossible to simulate MQTT 5 when the Client ID is empty. In this case, the MQTT Broker can automatically allocate a Client ID.

https://www.emqx.com/zh/blog/mqtt5-connect-properties

#### Issue Number

Example: https://askemq.com/t/topic/7181

#### What is the new behavior?

Support clearing the client ID, and do not limit the client ID to a required field.

<img width="684" alt="image" src="https://github.com/user-attachments/assets/36832dd8-28cb-4503-8c0a-511b943eb590">

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
