### PR TITLE
style(desktop): improve select dropdown item style

### DIFF
--- a/src/assets/scss/element/element-reset.scss
+++ b/src/assets/scss/element/element-reset.scss
@@ -262,10 +262,16 @@
     border-top-color: var(--color-bg-messagebox);
   }
 }
+
+/* Select Dropdown Item */
 .el-select-dropdown__item.hover,
 .el-select-dropdown__item:hover {
   background: var(--color-bg-item);
 }
+.el-select-dropdown__item.selected {
+  font-weight: 500;
+}
+
 // Fix css style bug in open el-dialog
 .el-popup-parent--hidden {
   padding-right: 0px !important;

--- a/src/components/ConnectionSelect.vue
+++ b/src/components/ConnectionSelect.vue
@@ -1,9 +1,17 @@
 <template>
-  <el-select v-model="modelValue" class="connection-select" v-bind="$attrs" :style="{ width }">
+  <el-select
+    v-model="modelValue"
+    class="connection-select"
+    v-bind="$attrs"
+    :style="{ width }"
+    popper-class="connection-select__popper"
+  >
     <el-option v-for="conn in connections" :key="conn.id" :label="`${conn.name}@${conn.host}`" :value="conn.id">
-      <span style="float: left">{{ conn.name }}@{{ conn.host }}</span>
+      <span style="float: left"> {{ conn.name }}@{{ conn.host }} </span>
       <span style="float: right; color: #8492a6; font-size: 13px; margin-left: 24px">
-        {{ getConnectionStatus(conn.id) }}
+        <el-tag size="mini" :type="getConnectionStatus(conn.id) ? '' : 'info'">
+          {{ getConnectionStatus(conn.id) ? $t('connections.connected') : $t('connections.noConnection') }}
+        </el-tag>
       </span>
     </el-option>
   </el-select>
@@ -34,13 +42,11 @@ export default class ConnectionSelect extends Vue {
     this.$emit('change', newVal)
   }
 
-  private getConnectionStatus(connectionId: string) {
+  private getConnectionStatus(connectionId: string): boolean {
     if (this.activeConnection[connectionId]) {
       return this.activeConnection[connectionId].client.connected
-        ? this.$tc('connections.connected')
-        : this.$tc('connections.noConnection')
     }
-    return this.$tc('connections.noConnection')
+    return false
   }
 
   private async loadConnections() {

--- a/web/src/assets/scss/element/element-reset.scss
+++ b/web/src/assets/scss/element/element-reset.scss
@@ -245,10 +245,16 @@
     border-top-color: var(--color-bg-messagebox);
   }
 }
+
+/* Select Dropdown Item */
 .el-select-dropdown__item.hover,
 .el-select-dropdown__item:hover {
   background: var(--color-bg-item);
 }
+.el-select-dropdown__item.selected {
+  font-weight: 500;
+}
+
 // Fix css style bug in open el-dialog
 .el-popup-parent--hidden {
   padding-right: 0px !important;


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

**Blod font-weight** is too heavy

<img width="283" alt="image" src="https://github.com/user-attachments/assets/9cd1a82a-7811-40f9-ad28-0eb7509af3f6">

#### What is the new behavior?

<img width="290" alt="image" src="https://github.com/user-attachments/assets/011f78f1-41f8-468c-8636-d18850960ada">

<img width="448" alt="image" src="https://github.com/user-attachments/assets/f8354557-b6d9-4601-80aa-b7fe1c247fca">

Maked the font style softer.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
