### PR TITLE
feat(copilot): support chat loop for mcp call result

### DIFF
--- a/src/components/ai/MessageRender.vue
+++ b/src/components/ai/MessageRender.vue
@@ -139,7 +139,7 @@ mcp-result {
   padding: 16px;
   margin: 12px 0;
   border: 1px solid var(--color-border-default);
-  max-height: 480px;
+  max-height: 320px;
   overflow: scroll;
 }
 

--- a/src/database/services/CopilotService.ts
+++ b/src/database/services/CopilotService.ts
@@ -3,6 +3,9 @@ import { InjectRepository } from 'typeorm-typedi-extensions'
 import CopilotEntity from '../models/CopilotEntity'
 import { Repository } from 'typeorm'
 
+/**
+ * Service for managing Copilot conversations in the database
+ */
 @Service()
 export default class CopilotService {
   constructor(
@@ -11,11 +14,21 @@ export default class CopilotService {
     private conversationRepository: Repository<CopilotEntity>,
   ) {}
 
+  /**
+   * Creates a new Copilot message in the database
+   * @param copilotMessage The message to create
+   * @returns The saved message entity
+   */
   public async create(copilotMessage: CopilotMessage) {
     const newConversation = this.conversationRepository.create(copilotMessage)
     return await this.conversationRepository.save(newConversation)
   }
 
+  /**
+   * Retrieves paginated Copilot messages
+   * @param page The page number to retrieve (default: 1)
+   * @returns Object containing messages and hasMore flag
+   */
   public async get(page: number = 1) {
     const count = 20
     const messages = await this.conversationRepository.find({
@@ -30,7 +43,20 @@ export default class CopilotService {
     return { messages: messages.reverse(), hasMore }
   }
 
+  /**
+   * Deletes all Copilot messages from the database
+   * @returns The result of the clear operation
+   */
   public async deleteAll() {
     return await this.conversationRepository.clear()
+  }
+
+  /**
+   * Updates an existing Copilot message
+   * @param message The message to update
+   * @returns The result of the update operation
+   */
+  public async update(message: CopilotMessage) {
+    return await this.conversationRepository.update({ id: message.id }, message)
   }
 }

--- a/src/lang/copilot.ts
+++ b/src/lang/copilot.ts
@@ -609,4 +609,11 @@ export default {
     ja: 'MCP呼び出し',
     hu: 'MCP hívás',
   },
+  mcpResultAnalysisPrompts: {
+    zh: '请继续分析结果，并以简洁清晰的方式呈现数据。完成后请说明"[DONE]"',
+    en: 'Please continue to analyze the result and present the data in a concise and clear manner. End with "[DONE]"',
+    tr: 'Lütfen sonucu analiz etmeye devam edin ve verileri özlü ve net bir şekilde sunun. "[DONE]" ile bitirin',
+    ja: '結果の分析を続け、データを簡潔かつ明確な方法で提示してください。「[DONE]」で終了してください',
+    hu: 'Kérjük, folytassa az eredmény elemzését, és mutassa be az adatokat tömör és világos módon. Fejezze be "[DONE]" jelzéssel',
+  },
 }

--- a/src/types/copilot.ts
+++ b/src/types/copilot.ts
@@ -206,3 +206,15 @@ export interface AIStreamOptions {
   frequencyPenalty?: number
   presencePenalty?: number
 }
+
+export interface ChatLoopOptions {
+  // Core control functions
+  shouldContinue: (content: string) => boolean
+  updateCallback: (message: CopilotMessage) => Promise<void>
+  // Optional configuration
+  formatAppend?: (current: string, next: string) => string
+  stopCondition?: (content: string) => boolean
+  maxTurns?: number
+  streamOptions?: AIStreamOptions
+  existingMessage: CopilotMessage
+}

--- a/src/utils/ai/copilot.ts
+++ b/src/utils/ai/copilot.ts
@@ -24,7 +24,7 @@ import {
   AVRO_SCHEMA_COMMAND_VALUES,
 } from './preset'
 
-const LANGUAGE_MAP = {
+export const LANGUAGE_MAP = {
   zh: '请使用中文回答（简体中文）',
   en: 'Please answer in English（English）',
   tr: 'Lütfen Türkçe cevap verin（Turkish）',

--- a/src/utils/ai/prompts/mcpResultAnalysis.txt
+++ b/src/utils/ai/prompts/mcpResultAnalysis.txt
@@ -1,0 +1,36 @@
+You are a MQTTX Copilot and data analyst specializing in analyzing MQTT and MCP (Model Context Protocol) tool execution results. Your role is to transform raw data into clear, actionable insights with minimal verbosity.
+
+Your primary responsibilities include:
+1. Analyzing data returned from MCP tool executions
+2. Providing concise, focused responses without unnecessary explanations
+3. Transforming data into visually appealing formats when appropriate
+4. Identifying patterns and anomalies in MQTT-related metrics and data
+
+When analyzing MCP tool results:
+- Format smaller datasets (less than 20 items) using appropriate visual presentations:
+  - Use tables for structured data with clear columns
+  - Use code blocks for configuration data, JSON responses, or command outputs
+  - Use lists for sequential or hierarchical information
+- For larger datasets, summarize key statistics and trends
+- Highlight important data points or anomalies
+- When specific values are requested, provide them directly without explanations
+- Include units of measurement where applicable (bytes, messages/second, etc.)
+
+Your responses should:
+- Avoid introductory phrases like "Here are the results" or "Based on the data"
+- Present information directly without redundant explanations
+- Use precise, technical terminology appropriate for MQTT and IoT contexts
+- Prioritize clarity and readability in data presentation
+- Organize information logically with appropriate hierarchical structure
+
+For time-series data or performance metrics:
+- Identify trends, peaks, or patterns
+- Compare values against common benchmarks when relevant
+- Note correlations between different metrics when apparent
+
+When analyzing connection data:
+- Highlight connection status, QoS levels, clean session settings
+- Note authentication methods and security settings
+- Summarize subscription patterns and topic structures
+
+Remember that users rely on your analysis for operational decision-making and troubleshooting, so accuracy and clarity are essential. Avoid opinions or speculation beyond what the data directly supports.


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

After executing an MCP call, the system only displays the raw results without further analysis. This requires users to interpret the data themselves, which can be challenging for complex results.

#### Issue Number

#### What is the new behavior?

Implemented Chat Loop functionality according to MCP documentation. After an MCP call is executed, the AI model now analyzes the results, providing users with more meaningful insights and interpretations. The implementation:

- Adds a conversation loop that processes MCP results using the AI model
- Includes proper stopping conditions using the "[DONE]" marker
- Cleans up the presentation by removing technical markers from the final output
- Improves user experience by providing analyzed data in a clear, structured format

<img width="1267" alt="image" src="https://github.com/user-attachments/assets/3832a1b0-db38-4e2e-a957-ecdcc81d778d" />


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Specific Instructions

When reviewing, please test the MCP result analysis functionality by:
1. Executing various MCP calls with different data sizes
2. Verifying that the analysis is properly formatted and markers are removed
3. Confirming the chat loop terminates correctly

#### Other information

This enhancement significantly improves the user experience by leveraging the AI's analytical capabilities to provide more valuable insights from MCP operation results.