### PR TITLE
fix(cli): support more biarny type files

### DIFF
--- a/cli/src/__tests__/utils/binaryFormats.test.ts
+++ b/cli/src/__tests__/utils/binaryFormats.test.ts
@@ -3,27 +3,121 @@ import { expect, describe, it } from '@jest/globals'
 
 describe('isSupportedBinaryFormatForMQTT', () => {
   it('should return true for supported binary formats', () => {
-    const supportedFormats = ['.png', '.mp4', '.mp3', '.zip', '.exe', '.pdf']
+    const supportedFormats = [
+      // Common formats
+      '.png',
+      '.mp4',
+      '.mp3',
+      '.zip',
+      '.exe',
+      '.pdf',
+      // Network & Protocol formats
+      '.netp',
+      '.pcap',
+      '.pcapng',
+      '.cap',
+      '.dmp',
+      '.trace',
+      // Database formats
+      '.db',
+      '.sqlite',
+      '.mdb',
+      '.frm',
+      '.myd',
+      '.myi',
+      // IoT & Device formats
+      '.dat',
+      '.raw',
+      '.log',
+      '.blob',
+      '.hex',
+      '.rom',
+      '.fw',
+      // Custom protocol & data formats
+      '.pkt',
+      '.mpack',
+      '.parquet',
+      '.orc',
+    ]
     supportedFormats.forEach((format) => {
       expect(isSupportedBinaryFormatForMQTT(format)).toBe(true)
     })
   })
 
   it('should return false for unsupported binary formats', () => {
-    const unsupportedFormats = ['.txt', '.doc', '.xls', '.ppt', '.html', '.css']
+    const unsupportedFormats = [
+      // Text formats
+      '.txt',
+      '.md',
+      '.rtf',
+      // Document formats
+      '.doc',
+      '.docx',
+      '.xls',
+      '.xlsx',
+      '.ppt',
+      '.pptx',
+      // Web formats
+      '.html',
+      '.css',
+      '.js',
+      '.json',
+      '.xml',
+      // Source code formats
+      '.c',
+      '.cpp',
+      '.java',
+      '.py',
+      '.ts',
+      // Config formats
+      '.yml',
+      '.ini',
+      '.conf',
+      '.env',
+    ]
     unsupportedFormats.forEach((format) => {
       expect(isSupportedBinaryFormatForMQTT(format)).toBe(false)
     })
   })
 
   it('should be case-sensitive', () => {
-    expect(isSupportedBinaryFormatForMQTT('.PNG')).toBe(false)
-    expect(isSupportedBinaryFormatForMQTT('.png')).toBe(true)
+    const testCases = [
+      ['.PNG', '.png'],
+      ['.DB', '.db'],
+      ['.NETP', '.netp'],
+      ['.PCAP', '.pcap'],
+      ['.HEX', '.hex'],
+    ]
+
+    testCases.forEach(([upper, lower]) => {
+      expect(isSupportedBinaryFormatForMQTT(upper)).toBe(false)
+      expect(isSupportedBinaryFormatForMQTT(lower)).toBe(true)
+    })
   })
 
   it('should include all supported formats', () => {
     supportedBinaryFormatsForMQTT.forEach((format) => {
       expect(isSupportedBinaryFormatForMQTT(format)).toBe(true)
     })
+  })
+
+  it('should handle format categories correctly', () => {
+    // Test by categories
+    const categories = {
+      image: ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.ico', '.tif', '.tiff'],
+      video: ['.mp4', '.avi', '.mov', '.mkv', '.flv', '.wmv', '.mpeg', '.3gp'],
+      audio: ['.mp3', '.wav', '.flac', '.aac', '.ogg', '.wma', '.m4a', '.m4p'],
+      compressed: ['.zip', '.gz', '.rar', '.tar', '.7z', '.bz2', '.xz', '.jar'],
+      network: ['.netp', '.pcap', '.pcapng', '.cap', '.dmp', '.trace'],
+      database: ['.db', '.sqlite', '.mdb', '.frm', '.myd', '.myi'],
+      device: ['.dat', '.raw', '.log', '.blob', '.hex', '.rom', '.fw'],
+      protocol: ['.pkt', '.mpack', '.parquet', '.orc'],
+    }
+
+    Object.values(categories)
+      .flat()
+      .forEach((format) => {
+        expect(isSupportedBinaryFormatForMQTT(format)).toBe(true)
+      })
   })
 })

--- a/cli/src/utils/binaryFormats.ts
+++ b/cli/src/utils/binaryFormats.ts
@@ -40,6 +40,29 @@ export const supportedBinaryFormatsForMQTT = [
   '.img', // Binary file formats
   '.pdf',
   '.epub', // Binary document file formats
+  '.netp', // Network protocol binary format
+  '.pcap', // Packet capture
+  '.pcapng', // Next generation packet capture
+  '.cap', // Network capture
+  '.dmp', // Memory dump
+  '.trace', // Network trace
+  '.db', // Generic database
+  '.sqlite', // SQLite database
+  '.mdb', // Microsoft Access database
+  '.frm', // MySQL table definition
+  '.myd', // MySQL data
+  '.myi', // MySQL index
+  '.dat', // Generic data file
+  '.raw', // Raw data
+  '.log', // Binary log
+  '.blob', // Binary large object
+  '.hex', // Hex dump
+  '.rom', // ROM image
+  '.fw', // Firmware
+  '.pkt', // Packet data
+  '.mpack', // MessagePack data
+  '.parquet', // Parquet columnar storage
+  '.orc', // Optimized Row Columnar
 ]
 
 const isSupportedBinaryFormatForMQTT = (fileExtname: string) => {


### PR DESCRIPTION
#### Issue Number

#1806 

#### What is the new behavior?

This pull request includes updates to the `cli/src/__tests__/utils/binaryFormats.test.ts` and `cli/src/utils/binaryFormats.ts` files to expand the list of supported and unsupported binary formats for MQTT. The changes also include improvements to the test cases to handle format categories and case sensitivity.

Updates to supported and unsupported formats:

* [`cli/src/__tests__/utils/binaryFormats.test.ts`](diffhunk://#diff-c40bf988261ec53add29e28ce331d71968c737b9c791af725edc4440a5f24b5eL6-R122): Expanded the list of supported and unsupported binary formats, including new categories such as Network & Protocol formats, Database formats, IoT & Device formats, and more.
* [`cli/src/utils/binaryFormats.ts`](diffhunk://#diff-4ab77bfacbb0af0860f0a241b049d85a929173595df25fbae3ad9593c83b0f7dR43-R65): Added new binary formats to the `supportedBinaryFormatsForMQTT` array, including network protocol formats, database formats, and custom protocol & data formats.

Improvements to test cases:

* [`cli/src/__tests__/utils/binaryFormats.test.ts`](diffhunk://#diff-c40bf988261ec53add29e28ce331d71968c737b9c791af725edc4440a5f24b5eL6-R122): Enhanced test cases to check for case sensitivity and to handle format categories correctly.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
