### PR TITLE
refactor(desktop): add mqtt properties component

### DIFF
--- a/src/components/MqttProperties.vue
+++ b/src/components/MqttProperties.vue
@@ -15,7 +15,12 @@
           />
         </template>
         <template v-else>
-          <span>{{ $t(`connections.${field.key}`) }}: {{ properties[field.key] }}</span>
+          <span class="property-item">
+            <span class="label"
+              >{{ $t(`connections.${field.key}`) }}<span v-if="showColon" class="colon">: </span></span
+            >
+            <span class="value">{{ properties[field.key] }}</span>
+          </span>
         </template>
       </p>
     </template>
@@ -38,6 +43,7 @@ interface PropertyField {
 export default class MqttProperties extends Vue {
   @Prop({ required: true }) public properties!: PushPropertiesModel
   @Prop({ default: '' }) public direction!: string
+  @Prop({ default: true }) public showColon!: boolean
 
   private propertyFields: PropertyField[] = [
     { key: 'subscriptionIdentifier' },

--- a/src/widgets/TreeNodeInfo.vue
+++ b/src/widgets/TreeNodeInfo.vue
@@ -54,6 +54,11 @@
       <pre
         class="payload-container mt-2 mb-2"
       ><code :class="`language-${payloadFormat}`" v-html="latestMessage"></code></pre>
+      <MqttProperties
+        class="tree-node-info-mqtt-properties"
+        :show-colon="false"
+        :properties="node.message.properties"
+      />
     </div>
   </div>
 </template>
@@ -64,8 +69,13 @@ import { Getter } from 'vuex-class'
 import { findSubTopics, findFullTopicPath, isPayloadEmpty } from '@/utils/topicTree'
 import Prism from 'prismjs'
 import { jsonStringify, jsonParse } from '@/utils/jsonUtils'
+import MqttProperties from '@/components/MqttProperties.vue'
 
-@Component
+@Component({
+  components: {
+    MqttProperties,
+  },
+})
 export default class TreeNodeInfo extends Vue {
   @Prop() private node!: TopicTreeNode
   @Prop() private treeData!: TopicTreeNode[]
@@ -180,6 +190,31 @@ body.night {
       margin: 0;
       white-space: pre-wrap;
       word-wrap: break-word;
+    }
+  }
+  .mqtt-properties.tree-node-info-mqtt-properties {
+    margin-top: 12px;
+    .properties {
+      .property-item {
+        display: flex;
+        flex-direction: column;
+        margin: 6px 0 12px 0;
+        .value {
+          background-color: var(--color-bg-select_lang);
+          padding: 6px 12px;
+          border-radius: 8px;
+          margin-top: 6px;
+        }
+      }
+      &.user-properties {
+        .editor-header {
+          margin-bottom: 6px;
+        }
+        .el-textarea.is-disabled .el-textarea__inner {
+          color: var(--color-text-default);
+          border: 1px solid var(--color-border-default);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Please describe the current behavior and link to a relevant issue.

#### Issue Number

Example: \#123

#### What is the new behavior?

This pull request introduces changes to the `MqttProperties` and `TreeNodeInfo` components to improve the display and styling of MQTT properties. The most important changes include adding a new `showColon` prop, updating the template to use the new prop, and integrating the `MqttProperties` component into `TreeNodeInfo`.

### Enhancements to `MqttProperties` component:

* Added a new `showColon` prop to control the display of a colon after the property label.
* Updated the template to use the new `showColon` prop and improved the structure of the property display.

### Integration with `TreeNodeInfo` component:

* Imported the `MqttProperties` component and registered it locally in `TreeNodeInfo`.
* Integrated the `MqttProperties` component into the `TreeNodeInfo` template to display MQTT properties.

### Styling updates:

* Added new styles to `TreeNodeInfo` to enhance the appearance of the `MqttProperties` component.

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/b0c06518-9700-4d96-ad13-235cce4628f1">

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
