### PR TITLE
chore(pkg): update node engine versiont to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "main": "background.js",
   "engines": {
-    "node": ">=16"
+    "node": "16"
   },
   "dependencies": {
     "appdata-path": "^1.0.0",


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

At present, the engine setting >= 16, but v18 cannot run, so we need to fix the node version to v16.

#### Issue Number

Example: #1833

#### What is the new behavior?

```bash
❯ yarn
yarn install v1.22.22
[1/6] 🔍  Validating package.json...
error MQTTX@1.11.1: The engine "node" is incompatible with this module. Expected version "16". Got "18.17.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
