### PR TITLE
feat(desktop): add connection select when left list hide

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -31,6 +31,7 @@
               </a>
             </el-tooltip>
             <el-tooltip
+              v-if="showConnectionList"
               :disabled="!showTitleTooltip"
               :effect="theme !== 'light' ? 'light' : 'dark'"
               :content="titleName"
@@ -41,6 +42,7 @@
                 {{ titleName }}
               </h2>
             </el-tooltip>
+            <ConnectionSelect v-else size="mini" width="180px" @change="handleConnectionSelect" />
             <a
               href="javascript:;"
               :class="['collapse-btn', showClientInfo ? 'top' : 'bottom']"
@@ -366,6 +368,7 @@ import { isLargeData } from '@/utils/data'
 import { serializeAvroToBuffer, deserializeBufferToAvro } from '@/utils/avro'
 import { globalEventBus } from '@/utils/globalEventBus'
 import SyncTopicTreeDialog from '@/widgets/SyncTopicTreeDialog.vue'
+import ConnectionSelect from '@/components/ConnectionSelect.vue'
 
 type CommandType =
   | 'searchContent'
@@ -401,6 +404,7 @@ interface TopModel {
     MsgTip,
     Copilot,
     SyncTopicTreeDialog,
+    ConnectionSelect,
   },
 })
 export default class ConnectionsDetail extends Vue {
@@ -2094,6 +2098,10 @@ export default class ConnectionsDetail extends Vue {
     this.toggleShowCopilot(false)
   }
 
+  private handleConnectionSelect(connectionId: string) {
+    this.$router.push({ path: `/recent_connections/${connectionId}` })
+  }
+
   private created() {
     this.getConnectionValue(this.curConnectionId)
     ipcRenderer.on('searchContent', () => {
@@ -2146,13 +2154,16 @@ export default class ConnectionsDetail extends Vue {
             color: var(--color-text-light);
           }
         }
+        .connection-select {
+          margin-right: 12px;
+        }
         .icon-show-connections,
         .icon-collapse {
           font-size: 20px;
         }
         a.show-connections-button {
           color: var(--color-text-title);
-          margin-right: 16px;
+          margin-right: 12px;
         }
         .icon-collapse {
           font-weight: bold;


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

<img width="482" alt="image" src="https://github.com/user-attachments/assets/42a52b9f-2d98-461c-8347-dd4c75aaaf6c">

This function requirement comes from the community. Users who are used to hiding the left list need to expand the connection list to switch to the current connection, which is inconvenient.

#### What is the new behavior?

<img width="635" alt="image" src="https://github.com/user-attachments/assets/39678e7f-8548-4930-8a3b-487c869a3b5b">

Support hidden in the left menu, you can quickly select the list in the connection list to view the corresponding relevant data

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
