### PR TITLE
feat(cli): add exit tips for conn

### DIFF
--- a/cli/src/lib/conn.ts
+++ b/cli/src/lib/conn.ts
@@ -4,6 +4,7 @@ import { parseConnectOptions } from '../utils/parse'
 import delay from '../utils/delay'
 import { handleSaveOptions, handleLoadOptions } from '../utils/options'
 import * as Debug from 'debug'
+import { triggerExitInfo } from '../utils/exitInfo'
 
 const conn = (options: ConnectOptions) => {
   const { debug, saveOptions, loadOptions } = options
@@ -27,6 +28,7 @@ const conn = (options: ConnectOptions) => {
   client.on('connect', () => {
     basicLog.connected()
     retryTimes = 0
+    setTimeout(triggerExitInfo, 1000)
   })
 
   client.on('error', (err) => {
@@ -96,6 +98,7 @@ const benchConn = async (options: BenchConnectOptions) => {
           if (connectedCount === count) {
             const end = Date.now()
             signale.success(`Created ${count} connections in ${(end - start) / 1000}s`)
+            setTimeout(triggerExitInfo, 1000)
           }
         } else {
           benchLog.reconnected(connectedCount, count, opts.clientId!)

--- a/cli/src/lib/pub.ts
+++ b/cli/src/lib/pub.ts
@@ -15,6 +15,7 @@ import { checkScenarioExists, checkTopicExists, parseConnectOptions, parsePublis
 import { serializeProtobufToBuffer } from '../utils/protobuf'
 import { serializeAvroToBuffer } from '../utils/avro'
 import { loadSimulator } from '../utils/simulate'
+import { triggerExitInfo } from '../utils/exitInfo'
 
 /**
  * Processes the outgoing message through two potential stages:
@@ -154,6 +155,7 @@ const multiSend = (
 
   client.on('connect', () => {
     basicLog.enterToPublish()
+    setTimeout(triggerExitInfo, 1000)
     retryTimes = 0
     isNewConnection &&
       pump(process.stdin, split2(), sender, (err) => {

--- a/cli/src/utils/exitInfo.ts
+++ b/cli/src/utils/exitInfo.ts
@@ -1,0 +1,5 @@
+import chalk from 'chalk'
+
+export const triggerExitInfo = () => {
+  console.log(chalk.dim('- Press Ctrl+C to disconnect and exit'))
+}

--- a/cli/src/utils/logWrapper.ts
+++ b/cli/src/utils/logWrapper.ts
@@ -72,7 +72,7 @@ const basicLog = {
   },
   publishing: () => logWrapper.await('Message publishing...'),
   published: () => logWrapper.success('Message published'),
-  enterToPublish: () => logWrapper.success('Connected, press Enter to publish, press Ctrl+C to exit'),
+  enterToPublish: () => logWrapper.success('Connected, input and press Enter to publish'),
   error: (err: Error) => logWrapper.fail(err.toString()),
   close: () => logWrapper.fail('Connection closed'),
   reconnecting: (retryTimes: number, maxReTryTimes: number) =>


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When users successfully establish a connection using the `mqttx conn` command, the program maintains the connection state (appearing to be "hanging"). Still, there is no prompt for users to exit. This causes users to need clarification about the program's behavior.

- Users are unclear that the expected behavior of the `mqttx conn` command is to maintain the connection
- Users don't know how to exit the connection state properly
- Lack of user guidance leads to poor operational experience

Please describe the current behavior and link to a relevant issue.

#### Issue Number

Example: #1810 

#### What is the new behavior?

```shell
❯ mqttx conn
✔ Connected
- Press Ctrl+C to disconnect and exit
```

Please describe the new behavior or provide screenshots.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
