### PR TITLE
feat(cli): line mode option support

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -149,6 +149,7 @@ export class Commander {
       .option('-d, --dup', 'mark as duplicate flag')
       .option('-s, --stdin', 'read the message body from stdin')
       .option('-M, --multiline', 'read lines from stdin as multiple messages')
+      .option('-lm, --line-mode', 'enter interactive mode to send messages line by line (equivalent to -s -M)', false)
       // properties options of MQTT 5.0
       .option('-pf, --payload-format-indicator', 'the payload format indicator of the publish message')
       .option('-e, --message-expiry-interval <NUMBER>', 'the lifetime of the publish message in seconds', parseNumber)

--- a/cli/src/lib/pub.ts
+++ b/cli/src/lib/pub.ts
@@ -221,6 +221,11 @@ const pub = (options: PublishOptions) => {
 
   checkTopicExists(options.topic, 'pub')
 
+  if (options.lineMode) {
+    options.multiline = true
+    options.stdin = true
+  }
+
   const connOpts = parseConnectOptions(options, 'pub')
 
   const pubOpts = parsePublishOptions(options)

--- a/cli/src/types/global.d.ts
+++ b/cli/src/types/global.d.ts
@@ -91,6 +91,7 @@ declare global {
     fileRead?: string
     stdin?: boolean
     multiline?: boolean
+    lineMode?: boolean
     // properties of MQTT 5.0
     payloadFormatIndicator?: boolean
     messageExpiryInterval?: number


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

To read messages from stdin line by line, users need to use two separate options: `-s` and `-M`. This combination is not intuitive and requires users to remember to use both options together.

Example of current usage:

```bash
mqttx pub -t "topic" -s -M
```

#### What is the new behavior?

Added a new convenient option `-lm, --line-mode` that combines the functionality of `-s` and `-M`. This makes the command more intuitive and easier to use.

New usage:

```bash
❯ mqttx pub -t test -lm
✔ Connected, input and press Enter to publish
- Press Ctrl+C to disconnect and exit
test
```

The old way (`-s -M`) still works for backward compatibility, but the new option provides a more straightforward approach.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Specific Instructions

1. The new `-lm` option is equivalent to using `-s -M` together
2. Existing code using `-s -M` will continue to work as before