### PR TITLE
fix(desktop): prevent drag on connection list

### DIFF
--- a/src/components/ConnectionSelect.vue
+++ b/src/components/ConnectionSelect.vue
@@ -77,3 +77,9 @@ export default class ConnectionSelect extends Vue {
   }
 }
 </script>
+
+<style lang="scss">
+.connection-select {
+  -webkit-app-region: no-drag;
+}
+</style>


### PR DESCRIPTION
#### What is the current behavior?

The connection select at the top is not clickable; it only triggers window drag.

<img width="604" alt="image" src="https://github.com/user-attachments/assets/f2d7f929-6b0c-4d50-9597-1809950d0cb3" />

#### What is the new behavior?

The issue is fixed — the select is now clickable as expected.