### PR TITLE
fix(desktop): fix can not init unread message count issue

### DIFF
--- a/src/views/connections/ConnectionsList.vue
+++ b/src/views/connections/ConnectionsList.vue
@@ -232,6 +232,7 @@ export default class ConnectionsList extends Vue {
         treeRef?.setCurrentKey(id)
         this.connectionId = id
         this.expandTreeNodeAncestor(id)
+        this.initUnreadMessageCount(id)
       }
     })
   }
@@ -738,6 +739,7 @@ export default class ConnectionsList extends Vue {
 
   private mounted() {
     this.loadData(true)
+    this.initUnreadMessageCount(this.connectionId)
   }
 }
 </script>
@@ -796,6 +798,9 @@ export default class ConnectionsList extends Vue {
         background-color: var(--color-bg-item);
       }
       .el-tree-node__content {
+        .el-tree-node__expand-icon {
+          padding: 4px;
+        }
         height: 100%;
         margin: 0 8px;
         border-radius: 8px;
@@ -860,6 +865,8 @@ export default class ConnectionsList extends Vue {
               color: var(--color-text-active);
               font-size: $font-size--tips;
               text-align: center;
+              position: relative;
+              top: -2px;
             }
             .connection-status {
               display: inline-block;


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Jumping to the new connection page or topic tree page cannot be initialized correctly if the connection has unread message statistics.

#### Issue Number

Example: \#123

#### What is the new behavior?

Fix it.

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
