### PR TITLE
refactor(ui): reorganize imports

### DIFF
--- a/apps/desktop/src/renderer/src/App.vue
+++ b/apps/desktop/src/renderer/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ElementI18nMap, useSettingsStore } from '@mqttx/ui'
+import { ElementI18nMap } from '@mqttx/ui/i18n'
+import { useSettingsStore } from '@mqttx/ui/stores'
 
 const settingsStore = useSettingsStore()
 console.log('MQTTX Desktop App init...')

--- a/apps/desktop/src/renderer/src/main.ts
+++ b/apps/desktop/src/renderer/src/main.ts
@@ -1,14 +1,18 @@
-import { i18n, pinia, useSettingsStore } from '@mqttx/ui'
+import { i18n } from '@mqttx/ui/i18n'
+import { useSettingsStore } from '@mqttx/ui/stores'
+import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 
 import App from './App.vue'
 import { router } from './router'
 
-import '@mqttx/ui/dist/style.css'
+import '@mqttx/ui/styles.scss'
 import './assets/scss/main.scss'
 
 // Create Vue
 const app = createApp(App)
+
+const pinia = createPinia()
 
 app.use(router).use(pinia)
 

--- a/apps/desktop/tailwind.config.ts
+++ b/apps/desktop/tailwind.config.ts
@@ -3,7 +3,11 @@ import baseConfig from '@mqttx/tailwind-config/base.config'
 
 const config: Config = {
   presets: [baseConfig],
-  content: ['./src/renderer/index.html', './src/renderer/src/**/*.{vue,js,ts,jsx,tsx}'],
+  content: [
+    './src/renderer/index.html',
+    './src/renderer/src/**/*.{vue,js,ts,jsx,tsx}',
+    '../../packages/ui/src/**/*.{vue,js,ts,jsx,tsx}',
+  ],
 }
 
 export default config

--- a/apps/desktop/tsconfig.web.json
+++ b/apps/desktop/tsconfig.web.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "baseUrl": ".",
+    "moduleResolution": "bundler",
     "paths": {
       "@renderer/*": ["src/renderer/src/*"]
     },

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ElementI18nMap, useSettingsStore } from '@mqttx/ui'
+import { ElementI18nMap } from '@mqttx/ui/i18n'
+import { useSettingsStore } from '@mqttx/ui/stores'
 
 const settingsStore = useSettingsStore()
 console.log('MQTTX Web App init...')

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -1,14 +1,18 @@
-import { i18n, pinia, useSettingsStore } from '@mqttx/ui'
+import { i18n } from '@mqttx/ui/i18n'
+import { useSettingsStore } from '@mqttx/ui/stores'
+import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 
 import App from './App.vue'
 import { router } from './router'
 
-import '@mqttx/ui/dist/style.css'
+import '@mqttx/ui/styles.scss'
 import './assets/scss/main.scss'
 
 // Create Vue
 const app = createApp(App)
+
+const pinia = createPinia()
 
 app.use(router).use(pinia)
 

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -2,7 +2,11 @@ import type { Config } from 'tailwindcss'
 import baseConfig from '@mqttx/tailwind-config/base.config'
 
 const config: Config = {
-  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+  content: [
+    './index.html',
+    './src/**/*.{vue,js,ts,jsx,tsx}',
+    '../../packages/ui/src/**/*.{vue,js,ts,jsx,tsx}',
+  ],
   presets: [baseConfig],
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "repository": "https://github.com/emqx/MQTTX",
   "scripts": {
     "prepare": "husky install",
-    "postinstall": "pnpm run generate:ui",
     "dev": "turbo run dev",
     "dev:desktop": "turbo run dev --filter @mqttx/desktop",
     "dev:web": "turbo run dev --filter @mqttx/web",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -2,6 +2,12 @@
   "name": "@mqttx/ui",
   "type": "module",
   "version": "0.0.0",
+  "exports": {
+    ".": "./src/index.ts",
+    "./i18n": "./src/i18n/index.ts",
+    "./stores": "./src/stores/index.ts",
+    "./styles.scss": "./src/styles/index.scss"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,12 +20,12 @@
     "test:dev": "vitest"
   },
   "peerDependencies": {
-    "@element-plus/icons-vue": "^2.1.0",
-    "element-plus": "^2.4.1",
-    "pinia": "^2.1.7",
-    "vue": "^3.3.4",
-    "vue-i18n": "9",
-    "vue-router": "4"
+    "@element-plus/icons-vue": "^2.3.1",
+    "element-plus": "^2.8.7",
+    "pinia": "^2.2.6",
+    "vue": "^3.5.12",
+    "vue-i18n": "^10.0.4",
+    "vue-router": "^4.4.5"
   },
   "devDependencies": {
     "@mqttx/core": "workspace:*",

--- a/packages/ui/src/i18n/index.ts
+++ b/packages/ui/src/i18n/index.ts
@@ -1,9 +1,9 @@
 import type { Lang } from 'mqttx'
-import ElementPlusEN from 'element-plus/dist/locale/en.mjs'
-import ElementPlusHU from 'element-plus/dist/locale/hu.mjs'
-import ElementPlusJA from 'element-plus/dist/locale/ja.mjs'
-import ElementPlusTR from 'element-plus/dist/locale/tr.mjs'
-import ElementPlusZH from 'element-plus/dist/locale/zh-cn.mjs'
+import ElementPlusEN from 'element-plus/es/locale/lang/en'
+import ElementPlusHU from 'element-plus/es/locale/lang/hu'
+import ElementPlusJA from 'element-plus/es/locale/lang/ja'
+import ElementPlusTR from 'element-plus/es/locale/lang/tr'
+import ElementPlusZH from 'element-plus/es/locale/lang/zh-cn'
 import { createI18n } from 'vue-i18n'
 
 export const ElementI18nMap: Record<Lang, any> = {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -8,9 +8,6 @@ import MainView from './components/common/MainView.vue'
 import SplitView from './components/common/SplitView.vue'
 import ConnectionDetailsView from './components/connections/DetailsView.vue'
 import ConnectionListView from './components/connections/ListView.vue'
-import 'element-plus/dist/index.css'
-import './styles/index.scss'
-import './assets/fonts/iconfont'
 
 export const pinia = createPinia()
 

--- a/packages/ui/src/styles/index.scss
+++ b/packages/ui/src/styles/index.scss
@@ -2,7 +2,7 @@
 
 @forward './tailwind.scss';
 // FIXME: fix iconfont
-@forward '../assets/fonts/iconfont.css';
+// @forward '../assets/fonts/iconfont.css';
 @forward './normalize.scss';
 @forward './connections.scss';
 

--- a/packages/ui/src/vite-env.d.ts
+++ b/packages/ui/src/vite-env.d.ts
@@ -1,1 +1,0 @@
-declare module 'element-plus/dist/locale/*.mjs'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,23 +354,23 @@ importers:
   packages/ui:
     dependencies:
       '@element-plus/icons-vue':
-        specifier: ^2.1.0
-        version: 2.1.0(vue@3.5.12)
+        specifier: ^2.3.1
+        version: 2.3.1(vue@3.5.12)
       element-plus:
-        specifier: ^2.4.1
-        version: 2.4.1(vue@3.5.12)
+        specifier: ^2.8.7
+        version: 2.8.7(vue@3.5.12)
       pinia:
-        specifier: ^2.1.7
-        version: 2.1.7(typescript@5.6.3)(vue@3.5.12)
+        specifier: ^2.2.6
+        version: 2.2.6(typescript@5.6.3)(vue@3.5.12)
       vue:
-        specifier: ^3.3.4
+        specifier: ^3.5.12
         version: 3.5.12(typescript@5.6.3)
       vue-i18n:
-        specifier: '9'
-        version: 9.6.2(vue@3.5.12)
+        specifier: ^10.0.4
+        version: 10.0.4(vue@3.5.12)
       vue-router:
-        specifier: '4'
-        version: 4.2.5(vue@3.5.12)
+        specifier: ^4.4.5
+        version: 4.4.5(vue@3.5.12)
     devDependencies:
       '@mqttx/core':
         specifier: workspace:*
@@ -989,14 +989,6 @@ packages:
       - supports-color
     dev: true
 
-  /@element-plus/icons-vue@2.1.0(vue@3.5.12):
-    resolution: {integrity: sha512-PSBn3elNoanENc1vnCfh+3WA9fimRC7n+fWkf3rE5jvv+aBohNHABC/KAR5KWPecxWxDTVT1ERpRbOMRcOV/vA==}
-    peerDependencies:
-      vue: ^3.2.0
-    dependencies:
-      vue: 3.5.12(typescript@5.6.3)
-    dev: false
-
   /@element-plus/icons-vue@2.3.1(vue@3.5.12):
     resolution: {integrity: sha512-XxVUZv48RZAd87ucGS48jPf6pKu0yV5UCg9f4FFwtrYxXOwWuVJo6wOvSLKEoMQKjv8GsX/mhP6UsC1lRwbUWg==}
     peerDependencies:
@@ -1317,23 +1309,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
     dev: true
 
-  /@floating-ui/core@1.5.0:
-    resolution: {integrity: sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==}
-    dependencies:
-      '@floating-ui/utils': 0.1.6
-    dev: false
-
   /@floating-ui/core@1.6.8:
     resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
     dependencies:
       '@floating-ui/utils': 0.2.8
-    dev: false
-
-  /@floating-ui/dom@1.5.3:
-    resolution: {integrity: sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==}
-    dependencies:
-      '@floating-ui/core': 1.5.0
-      '@floating-ui/utils': 0.1.6
     dev: false
 
   /@floating-ui/dom@1.6.12:
@@ -1341,10 +1320,6 @@ packages:
     dependencies:
       '@floating-ui/core': 1.6.8
       '@floating-ui/utils': 0.2.8
-    dev: false
-
-  /@floating-ui/utils@0.1.6:
-    resolution: {integrity: sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A==}
     dev: false
 
   /@floating-ui/utils@0.2.8:
@@ -1391,14 +1366,6 @@ packages:
       '@intlify/shared': 10.0.4
     dev: false
 
-  /@intlify/core-base@9.6.2:
-    resolution: {integrity: sha512-ci0j2nbEL/pamvqgcCqyIVeQ3LS41F1IRqI5rCBNnpSp0FjNnH8bpha8R3OifkhqatzlP4wGOuN/UqfLYVDv7g==}
-    engines: {node: '>= 16'}
-    dependencies:
-      '@intlify/message-compiler': 9.6.2
-      '@intlify/shared': 9.6.2
-    dev: false
-
   /@intlify/message-compiler@10.0.4:
     resolution: {integrity: sha512-AFbhEo10DP095/45EauinQJ5hJ3rJUmuuqltGguvc3WsvezZN+g8qNHLGWKu60FHQVizMrQY7VJ+zVlBXlQQkQ==}
     engines: {node: '>= 16'}
@@ -1407,21 +1374,8 @@ packages:
       source-map-js: 1.2.1
     dev: false
 
-  /@intlify/message-compiler@9.6.2:
-    resolution: {integrity: sha512-kgZQL9zeJDeEB5vvD93Y++HvFUELnT48PjnpfCcF3EJaLLVs9he8IzODiNK42Z40lWbFyja0SXJZjsalybQygA==}
-    engines: {node: '>= 16'}
-    dependencies:
-      '@intlify/shared': 9.6.2
-      source-map-js: 1.0.2
-    dev: false
-
   /@intlify/shared@10.0.4:
     resolution: {integrity: sha512-ukFn0I01HsSgr3VYhYcvkTCLS7rGa0gw4A4AMpcy/A9xx/zRJy7PS2BElMXLwUazVFMAr5zuiTk3MQeoeGXaJg==}
-    engines: {node: '>= 16'}
-    dev: false
-
-  /@intlify/shared@9.6.2:
-    resolution: {integrity: sha512-9KBcXmJNxElp7QMnU8V0/tScTOitDqyFi4HceEZqJyyDkMi8K5DBPMTIuXIAMmtMlXpe/nj5pke7tRw97VeQRA==}
     engines: {node: '>= 16'}
     dev: false
 
@@ -2042,20 +1996,10 @@ packages:
     dependencies:
       '@types/node': 20.17.6
 
-  /@types/lodash-es@4.17.10:
-    resolution: {integrity: sha512-YJP+w/2khSBwbUSFdGsSqmDvmnN3cCKoPOL7Zjle6s30ZtemkkqhjVfFqGwPN7ASil5VyjE2GtyU/yqYY6mC0A==}
-    dependencies:
-      '@types/lodash': 4.14.200
-    dev: false
-
   /@types/lodash-es@4.17.12:
     resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
     dependencies:
       '@types/lodash': 4.17.13
-    dev: false
-
-  /@types/lodash@4.14.200:
-    resolution: {integrity: sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==}
     dev: false
 
   /@types/lodash@4.17.13:
@@ -2519,10 +2463,6 @@ packages:
       de-indent: 1.0.2
       he: 1.2.0
     dev: true
-
-  /@vue/devtools-api@6.5.1:
-    resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
-    dev: false
 
   /@vue/devtools-api@6.6.4:
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -3685,10 +3625,6 @@ packages:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
 
-  /dayjs@1.11.10:
-    resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
-    dev: false
-
   /dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
     dev: false
@@ -4029,31 +3965,6 @@ packages:
       extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
-
-  /element-plus@2.4.1(vue@3.5.12):
-    resolution: {integrity: sha512-t7nl+vQlkBKVk1Ag6AufSDyFV8YIXxTFsaya4Nz/0tiRlcz65WPN4WMFeNURuFJleu1HLNtP4YyQKMuS7El8uA==}
-    peerDependencies:
-      vue: ^3.2.0
-    dependencies:
-      '@ctrl/tinycolor': 3.6.1
-      '@element-plus/icons-vue': 2.1.0(vue@3.5.12)
-      '@floating-ui/dom': 1.5.3
-      '@popperjs/core': /@sxzz/popperjs-es@2.11.7
-      '@types/lodash': 4.14.200
-      '@types/lodash-es': 4.17.10
-      '@vueuse/core': 9.13.0(vue@3.5.12)
-      async-validator: 4.2.5
-      dayjs: 1.11.10
-      escape-html: 1.0.3
-      lodash: 4.17.21
-      lodash-es: 4.17.21
-      lodash-unified: 1.0.3(@types/lodash-es@4.17.10)(lodash-es@4.17.21)(lodash@4.17.21)
-      memoize-one: 6.0.0
-      normalize-wheel-es: 1.2.0
-      vue: 3.5.12(typescript@5.6.3)
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-    dev: false
 
   /element-plus@2.8.7(vue@3.5.12):
     resolution: {integrity: sha512-oGQyFRufFOgjd872tZc+T4xQAYLlX4hj6d3ixeY13L4fFNUuc1N49JHAqJGPda0tdx3qCnjceZoh1kqqj2+tXQ==}
@@ -5804,18 +5715,6 @@ packages:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
     dev: false
 
-  /lodash-unified@1.0.3(@types/lodash-es@4.17.10)(lodash-es@4.17.21)(lodash@4.17.21):
-    resolution: {integrity: sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ==}
-    peerDependencies:
-      '@types/lodash-es': '*'
-      lodash: '*'
-      lodash-es: '*'
-    dependencies:
-      '@types/lodash-es': 4.17.10
-      lodash: 4.17.21
-      lodash-es: 4.17.21
-    dev: false
-
   /lodash-unified@1.0.3(@types/lodash-es@4.17.12)(lodash-es@4.17.21)(lodash@4.17.21):
     resolution: {integrity: sha512-WK9qSozxXOD7ZJQlpSqOT+om2ZfcT4yO+03FuzAHD0wF6S0l0090LRPDx3vhTTLZ8cFKpBn+IOcVXK6qOcIlfQ==}
     peerDependencies:
@@ -7013,24 +6912,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /pinia@2.1.7(typescript@5.6.3)(vue@3.5.12):
-    resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
-    peerDependencies:
-      '@vue/composition-api': ^1.4.0
-      typescript: '>=4.4.4'
-      vue: ^2.6.14 || ^3.3.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      '@vue/devtools-api': 6.5.1
-      typescript: 5.6.3
-      vue: 3.5.12(typescript@5.6.3)
-      vue-demi: 0.14.6(vue@3.5.12)
-    dev: false
-
   /pinia@2.2.6(typescript@5.6.3)(vue@3.5.12):
     resolution: {integrity: sha512-vIsR8JkDN5Ga2vAxqOE2cJj4VtsHnzpR1Fz30kClxlh0yCHfec6uoMeM3e/ddqmwFUejK3NlrcQa/shnpyT4hA==}
     peerDependencies:
@@ -7975,11 +7856,6 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
-  /source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -8858,21 +8734,6 @@ packages:
       vue: 3.5.12(typescript@5.6.3)
     dev: false
 
-  /vue-demi@0.14.6(vue@3.5.12):
-    resolution: {integrity: sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    peerDependencies:
-      '@vue/composition-api': ^1.0.0-rc.1
-      vue: ^3.0.0-0 || ^2.6.0
-    peerDependenciesMeta:
-      '@vue/composition-api':
-        optional: true
-    dependencies:
-      vue: 3.5.12(typescript@5.6.3)
-    dev: false
-
   /vue-eslint-parser@9.4.3(eslint@9.14.0):
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}
     engines: {node: ^14.17.0 || >=16.0.0}
@@ -8900,27 +8761,6 @@ packages:
       '@intlify/core-base': 10.0.4
       '@intlify/shared': 10.0.4
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.12(typescript@5.6.3)
-    dev: false
-
-  /vue-i18n@9.6.2(vue@3.5.12):
-    resolution: {integrity: sha512-J43grTQjPR8LCUxvx3mkoM+11xhTnej1Al4lvJCEeKmQqf8eqbuYPQb54HXnEg/UzZyaxLBAwPAUTbrZ8V7hcg==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      vue: ^3.0.0
-    dependencies:
-      '@intlify/core-base': 9.6.2
-      '@intlify/shared': 9.6.2
-      '@vue/devtools-api': 6.5.1
-      vue: 3.5.12(typescript@5.6.3)
-    dev: false
-
-  /vue-router@4.2.5(vue@3.5.12):
-    resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}
-    peerDependencies:
-      vue: ^3.2.0
-    dependencies:
-      '@vue/devtools-api': 6.5.1
       vue: 3.5.12(typescript@5.6.3)
     dev: false
 


### PR DESCRIPTION
This pull request includes several changes across multiple files to improve the structure and organization of imports, update Tailwind CSS configurations, and adjust module exports. The most important changes include refactoring imports, updating Tailwind CSS content paths, and modifying the `package.json` files for better module resolution.

Refactoring imports:

* [`apps/desktop/src/renderer/src/App.vue`](diffhunk://#diff-742de6ecc0e88763b22ebb751c98d3168acc223abb61ef63b7e9991add5914bbL2-R3): Separated imports from `@mqttx/ui` into `@mqttx/ui/i18n` and `@mqttx/ui/stores`.
* [`apps/web/src/App.vue`](diffhunk://#diff-3484783b87f953af09f16dea9b15f3b6b00410249c4acae47f327bc2e02d9e65L2-R3): Similar separation of imports from `@mqttx/ui` into `@mqttx/ui/i18n` and `@mqttx/ui/stores`.
* `apps/desktop/src/renderer/src/main.ts` and `apps/web/src/main.ts`: Updated imports and added `createPinia` for state management.

Updating Tailwind CSS configurations:

* `apps/desktop/tailwind.config.ts` and `apps/web/tailwind.config.ts`: Expanded `content` paths to include files from `../../packages/ui/src`. [[1]](diffhunk://#diff-bda710c3dc41046b13618bc759cba1bcd2715ef0122c0916aadee99623adee23L6-R10) [[2]](diffhunk://#diff-65c88a514382936faaa24049378886241ce9c689dfe4a5a3fcb7b2cc53794ea2L5-R9)

Modifying `package.json` files:

* [`packages/ui/package.json`](diffhunk://#diff-1ae5a5e8c23bd3bc31ea590a9cbe48eb9ad3bbddc0fb5732d08c04a53c8ad51dR5-R10): Added `exports` field to specify module entry points for better module resolution.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L11): Removed the `postinstall` script for generating UI.

Additional changes:

* [`packages/ui/src/styles/index.scss`](diffhunk://#diff-f30fa353722f424b0463effb72fb2897b6e2d44649fdf777708159e1b4c335dcL5-R5): Commented out the `@forward` for `iconfont.css` to address a FIXME note.