### PR TITLE
feat(copilot): support separate Protobuf and Avro schema generation prompts

### DIFF
--- a/src/utils/ai/copilot.ts
+++ b/src/utils/ai/copilot.ts
@@ -9,7 +9,8 @@ import payloadGen from './prompts/payloadGen.txt'
 import emqxGuide from './prompts/emqxGuide.txt'
 import mqttFaq from './prompts/mqttFaq.txt'
 import funcGen from './prompts/funcGen.txt'
-import schemaGen from './prompts/schemaGen.txt'
+import protobufSchemaGen from './prompts/protobufSchemaGen.txt'
+import avroSchemaGen from './prompts/avroSchemaGen.txt'
 import {
   ALL_CODE_GENERATION_COMMAND_VALUES,
   PAYLOAD_GENERATION_COMMAND_VALUES,
@@ -17,6 +18,8 @@ import {
   MQTT_FAQ_COMMAND_VALUES,
   CUSTOM_FUNCTION_COMMAND_VALUES,
   ALL_SCHEMA_COMMAND_VALUES,
+  PROTOBUF_SCHEMA_COMMAND_VALUES,
+  AVRO_SCHEMA_COMMAND_VALUES,
 } from './preset'
 
 const LANGUAGE_MAP = {
@@ -57,7 +60,12 @@ export const loadSystemPrompt = (lang: Language, command?: string) => {
 
   // Check if the command is related to schema generation
   if (command && ALL_SCHEMA_COMMAND_VALUES.includes(command)) {
-    _basePrompt = `${_basePrompt}\n\n${schemaGen}`
+    // Use the specific schema prompt based on the command (Protobuf or Avro)
+    if (command && PROTOBUF_SCHEMA_COMMAND_VALUES.includes(command)) {
+      _basePrompt = `${_basePrompt}\n\n${protobufSchemaGen}`
+    } else if (command && AVRO_SCHEMA_COMMAND_VALUES.includes(command)) {
+      _basePrompt = `${_basePrompt}\n\n${avroSchemaGen}`
+    }
   }
 
   return `${_basePrompt}\n\n${LANGUAGE_MAP[lang]}`

--- a/src/utils/ai/prompts/avroSchemaGen.txt
+++ b/src/utils/ai/prompts/avroSchemaGen.txt
@@ -1,0 +1,57 @@
+Now, you are a specialized Schema generation expert for IoT and MQTT messaging systems. Your task is to create precise, efficient, and standards-compliant data schemas that optimize message transmission while maintaining data integrity.
+
+Please generate Avro Schema and corresponding sample data based on your selection:
+[Generation Mode]
+- Generation Mode Options:
+  ├─ Custom Requirements (please fill in description below)
+  └─ Preset Scenarios for Quick Generation:
+     │ Smart Home Device Status Report
+     │ Industrial Equipment Alarm Message
+     │ Connected Vehicle Telemetry Data
+     │ Smart Meter Real-time Readings
+
+==== Custom Mode ====
+Please provide detailed data structure requirements (e.g., "include sensor data with status, require millisecond timestamp precision"), you can provide sample field data to better understand your needs
+
+==== Preset Scenario Features ====
+▶ Smart Home Device Status Report
+  - Required fields: device_id (string), status (enum), temperature (with fluctuation range)
+  - Optional extensions: online status, firmware version, signal strength
+▶ Industrial Equipment Alarm Message
+  - Required fields: alarm_code (integer), severity (enum), timestamp (timestamp)
+  - Optional extensions: device coordinates, related work order number, recovery suggestions
+▶ Connected Vehicle Telemetry Data
+  - Required fields: vin (string), gps (coordinate object), speed (fluctuating value)
+  - Optional extensions: remaining battery, tire pressure array, driving mode
+▶ Smart Meter Real-time Readings
+  - Required fields: meter_id (fixed-length string), voltage (value with precision), timestamp (ISO8601)
+  - Optional extensions: phase imbalance, anomaly event flags
+
+==== Generation Rules ====
+Avro Output Order:
+▼ Complete .avsc file
+▼ Sample input data
+
+// Example structure
+## Schema
+Description of the current Schema, explaining the purpose of important fields (use markdown plain paragraph)
+{
+  "type": "record",
+  "name": "Person",
+  "fields": [
+    {"name": "id", "type": "int"},
+    {"name": "name", "type": "string"}
+  ]
+}
+
+## Sample data
+{
+  "id": 123,
+  "name": "John Doe"
+}
+
+==== Notes ====
+1. Provide sample data in JSON format, ensuring all fields defined in the Schema are included, field names match exactly, with no omissions
+2. All code and data must be output in markdown code block format for easy copying and viewing
+
+Selected encoding format: Avro 

--- a/src/utils/ai/prompts/base.txt
+++ b/src/utils/ai/prompts/base.txt
@@ -30,4 +30,6 @@ When generating code and documentation:
 - Include essential error handling for common failure scenarios
 - Use idiomatic patterns for the target programming language
 - Ensure the generated code is immediately usable with minimal modification
+- Format all responses using proper Markdown syntax for optimal readability, with appropriate use of headings, code blocks, paragraphs, lists, tables, and other formatting elements
+
 For questions requiring deeper technical information than what you provide, suggest relevant MQTT or EMQX documentation and resources when appropriate.

--- a/src/utils/ai/prompts/protobufSchemaGen.txt
+++ b/src/utils/ai/prompts/protobufSchemaGen.txt
@@ -1,8 +1,7 @@
 Now, you are a specialized Schema generation expert for IoT and MQTT messaging systems. Your task is to create precise, efficient, and standards-compliant data schemas that optimize message transmission while maintaining data integrity.
 
-Please generate data Schema and corresponding sample data based on your selection:
-[Encoding Format] => [Generation Mode]
-- Encoding Format Options: Protobuf | Avro
+Please generate Protobuf Schema and corresponding sample data based on your selection:
+[Generation Mode]
 - Generation Mode Options:
   ├─ Custom Requirements (please fill in description below)
   └─ Preset Scenarios for Quick Generation:
@@ -10,8 +9,10 @@ Please generate data Schema and corresponding sample data based on your selectio
      │ Industrial Equipment Alarm Message
      │ Connected Vehicle Telemetry Data
      │ Smart Meter Real-time Readings
+
 ==== Custom Mode ====
 Please provide detailed data structure requirements (e.g., "include sensor data with status, require millisecond timestamp precision"), you can provide sample field data to better understand your needs
+
 ==== Preset Scenario Features ====
 ▶ Smart Home Device Status Report
   - Required fields: device_id (string), status (enum), temperature (with fluctuation range)
@@ -25,50 +26,37 @@ Please provide detailed data structure requirements (e.g., "include sensor data 
 ▶ Smart Meter Real-time Readings
   - Required fields: meter_id (fixed-length string), voltage (value with precision), timestamp (ISO8601)
   - Optional extensions: phase imbalance, anomaly event flags
+
 ==== Generation Rules ====
-1. Protobuf Output Order:
-   ▼ Complete .proto file, including syntax declaration like syntax = "proto3";
-   ▼ Data type name (e.g., Type name: DeviceStatusReport)
-   ▼ Sample input data
-   
-   // Example structure
-   ## Schema
-   Description of the current Schema, explaining the purpose of important fields (use markdown plain paragraph)
-   syntax = "proto3";
-   message DeviceReport {
-     string device_id = 1;
-     int32 value = 2;
-     string firmware = 3;
-   }
-   
-   ## Type name (use markdown code block format)
-   DeviceReport
-   
-   ## Sample data
-   {
-     "device_id": "dev12345",
-     "value": 100,
-     "firmware": "1.0.0"
-   }
-   
-2. Avro Output Order:
-   ▼ Complete .avsc file
-   ▼ Sample input data
-   
-   // Example structure
-   ## Schema
-   Description of the current Schema, explaining the purpose of important fields (use markdown plain paragraph)
-   {
-     "type": "record",
-     "name": "Person",
-     "fields": [
-       {"name": "id", "type": "int"},
-       {"name": "name", "type": "string"}
-     ]
-   }
+Protobuf Output Order:
+▼ Complete .proto file, including syntax declaration like syntax = "proto3";
+▼ Data type name (e.g., Type name: DeviceStatusReport)
+▼ Sample input data
+
+// Example structure
+## Schema
+Description of the current Schema, explaining the purpose of important fields (use markdown plain paragraph)
+syntax = "proto3";
+message DeviceReport {
+  string device_id = 1;
+  int32 value = 2;
+  string firmware = 3;
+}
+
+## Type name (use markdown code block format)
+DeviceReport
+
+## Sample data
+{
+  "device_id": "dev12345",
+  "value": 100,
+  "firmware": "1.0.0"
+}
+
 ==== Notes ====
 1. Protobuf Special Requirements:
    - Enum values must use integer values, sample data must use the corresponding integer value for enums (e.g., status: 2)
 2. Provide sample data in JSON format, ensuring all fields defined in the Schema are included, field names match exactly, with no omissions
 3. All code and data must be output in markdown code block format for easy copying and viewing
-Selected encoding format: {0}
+
+Selected encoding format: Protobuf 


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When requesting encoding/decoding help for message formats like Protobuf and Avro, the system sometimes returns both formats together inconsistently. The output formatting is also inconsistent across different AI models, with some responses lacking proper Markdown code blocks and structure.

#### Issue Number

<!-- Please add related issue number if available -->

#### What is the new behavior?

- Separated Protobuf and Avro encoding/decoding into distinct system prompts
- Improved prompt instructions to enforce consistent Markdown formatting with proper code blocks
- Added constraints to ensure AI responses maintain consistent structure and format
- Optimized custom function return formats with explicit instructions for code block usage

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Please test with various encoding/decoding scenarios to ensure the AI properly separates Protobuf and Avro responses and consistently uses proper Markdown formatting with code blocks.

#### Other information