### PR TITLE
improve(payload): move CBOR and MsgPack to the codec

### DIFF
--- a/apps/web/auto-imports.d.ts
+++ b/apps/web/auto-imports.d.ts
@@ -101,8 +101,6 @@ declare module 'vue' {
   interface GlobalComponents {}
   interface ComponentCustomProperties {
     readonly EffectScope: UnwrapRef<typeof import('vue')['EffectScope']>
-    readonly ElMessage: UnwrapRef<typeof import('element-plus/es')['ElMessage']>
-    readonly ElMessageBox: UnwrapRef<typeof import('element-plus/es')['ElMessageBox']>
     readonly acceptHMRUpdate: UnwrapRef<typeof import('pinia')['acceptHMRUpdate']>
     readonly computed: UnwrapRef<typeof import('vue')['computed']>
     readonly createApp: UnwrapRef<typeof import('vue')['createApp']>

--- a/examples/function/binaryData.js
+++ b/examples/function/binaryData.js
@@ -1,0 +1,49 @@
+/**
+ * @description: Read and modify binary data
+ * @param {object} params - The parameters object
+ * @param {string} params.payload - Message payload string
+ * @param {object} params.payloadRaw - Binary data in JSON serialized format {type: 'Buffer', data: number[]}
+ * @param {string} params.messageType - Message type, value is 'received' or 'publish'
+ * @return {object} - Return modified binary data
+ */
+function handlePayload(params) {
+  const { payload, payloadRaw } = params
+  
+  try {
+    // Check if we have binary data
+    if (payloadRaw && payloadRaw.type === 'Buffer' && Array.isArray(payloadRaw.data)) {
+      // Convert to Uint8Array for easier manipulation
+      const uint8Array = new Uint8Array(payloadRaw.data)
+      
+      // Example: Read first 4 bytes as a message header
+      const header = uint8Array.slice(0, 4)
+      
+      // Example: Modify the data - add 1 to each byte
+      const modifiedData = uint8Array.map(byte => (byte + 1) % 256)
+      
+      // Create output object with metadata and modified binary data
+      return {
+        original_size: uint8Array.length,
+        header: Array.from(header),
+        modified: true,
+        type: 'Buffer',
+        data: Array.from(modifiedData)
+      }
+    }
+    
+    // If not binary data, try to parse as JSON
+    const parsedPayload = JSON.parse(payload)
+    return {
+      message: 'No binary data detected',
+      original: parsedPayload
+    }
+  } catch (error) {
+    // If payload is not valid JSON, return basic info
+    return {
+      message: 'Unable to process data',
+      error: error.message
+    }
+  }
+}
+
+return execute(handlePayload)

--- a/examples/function/dynamicSwitch.js
+++ b/examples/function/dynamicSwitch.js
@@ -1,13 +1,15 @@
 /**
  * @description: Simulated dynamic switch command
- * @param {string} message - Message payload
- * @param {string} messageType - Message type, value is 'received' or 'publish'
- * @param {number} index - Index of the message, valid only when script is used in the publish message and timed message is enabled
+ * @param {object} params - The parameters object
+ * @param {string} params.payload - Message payload
+ * @param {string} params.messageType - Message type, value is 'received' or 'publish'
+ * @param {number} params.sendCounter - Counter for sent messages (only valid when timed sending is enabled)
  * @return {string} - Return two commands alternately, { "command": "on" } or { "command": "off" }
  */
-function handlePayload(message, messageType, index) {
-  let _message = JSON.parse(message || '{}')
-  if (index % 2 === 0) {
+function handlePayload(params) {
+  const { payload, sendCounter } = params
+  let _message = JSON.parse(payload || '{}')
+  if (sendCounter % 2 === 0) {
     _message.command = 'on'
   } else {
     _message.command = 'off'

--- a/examples/function/tempAndHum.js
+++ b/examples/function/tempAndHum.js
@@ -3,12 +3,15 @@ function random(min, max) {
 }
 
 /**
- * @description: Simulated dynamic switch command
- * @param {string} message - Message payload
+ * @description: Simulated dynamic temperature and humidity data
+ * @param {object} params - The parameters object
+ * @param {string} params.payload - Message payload
+ * @param {string} params.messageType - Message type, value is 'received' or 'publish'
  * @return {string} - Return a simulated temperature and humidity data - { "temperature": 23, "humidity": 40 }
  */
-function handlePayload(message) {
-  let _message = JSON.parse(message || '{}')
+function handlePayload(params) {
+  const { payload } = params
+  let _message = JSON.parse(payload || '{}')
   _message.temperature = random(10, 30)
   _message.humidity = random(20, 40)
   return JSON.stringify(_message, null, 2)

--- a/examples/function/timestamp.js
+++ b/examples/function/timestamp.js
@@ -1,10 +1,13 @@
 /**
  * Convert timestamp to normal time
- * @param {string} message - Message payload - { "time": 1608185887 }
+ * @param {object} params - The parameters object
+ * @param {string} params.payload - Message payload - { "time": 1608185887 }
+ * @param {string} params.messageType - Message type, value is 'received' or 'publish'
  * @return {string} - Return the message with the time converted to normal time - { "time": "17/12/2020, 06:18:07" }
  */
-function handlePayload(message) {
-  let _message = JSON.parse(message)
+function handlePayload(params) {
+  const { payload } = params
+  let _message = JSON.parse(payload)
   const date = new Date(_message.time * 1000)
   _message.time = new Intl.DateTimeFormat('en-GB', {
     timeZone: 'UTC',

--- a/packages/core/src/utils/sandbox.ts
+++ b/packages/core/src/utils/sandbox.ts
@@ -4,24 +4,44 @@ import { Buffer } from 'buffer'
 import uvm from 'uvm'
 import { jsonStringify } from './jsonUtils'
 
-export function executeScript(opts: {
+/**
+ * Executes JavaScript code in a secure sandboxed environment
+ *
+ * Uses UVM to create an isolated execution environment to prevent potential security risks.
+ * The sandbox restricts the script's execution context, providing access only to necessary message data.
+ *
+ * @throws Rejects the Promise with an error message if script execution fails
+ */
+export function executeScript(args: {
   script: string
   payload: string
+  payloadRaw: Buffer
   messageType: MessageType
-  index?: number
+  sendCounter?: number
 }): Promise<Buffer> {
   return new Promise((resolve, reject) => {
     uvm.spawn(
       {
         bootCode: `
-          bridge.on('runScript', function ({ script, payload, messageType, index }) {
+          bridge.on('runScript', function ({ script, payload, payloadRaw, messageType, sendCounter }) {
             try {
               function execute(callback) {
-                return callback(payload, messageType, index);
+                const params = {
+                  payload,
+                  payloadRaw,
+                  messageType,
+                  sendCounter
+                };
+                return callback(params);
               };
               bridge.dispatch(
                 'scriptResult', 
-                Function('execute', 'payload', 'messageType', 'index', script)(execute, payload, messageType, index)
+                Function('execute', 'params', script)(execute, {
+                  payload,
+                  payloadRaw,
+                  messageType,
+                  sendCounter
+                })
               );
             } catch (error) {
               bridge.dispatch('scriptError', error.message);
@@ -35,20 +55,38 @@ export function executeScript(opts: {
         if (err) reject(err)
 
         context.on('scriptResult', (result: any) => {
-          let resultStr: string
-          if (typeof result === 'object') {
-            resultStr = jsonStringify(result, null, 2)
+          // Handle different types of results and ensure we return a proper Buffer
+          if (Buffer.isBuffer(result)) {
+            resolve(result)
+          } else if (
+            result
+            && result.type === 'Buffer'
+            && Array.isArray(result.data)
+            // Check if object has only type and data properties (is pure Buffer)
+            && Object.keys(result).length === 2
+          ) {
+            // Handle JSON serialized Buffer format
+            resolve(Buffer.from(result.data))
+          } else if (result instanceof Uint8Array) {
+            // Handle Uint8Array result
+            resolve(Buffer.from(result))
           } else {
-            resultStr = String(result)
+            // Convert other types to string and then to Buffer
+            let resultStr: string
+            if (typeof result === 'object') {
+              resultStr = jsonStringify(result, null, 2)
+            } else {
+              resultStr = String(result)
+            }
+            resolve(Buffer.from(resultStr))
           }
-          resolve(Buffer.from(resultStr))
         })
 
         context.on('scriptError', (error?: string) => {
           reject(new Error(error))
         })
 
-        context.dispatch('runScript', opts)
+        context.dispatch('runScript', args)
       },
     )
   })

--- a/packages/types/base.ts
+++ b/packages/types/base.ts
@@ -17,7 +17,9 @@ export type Protocol = Extract<IClientOptions['protocol'], 'mqtt' | 'mqtts' | 'w
 
 export type QoS = NonNullable<IClientPublishOptions['qos']>
 
-export type PayloadType = 'Plaintext' | 'Base64' | 'JSON' | 'Hex' | 'CBOR' | 'MsgPack'
+export type OutputFormat = 'Plaintext' | 'Base64' | 'JSON' | 'Hex'
+
+export type SerializationFormat = 'CBOR' | 'MsgPack' | 'Protobuf' | 'Avro'
 
 export type MessageType = 'all' | 'received' | 'publish'
 

--- a/packages/ui/src/components/script/function/Editor.vue
+++ b/packages/ui/src/components/script/function/Editor.vue
@@ -34,14 +34,24 @@ const defaultFunction: Record<string, { content: string }> = {
   javascript: {
     content: `/**
  * @description: Default custom function template
- * @param {string} message - Message payload
- * @param {string} messageType - Message type, value is 'received' or 'publish'
- * @param {number} index - Index of the message, valid only when script is used in the publish message and timed message is enabled
- * @return {string | object} - Returns a string or an object that can be JSON.stringify
+ * @param {object} params - The parameters object
+ * @param {string} params.payload - String representation of the message payload
+ * @param {object} params.payloadRaw - Binary data in JSON serialized format {type: 'Buffer', data: number[]}
+ * @param {string} params.messageType - Message type, value is 'received' or 'publish'
+ * @param {number} params.sendCounter - Counter for sent messages (only valid when timed sending is enabled)
+ * @return {*} - Supported return formats:
+ *         - String: used as message payload
+ *         - Object: converted to JSON string
+ *         - {type: 'Buffer', data: number[]}: treated as binary data
  */
-function handlePayload(message, messageType, index) {
-  const payload = JSON.parse(message)
-  return payload.msg
+function handlePayload(params) {
+  const { payload } = params
+  try {
+    const parsedPayload = JSON.parse(payload)
+    return parsedPayload.msg || parsedPayload
+  } catch (error) {
+    return payload
+  }
 }
 
 return execute(handlePayload)`,

--- a/packages/ui/src/components/script/function/Test.vue
+++ b/packages/ui/src/components/script/function/Test.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ScriptFunction } from 'mqttx'
+import type { MessageType, ScriptFunction } from 'mqttx'
 import { executeScript } from '@mqttx/core'
 
 const props = defineProps<{
@@ -16,6 +16,18 @@ const {
   monacoEditorLangugage: resultMonacoEditorLangugage,
 } = usePayloadConverter()
 
+const { t } = useI18n()
+const messagesTypeList: {
+  value: MessageType
+  label: string
+}[] = [
+  { value: 'all', label: t('connections.all') },
+  { value: 'received', label: t('connections.received') },
+  { value: 'publish', label: t('script.publish') },
+]
+const messageType = ref<MessageType>('all')
+const sendCounter = ref(1)
+
 function resetResults() {
   resultString.value = ''
   resultPayloadType.value = 'Plaintext'
@@ -30,12 +42,10 @@ function handleTest() {
       script: currentFunctionContent.value,
       payload: payloadString.value,
       payloadRaw: payloadBuffer.value,
-      messageType: 'publish',
+      messageType: messageType.value,
+      sendCounter: sendCounter.value,
     })
       .then((data) => {
-        console.log(data)
-        console.log(data.toString())
-
         resultString.value = data.toString()
       })
       .catch((error) => {
@@ -55,12 +65,33 @@ function handleTest() {
   <section>
     <div class="my-3 flex justify-between items-center">
       <label class="text-title">{{ $t('script.input') }}</label>
-      <ElButton
-        type="primary"
-        @click="handleTest"
-      >
-        {{ $t('script.test') }}
-      </ElButton>
+      <div class="flex items-center gap-3">
+        <div class="flex items-center gap-2">
+          <span class="text-title">{{ $t('script.messageType') }}:</span>
+          <ElSelect v-model="messageType" style="width: 120px">
+            <ElOption
+              v-for="item in messagesTypeList"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </ElSelect>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class="text-title">{{ $t('script.sendCounter') }}:</span>
+          <ElInputNumber
+            v-model="sendCounter"
+            :min="1"
+            style="width: 120px"
+          />
+        </div>
+        <ElButton
+          type="primary"
+          @click="handleTest"
+        >
+          {{ $t('script.test') }}
+        </ElButton>
+      </div>
     </div>
     <section class="h-40 bg-normal border border-b-0 px-0.5 pb-0.5 pt-3 border-border-default rounded-t">
       <MonacoEditor

--- a/packages/ui/src/components/script/function/Test.vue
+++ b/packages/ui/src/components/script/function/Test.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
 }>()
 
 const { currentLang, currentFunctionContent } = toRefs(props)
-const { payloadTypeList, payloadType, payloadString, monacoEditorLangugage } = usePayloadConverter()
+const { payloadTypeList, payloadType, payloadString, payloadBuffer, monacoEditorLangugage } = usePayloadConverter()
 
 const {
   payloadType: resultPayloadType,
@@ -23,15 +23,19 @@ function resetResults() {
 
 resetResults()
 
-function handleTest(payload: string) {
+function handleTest() {
   resetResults()
   if (currentLang.value === 'javascript') {
     executeScript({
       script: currentFunctionContent.value,
-      payload,
+      payload: payloadString.value,
+      payloadRaw: payloadBuffer.value,
       messageType: 'publish',
     })
       .then((data) => {
+        console.log(data)
+        console.log(data.toString())
+
         resultString.value = data.toString()
       })
       .catch((error) => {
@@ -53,7 +57,7 @@ function handleTest(payload: string) {
       <label class="text-title">{{ $t('script.input') }}</label>
       <ElButton
         type="primary"
-        @click="handleTest(payloadString)"
+        @click="handleTest"
       >
         {{ $t('script.test') }}
       </ElButton>

--- a/packages/ui/src/i18n/script.ts
+++ b/packages/ui/src/i18n/script.ts
@@ -181,4 +181,25 @@ export default {
     ja: 'Proto名は必須です',
     hu: 'Szükséges a Proto név',
   },
+  messageType: {
+    zh: '消息类型',
+    en: 'Message type',
+    tr: 'Mesaj türü',
+    ja: 'メッセージタイプ',
+    hu: 'Üzenet típus',
+  },
+  publish: {
+    zh: '发布',
+    en: 'Publish',
+    tr: 'Yayınla',
+    ja: '公開',
+    hu: 'Közzététel',
+  },
+  sendCounter: {
+    zh: '发送计数',
+    en: 'Send count',
+    tr: 'Gönderim sayısı',
+    ja: '送信カウント',
+    hu: 'Küldési szám',
+  },
 }


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

- CBOR and MsgPack are currently treated as message display formats like Plaintext and Base64, but they should be considered as encoding/decoding methods.  
- Custom scripts currently cannot retrieve or modify raw data.  
- In script testing, it is not possible to select the message type

#### What is the new behavior?

- Moved CBOR and MsgPack to the decoder category.  
- Introduced a `payloadRaw` parameter that allows users to retrieve and modify raw data as needed.  
- Added options in script testing to select the message type and configure the number of messages to send.  
- Improved data handling for custom script return values.  

<img width="1284" alt="image" src="https://github.com/user-attachments/assets/6ac88eb0-f4f8-4cf7-b6bf-a24781081750" />

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
