### PR TITLE
feat(desktop): add electron-context-menu

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,7 @@
     "compare-versions": "^6.1.1",
     "crypto-js": "^4.2.0",
     "drizzle-orm": "^0.36.4",
+    "electron-context-menu": "^4.0.4",
     "electron-debug": "^4.1.0",
     "electron-store": "^10.0.0",
     "electron-updater": "^6.3.9",

--- a/apps/desktop/src/database/services/SettingsService.ts
+++ b/apps/desktop/src/database/services/SettingsService.ts
@@ -34,6 +34,11 @@ export default function useSettingsService() {
     watch(storeSettings, (newSettings) => {
       updateSettingsInDB(newSettings!)
     }, { deep: true })
+    watch(() => storeSettings.value?.currentLang, (lang) => {
+      if (lang) {
+        window.api.store.set('currentLang', lang)
+      }
+    }, { immediate: true })
     watchRegistered = true
   }
 

--- a/apps/desktop/src/main/config/contextMenu.ts
+++ b/apps/desktop/src/main/config/contextMenu.ts
@@ -1,0 +1,33 @@
+import type { Options } from 'electron-context-menu'
+import type { Lang } from 'mqttx'
+import Store from 'electron-store'
+import contextMenuLabels from './contextMenuLabels'
+
+// FIXME: https://github.com/sindresorhus/electron-store/issues/276
+const store = new Store() as any
+
+export function getContextMenuLabels(lang: Lang) {
+  const labels: Options['labels'] = {}
+  Object.keys(contextMenuLabels).forEach((key) => {
+    labels[key] = contextMenuLabels[key][lang]
+  })
+  return labels
+}
+
+export const contextMenuConfig: Options = {
+  showCopyImage: false,
+  labels: getContextMenuLabels('en'),
+  shouldShowMenu: (_event, parameters) => {
+    // @ts-expect-error To support i18n, we need to set labels dynamically
+    contextMenuConfig.labels = getContextMenuLabels(store.get('currentLang') || 'en')
+
+    // Doesn't show the menu if the link is the internal link
+    const { linkURL, pageURL } = parameters
+    const linkURLPrefix = linkURL?.split('#')[0]
+    const pageURLPrefix = pageURL?.split('#')[0]
+    if (linkURLPrefix === pageURLPrefix) {
+      return false
+    }
+    return true
+  },
+}

--- a/apps/desktop/src/main/config/contextMenuLabels.ts
+++ b/apps/desktop/src/main/config/contextMenuLabels.ts
@@ -1,0 +1,133 @@
+import type { Labels } from 'electron-context-menu'
+import type { Lang } from 'mqttx'
+
+const labels: Record<keyof Labels, Record<Lang, string>> = {
+  learnSpelling: {
+    zh: '学习拼写',
+    en: 'Learn Spelling',
+    ja: 'スペルを学ぶ',
+    tr: 'Yazımı Öğren',
+    hu: 'Szótagolás Tanulása',
+  },
+  lookUpSelection: {
+    zh: '查找 “{selection}”',
+    en: 'Look Up “{selection}”',
+    ja: '“{selection}”を検索',
+    tr: '“{selection}”\'ı Ara',
+    hu: 'Keresés “{selection}”',
+  },
+  searchWithGoogle: {
+    zh: '使用谷歌搜索',
+    en: 'Search with Google',
+    ja: 'Googleで検索',
+    tr: 'Google ile Ara',
+    hu: 'Keresés Google-lel',
+  },
+  cut: {
+    zh: '剪切',
+    en: 'Cut',
+    ja: '切り取り',
+    tr: 'Kes',
+    hu: 'Kivágás',
+  },
+  copy: {
+    zh: '复制',
+    en: 'Copy',
+    ja: 'コピー',
+    tr: 'Kopyala',
+    hu: 'Másolás',
+  },
+  paste: {
+    zh: '粘贴',
+    en: 'Paste',
+    ja: '貼り付け',
+    tr: 'Yapıştır',
+    hu: 'Beillesztés',
+  },
+  selectAll: {
+    zh: '全选',
+    en: 'Select All',
+    ja: 'すべて選択',
+    tr: 'Hepsini Seç',
+    hu: 'Összes Kijelölése',
+  },
+  saveImage: {
+    zh: '保存图片',
+    en: 'Save Image',
+    ja: '画像を保存',
+    tr: 'Resmi Kaydet',
+    hu: 'Kép Mentése',
+  },
+  saveImageAs: {
+    zh: '另存图片...',
+    en: 'Save Image As…',
+    ja: '画像を名前を付けて保存',
+    tr: 'Resmi Farklı Kaydet…',
+    hu: 'Kép Mentése Másként…',
+  },
+  saveVideo: {
+    zh: '保存视频',
+    en: 'Save Video',
+    ja: 'ビデオを保存',
+    tr: 'Videoyu Kaydet',
+    hu: 'Videó Mentése',
+  },
+  saveVideoAs: {
+    zh: '另存视频...',
+    en: 'Save Video As…',
+    ja: 'ビデオを名前を付けて保存',
+    tr: 'Videoyu Farklı Kaydet…',
+    hu: 'Videó Mentése Másként…',
+  },
+  copyLink: {
+    zh: '复制链接',
+    en: 'Copy Link',
+    ja: 'リンクをコピー',
+    tr: 'Bağlantıyı Kopyala',
+    hu: 'Hivatkozás Másolása',
+  },
+  saveLinkAs: {
+    zh: '另存链接...',
+    en: 'Save Link As…',
+    ja: 'リンクを名前を付けて保存',
+    tr: 'Bağlantıyı Farklı Kaydet…',
+    hu: 'Hivatkozás Mentése Másként…',
+  },
+  copyImage: {
+    zh: '复制图片',
+    en: 'Copy Image',
+    ja: '画像をコピー',
+    tr: 'Resmi Kopyala',
+    hu: 'Kép Másolása',
+  },
+  copyImageAddress: {
+    zh: '复制图片地址',
+    en: 'Copy Image Address',
+    ja: '画像のアドレスをコピー',
+    tr: 'Resim Adresini Kopyala',
+    hu: 'Kép Címének Másolása',
+  },
+  copyVideoAddress: {
+    zh: '复制视频地址',
+    en: 'Copy Video Address',
+    ja: 'ビデオのアドレスをコピー',
+    tr: 'Video Adresini Kopyala',
+    hu: 'Videó Címének Másolása',
+  },
+  inspect: {
+    zh: '检查元素',
+    en: 'Inspect Element',
+    ja: '要素を検証',
+    tr: 'Elemanı İncele',
+    hu: 'Elem Ellenőrzése',
+  },
+  services: {
+    zh: '服务',
+    en: 'Services',
+    ja: 'サービス',
+    tr: 'Hizmetler',
+    hu: 'Szolgáltatások',
+  },
+}
+
+export default labels

--- a/apps/desktop/src/main/config/index.ts
+++ b/apps/desktop/src/main/config/index.ts
@@ -1,0 +1,1 @@
+export * from './contextMenu'

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { electronApp, is, optimizer } from '@electron-toolkit/utils'
 import { eq } from 'drizzle-orm'
 import { app, BrowserWindow, ipcMain, shell } from 'electron'
+import contextMenu from 'electron-context-menu'
 import debug from 'electron-debug'
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import icon from '../../resources/icon.png?asset'
@@ -11,6 +12,20 @@ import { useInstallCLI } from './installCLI'
 import { useAppUpdater } from './update'
 
 debug()
+
+contextMenu({
+  showCopyImage: false,
+  shouldShowMenu: (_event, parameters) => {
+    // Doesn't show the menu if the link is the internal link
+    const { linkURL, pageURL } = parameters
+    const linkURLPrefix = linkURL?.split('#')[0]
+    const pageURLPrefix = pageURL?.split('#')[0]
+    if (linkURLPrefix === pageURLPrefix) {
+      return false
+    }
+    return true
+  },
+})
 
 // const IsMacOS = process.platform === 'darwin'
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -8,24 +8,14 @@ import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer'
 import icon from '../../resources/icon.png?asset'
 import { db, execute, runMigrate } from '../database/db.main'
 import { type SelectSettings, settings } from '../database/schemas/settings'
+import { contextMenuConfig } from './config'
 import { useInstallCLI } from './installCLI'
+import { useStore } from './store'
 import { useAppUpdater } from './update'
 
 debug()
 
-contextMenu({
-  showCopyImage: false,
-  shouldShowMenu: (_event, parameters) => {
-    // Doesn't show the menu if the link is the internal link
-    const { linkURL, pageURL } = parameters
-    const linkURLPrefix = linkURL?.split('#')[0]
-    const pageURLPrefix = pageURL?.split('#')[0]
-    if (linkURLPrefix === pageURLPrefix) {
-      return false
-    }
-    return true
-  },
-})
+contextMenu(contextMenuConfig)
 
 // const IsMacOS = process.platform === 'darwin'
 
@@ -116,6 +106,8 @@ app.whenReady().then(async () => {
   await runMigrate()
 
   await createWindow()
+
+  useStore()
 
   useAppUpdater(existingSettings!)
 

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -1,0 +1,21 @@
+import { ipcMain } from 'electron'
+import Store from 'electron-store'
+
+// FIXME: https://github.com/sindresorhus/electron-store/issues/276
+const store = new Store() as any
+
+function useStore() {
+  ipcMain.handle('store-send', (_event, params) => {
+    const { action, key, value } = params
+
+    switch (action) {
+      case 'get':
+        return store.get(key)
+
+      case 'set':
+        return store.set(key, value)
+    }
+  })
+}
+
+export { useStore }

--- a/apps/desktop/src/preload/index.d.ts
+++ b/apps/desktop/src/preload/index.d.ts
@@ -14,6 +14,10 @@ declare global {
       installUpdate: () => Promise<void>
       installCLI: () => Promise<void>
       onInstallCLIStatus: (callback: (event: Electron.IpcRendererEvent, installCLIEvent: InstallCLIEvent) => void) => void
+      store: {
+        get: <T = any>(key: string) => Promise<T>
+        set: (key: string, value: any) => Promise<void>
+      }
     }
   }
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -15,6 +15,10 @@ const api: Window['api'] = {
   onInstallCLIStatus: callback => ipcRenderer.on('install-cli-status', (event, status, data) => {
     callback(event, { status, data })
   }),
+  store: {
+    get: key => ipcRenderer.invoke('store-send', { action: 'get', key }),
+    set: (key, value) => ipcRenderer.invoke('store-send', { action: 'set', key, value }),
+  },
 }
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       drizzle-orm:
         specifier: ^0.36.4
         version: 0.36.4(@types/better-sqlite3@7.6.12)(better-sqlite3@11.6.0)
+      electron-context-menu:
+        specifier: ^4.0.4
+        version: 4.0.4
       electron-debug:
         specifier: ^4.1.0
         version: 4.1.0
@@ -4102,7 +4105,6 @@ packages:
   /ansi-regex@6.1.0:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
-    dev: true
 
   /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
@@ -4120,7 +4122,6 @@ packages:
   /ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
-    dev: true
 
   /any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -4890,7 +4891,6 @@ packages:
     dependencies:
       slice-ansi: 5.0.0
       string-width: 7.2.0
-    dev: true
 
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -5749,6 +5749,15 @@ packages:
       - supports-color
     dev: true
 
+  /electron-context-menu@4.0.4:
+    resolution: {integrity: sha512-XPGj35npL8+MG9Lx5ukmK/h8KLmjYJ3e1GvwWKrNZvf2ocv746WXIyltoV1yWtkEPT7g2kQ8hFmu0ZupK5KieA==}
+    engines: {node: '>=18'}
+    dependencies:
+      cli-truncate: 4.0.0
+      electron-dl: 4.0.0
+      electron-is-dev: 3.0.1
+    dev: false
+
   /electron-debug@4.1.0:
     resolution: {integrity: sha512-rdbvmotqbaNcSuinPe1tzB5zK+JKal+4LSDbguBcqTLARNqWrGoRS/TkR1gGH4+63boYH3HUaf9r9ECAxgIe9g==}
     engines: {node: '>=18'}
@@ -5767,6 +5776,15 @@ packages:
       tslib: 2.8.1
       unzip-crx-3: 0.2.0
     dev: true
+
+  /electron-dl@4.0.0:
+    resolution: {integrity: sha512-USiB9816d2JzKv0LiSbreRfTg5lDk3lWh0vlx/gugCO92ZIJkHVH0UM18EHvKeadErP6Xn4yiTphWzYfbA2Ong==}
+    engines: {node: '>=18'}
+    dependencies:
+      ext-name: 5.0.0
+      pupa: 3.1.0
+      unused-filename: 4.0.1
+    dev: false
 
   /electron-is-accelerator@0.1.2:
     resolution: {integrity: sha512-fLGSAjXZtdn1sbtZxx52+krefmtNuVwnJCV2gNiVt735/ARUboMl8jnNC9fZEqQdlAv2ZrETfmBUsoQci5evJA==}
@@ -5903,7 +5921,6 @@ packages:
 
   /emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
-    dev: true
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -6103,6 +6120,11 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  /escape-goat@4.0.0:
+    resolution: {integrity: sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==}
+    engines: {node: '>=12'}
+    dev: false
+
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
     dev: false
@@ -6119,7 +6141,6 @@ packages:
   /escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-    dev: true
 
   /eslint-compat-utils@0.5.1(eslint@9.14.0):
     resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
@@ -6681,6 +6702,21 @@ packages:
     resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
     dev: true
 
+  /ext-list@2.2.2:
+    resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
+  /ext-name@5.0.0:
+    resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
+    engines: {node: '>=4'}
+    dependencies:
+      ext-list: 2.2.2
+      sort-keys-length: 1.0.1
+    dev: false
+
   /extract-zip@2.0.1:
     resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
     engines: {node: '>= 10.17.0'}
@@ -6993,7 +7029,6 @@ packages:
   /get-east-asian-width@1.3.0:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
-    dev: true
 
   /get-graphql-from-jsonschema@8.1.0:
     resolution: {integrity: sha512-MhvxGPBjJm1ls6XmvcmgJG7ApqxkFEs5T8uDzytlpbMBBwMMnoF/rMUWzPxM6YvejyLhCB3axD4Dwci3G5F4UA==}
@@ -7516,7 +7551,6 @@ packages:
   /is-fullwidth-code-point@4.0.0:
     resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
     engines: {node: '>=12'}
-    dev: true
 
   /is-fullwidth-code-point@5.0.0:
     resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
@@ -7571,6 +7605,11 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  /is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -9445,6 +9484,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -10077,6 +10121,13 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  /pupa@3.1.0:
+    resolution: {integrity: sha512-FLpr4flz5xZTSJxSeaheeMKN/EDzMdK7b8PTOC6a5PYFKTucWbdqjgqaEyH0shFiSJrVB1+Qqi4Tk19ccU6Aug==}
+    engines: {node: '>=12.20'}
+    dependencies:
+      escape-goat: 4.0.0
+    dev: false
+
   /qs@6.13.1:
     resolution: {integrity: sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==}
     engines: {node: '>=0.6'}
@@ -10688,7 +10739,6 @@ packages:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
-    dev: true
 
   /slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
@@ -10722,6 +10772,20 @@ packages:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
     dev: true
+
+  /sort-keys-length@1.0.1:
+    resolution: {integrity: sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      sort-keys: 1.1.2
+    dev: false
+
+  /sort-keys@1.1.2:
+    resolution: {integrity: sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      is-plain-obj: 1.1.0
+    dev: false
 
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -10865,7 +10929,6 @@ packages:
       emoji-regex: 10.4.0
       get-east-asian-width: 1.3.0
       strip-ansi: 7.1.0
-    dev: true
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -10889,7 +10952,6 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.1.0
-    dev: true
 
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -11574,6 +11636,14 @@ packages:
       acorn: 8.14.0
       webpack-virtual-modules: 0.6.2
     dev: true
+
+  /unused-filename@4.0.1:
+    resolution: {integrity: sha512-ZX6U1J04K1FoSUeoX1OicAhw4d0aro2qo+L8RhJkiGTNtBNkd/Fi1Wxoc9HzcVu6HfOzm0si/N15JjxFmD1z6A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      escape-string-regexp: 5.0.0
+      path-exists: 5.0.0
+    dev: false
 
   /unzip-crx-3@0.2.0:
     resolution: {integrity: sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==}


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

There is no built-in context menu in Electron.

#### What is the new behavior?

- Supports common context menu features, such as spell check, text options like Cut / Copy / Paste, and link options like Copy Link. Additionally, in development mode, an Inspect Element menu item is added for quickly viewing items in the inspector, similar to Chrome.
- Supports i18n for the context menu.
- Added store communication events to facilitate sharing simple data between the main process and renderer process.

<img width="311" alt="image" src="https://github.com/user-attachments/assets/d455a865-452e-4cc2-8df5-27cf879263e6" />


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
