### PR TITLE
feat(copilot): improve preset prompt display behavior on input focus

### DIFF
--- a/src/components/ai/CopilotInput.vue
+++ b/src/components/ai/CopilotInput.vue
@@ -12,7 +12,7 @@
       v-model="message"
       :placeholder="$t('copilot.copiltePubMsgPlacehoder')"
       @keydown.native.enter="handleEnterKey"
-      @focus="showPresetPrompt = true"
+      @focus="handleFocus"
       @input="handleInput"
     ></el-input>
     <el-button
@@ -47,6 +47,7 @@ export default class CopilotInput extends Vue {
 
   private showPresetPrompt = false
   private message = ''
+  private shouldShowPresetOnFocus = true
 
   created() {
     this.message = this.value
@@ -73,6 +74,7 @@ export default class CopilotInput extends Vue {
   @Emit('preset-change')
   handlePresetsChange(prompt: string, promptMap: CopilotPresetPrompt['promptMap']) {
     this.showPresetPrompt = false
+    this.shouldShowPresetOnFocus = false
     return { prompt, promptMap }
   }
 
@@ -91,6 +93,14 @@ export default class CopilotInput extends Vue {
     }
   }
 
+  handleFocus() {
+    if (this.shouldShowPresetOnFocus) {
+      this.showPresetPrompt = true
+    } else {
+      this.shouldShowPresetOnFocus = true
+    }
+  }
+
   focus() {
     const inputEl = this.$refs.publishMsgInput as Vue
     if (inputEl && inputEl.$el) {
@@ -98,7 +108,6 @@ export default class CopilotInput extends Vue {
       if (textarea) {
         this.$nextTick(() => {
           textarea.focus()
-          // Position cursor at the end of text
           textarea.selectionStart = textarea.selectionEnd = textarea.value.length
         })
       }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The dropdown menu reopens automatically after selecting custom generation options for the copilot feature. This creates a disruptive user experience as users must repeatedly dismiss the dropdown.

#### Issue Number

<!-- Please add related issue number if available -->

#### What is the new behavior?

Fixed the dropdown behavior to stay closed after selecting a custom generation option. The dropdown will now only open when explicitly triggered by the user, creating a smoother interaction flow.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Testing should focus on verifying that the dropdown menu behaves correctly in all scenarios - it should open when clicked, but not reopen automatically after a selection is made.

#### Other information

This fix improves the overall UX of the preset prompt feature by making the input focus behavior more predictable and reducing unnecessary UI interactions.