### PR TITLE
feat(desktop): add native theme support and integrate with settings

### DIFF
--- a/apps/desktop/src/database/services/SettingsService.ts
+++ b/apps/desktop/src/database/services/SettingsService.ts
@@ -32,13 +32,9 @@ export default function useSettingsService() {
     const data = await getSettingsInDB()
     updateSettings(data)
     watch(storeSettings, (newSettings) => {
+      window.api.store.set('settings', { ...newSettings })
       updateSettingsInDB(newSettings!)
-    }, { deep: true })
-    watch(() => storeSettings.value?.currentLang, (lang) => {
-      if (lang) {
-        window.api.store.set('currentLang', lang)
-      }
-    }, { immediate: true })
+    }, { immediate: true, deep: true })
     watchRegistered = true
   }
 

--- a/apps/desktop/src/main/config/contextMenu.ts
+++ b/apps/desktop/src/main/config/contextMenu.ts
@@ -1,5 +1,5 @@
 import type { Options } from 'electron-context-menu'
-import type { Lang } from 'mqttx'
+import type { Lang, Settings } from 'mqttx'
 import Store from 'electron-store'
 import contextMenuLabels from './contextMenuLabels'
 
@@ -18,8 +18,9 @@ export const contextMenuConfig: Options = {
   showCopyImage: false,
   labels: getContextMenuLabels('en'),
   shouldShowMenu: (_event, parameters) => {
+    const settings = store.get('settings') as Settings | undefined
     // @ts-expect-error To support i18n, we need to set labels dynamically
-    contextMenuConfig.labels = getContextMenuLabels(store.get('currentLang') || 'en')
+    contextMenuConfig.labels = getContextMenuLabels(settings?.currentLang || 'en')
 
     // Doesn't show the menu if the link is the internal link
     const { linkURL, pageURL } = parameters

--- a/apps/desktop/src/main/config/index.ts
+++ b/apps/desktop/src/main/config/index.ts
@@ -1,3 +1,4 @@
 export * from './contextMenu'
 export * from './menu'
+export * from './nativeTheme'
 export * from './windowState'

--- a/apps/desktop/src/main/config/menu.ts
+++ b/apps/desktop/src/main/config/menu.ts
@@ -1,5 +1,5 @@
 import type { MenuItem, MenuItemConstructorOptions } from 'electron'
-import type { Lang } from 'mqttx'
+import type { Lang, Settings } from 'mqttx'
 import { app, BrowserWindow, Menu, shell } from 'electron'
 import Store from 'electron-store'
 import menuLabels from './menuLabels'
@@ -209,7 +209,8 @@ function getMenuTemplate(win: BrowserWindow, lang?: Lang) {
 
 export function setMenu() {
   const win = BrowserWindow.getFocusedWindow()!
-  const menuTemplate = getMenuTemplate(win, store.get('currentLang') || 'en')
+  const settings = store.get('settings') as Settings | undefined
+  const menuTemplate = getMenuTemplate(win, settings?.currentLang || 'en')
   const menu = Menu.buildFromTemplate(menuTemplate)
   Menu.setApplicationMenu(menu)
 }

--- a/apps/desktop/src/main/config/nativeTheme.ts
+++ b/apps/desktop/src/main/config/nativeTheme.ts
@@ -1,0 +1,27 @@
+import type { Settings } from 'mqttx'
+import { BrowserWindow, nativeTheme } from 'electron'
+import Store from 'electron-store'
+
+// FIXME: https://github.com/sindresorhus/electron-store/issues/276
+const store = new Store() as any
+
+export const bgColor = {
+  dark: '#232323',
+  night: '#212328',
+  light: '#ffffff',
+}
+
+export function setNativeTheme() {
+  const settings = store.get('settings') as Settings | undefined
+  const { syncOsTheme = false, currentTheme = 'light' } = settings || {}
+  if (syncOsTheme) {
+    nativeTheme.themeSource = 'system'
+  } else {
+    const nativeThemeMode = currentTheme === 'light' ? 'light' : 'dark'
+    nativeTheme.themeSource = nativeThemeMode
+  }
+  const color = bgColor[currentTheme]
+  BrowserWindow.getAllWindows().forEach((window) => {
+    window.setBackgroundColor(color)
+  })
+}

--- a/apps/desktop/src/main/store.ts
+++ b/apps/desktop/src/main/store.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import Store from 'electron-store'
-import { setMenu } from './config/menu'
+import { setMenu, setNativeTheme } from './config'
 
 // FIXME: https://github.com/sindresorhus/electron-store/issues/276
 const store = new Store() as any
@@ -15,8 +15,9 @@ function useStore() {
 
       case 'set': {
         const result = store.set(key, value)
-        if (key === 'currentLang') {
+        if (key === 'settings') {
           setMenu()
+          setNativeTheme()
         }
         return result
       }

--- a/apps/desktop/src/main/update.ts
+++ b/apps/desktop/src/main/update.ts
@@ -95,9 +95,10 @@ function sendUpdateStatus(updateEvent: UpdateEvent) {
 
 let downloadCancelToken: CancellationToken | null = null
 
-function useAppUpdater(settings: SelectSettings) {
+function useAppUpdater() {
   const version = app.getVersion()
   if (store.get('version') !== version) {
+    const settings = store.get('settings') as SelectSettings
     showReleaseNotesWindow(settings.currentLang)
     store.set('version', version)
   }

--- a/packages/ui/src/components/SettingsView.vue
+++ b/packages/ui/src/components/SettingsView.vue
@@ -19,11 +19,11 @@ const langOptions = [
   { label: 'Türkçe', value: 'tr' },
   { label: 'Magyar', value: 'hu' },
 ]
-const themeOptions = [
+const themeOptions = computed(() => [
   { label: t('settings.light'), value: 'light' },
   { label: t('settings.dark'), value: 'dark' },
   { label: t('settings.night'), value: 'night' },
-]
+])
 const logLevelOptions = [
   { label: 'DEBUG', value: 'debug' },
   { label: 'INFO', value: 'info' },

--- a/packages/ui/src/stores/useSettingsStore.ts
+++ b/packages/ui/src/stores/useSettingsStore.ts
@@ -2,6 +2,8 @@ import type { Settings } from 'mqttx'
 import { usePreferredDark } from '@vueuse/core'
 import { i18n } from '../i18n'
 
+const isDark = usePreferredDark()
+
 export const useSettingsStore = defineStore('settings', () => {
   const settings = ref<Settings | null>(null)
 
@@ -15,15 +17,18 @@ export const useSettingsStore = defineStore('settings', () => {
     i18n.global.locale = newLang
   })
 
-  watch([() => settings.value?.syncOsTheme, () => settings.value?.currentTheme], ([syncOsTheme, currentTheme]) => {
-    if (typeof document === 'undefined') return
-    if (syncOsTheme) {
-      const isDark = usePreferredDark()
-      settings.value!.currentTheme = isDark.value ? 'dark' : 'light'
-      document.documentElement.className = isDark.value ? 'dark' : 'light'
-    } else {
-      document.documentElement.className = currentTheme || 'light'
-    }
+  watch(isDark, (value) => {
+    if (!settings.value?.syncOsTheme) return
+    settings.value!.currentTheme = value ? 'dark' : 'light'
+  })
+
+  watch(() => settings.value?.syncOsTheme, (value) => {
+    if (!value) return
+    settings.value!.currentTheme = isDark.value ? 'dark' : 'light'
+  })
+
+  watch(() => settings.value?.currentTheme, (value) => {
+    document.documentElement.className = value || 'light'
   })
 
   return { settings, updateSettings }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

- Theme changes are only applied at the rendering layer, and there is no theme setting for Chromium, causing the window color not to change with the theme.
- The window background color is set only on startup and does not change with the theme.

#### Issue Number

\#1544

#### What is the new behavior?

- The Chromium theme correctly follows the theme settings of the configuration page.
- The window background color can change with the theme.

<img width="2374" alt="image" src="https://github.com/user-attachments/assets/dda528a6-e1b5-4e20-bbba-ae5be0cf27c3" />


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
