### PR TITLE
fix(desktop): delay open the topic tooltip

### DIFF
--- a/src/components/SubscriptionsList.vue
+++ b/src/components/SubscriptionsList.vue
@@ -33,6 +33,7 @@
           placement="top"
           trigger="hover"
           popper-class="topic-tooltip"
+          :open-delay="600"
           :content="getPopoverContent(copySuccess, sub)"
         >
           <a


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When hovering over topics, the tag that appears gets in the way. Long hover should have tag appear

#### Issue Number

Example: https://github.com/emqx/MQTTX/discussions/452#discussioncomment-10629550

#### What is the new behavior?

Not immediately to show.

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
