### PR TITLE
refactor(copilot): repalce show preset prompt hover with Reverting to…

### DIFF
--- a/src/components/ai/CopilotHeader.vue
+++ b/src/components/ai/CopilotHeader.vue
@@ -25,6 +25,10 @@ export default class CopilotHeader extends Vue {
 
 <style lang="scss">
 .copilot-header {
+  position: relative;
+  z-index: 10;
+  -webkit-app-region: no-drag;
+
   &.clearfix {
     display: flex;
     align-items: center;

--- a/src/components/ai/CopilotInput.vue
+++ b/src/components/ai/CopilotInput.vue
@@ -10,7 +10,7 @@
       :rows="1"
       class="chat-msg-input"
       v-model="message"
-      :placeholder="$t('copilot.copiltePubMsgPlacehoder')"
+      :placeholder="$t('copilot.copilotPubMsgPlaceholder')"
       @keydown.native.enter="handleEnterKey"
       @input="handleInput"
     ></el-input>

--- a/src/components/ai/PresetPromptSelect.vue
+++ b/src/components/ai/PresetPromptSelect.vue
@@ -1,5 +1,6 @@
 <template>
   <el-cascader-panel
+    ref="cascaderPanel"
     class="preset-prompts-select"
     :options="filteredPresetPromptOptions"
     :props="{ expandTrigger: 'hover', emitPath: false }"
@@ -201,6 +202,23 @@ export default class PresetPromptSelect extends Vue {
 
   private handleChange(val: string) {
     this.$emit('onChange', val, this.presetPromptsMap)
+  }
+
+  public focusPanel() {
+    this.$nextTick(() => {
+      const panelComponent = this.$refs.cascaderPanel as Vue
+      if (panelComponent && panelComponent.$el instanceof HTMLElement) {
+        const firstMenuItem = panelComponent.$el.querySelector(
+          '.el-cascader-menu .el-cascader-node:not(.is-disabled)',
+        ) as HTMLElement | null
+
+        if (firstMenuItem) {
+          firstMenuItem.focus()
+        } else {
+          panelComponent.$el.focus()
+        }
+      }
+    })
   }
 }
 </script>

--- a/src/lang/copilot.ts
+++ b/src/lang/copilot.ts
@@ -77,11 +77,11 @@ export default {
     hu: 'Gondolkodási folyamat megtekintése',
   },
   copiltePubMsgPlacehoder: {
-    zh: '向 MQTTX Copilot 发送消息...',
-    en: 'Message MQTTX Copilot...',
-    tr: "MQTTX Copilot'a mesaj gönder...",
-    ja: 'MQTTX Copilotにメッセージを送る...',
-    hu: 'Üzenet küldése a MQTTX Copilotnak...',
+    en: 'Enter message, use / for preset prompts, ↩︎ to send',
+    zh: '输入消息，使用 / 打开预设指令，↩︎ 发送',
+    ja: 'メッセージを入力し、/ でプリセットプロンプトを開き、↩︎ で送信します',
+    tr: 'Mesajı girin, hazır istemler için / kullanın, göndermek için ↩︎ kullanın',
+    hu: 'Üzenet beírása, használja a / jelet az előre beállított promptokhoz, ↩︎ a küldéshez',
   },
   copilotUser: {
     zh: '用户',

--- a/src/lang/copilot.ts
+++ b/src/lang/copilot.ts
@@ -76,7 +76,7 @@ export default {
     ja: '思考プロセスを表示',
     hu: 'Gondolkodási folyamat megtekintése',
   },
-  copiltePubMsgPlacehoder: {
+  copilotPubMsgPlaceholder: {
     en: 'Enter message, use / for preset prompts, ↩︎ to send',
     zh: '输入消息，使用 / 打开预设指令，↩︎ 发送',
     ja: 'メッセージを入力し、/ でプリセットプロンプトを開き、↩︎ で送信します',


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The Copilot preset prompt selection panel (`PresetPromptSelect.vue`) appears automatically whenever the Copilot input field (`CopilotInput.vue`) receives focus. This can be intrusive and annoying for users who want to type a message. Additionally, once the panel appears, keyboard navigation (up/down/left/right arrows) does not work because the focus remains in the input field, and there's no dedicated way (like pressing `Esc`) to dismiss the panel without selecting an item or clicking outside.

#### Issue Number: None

#### What is the new behavior?

This PR significantly improves the usability of the Copilot preset prompts:

1.  **Trigger Change:** The preset prompt panel (`PresetPromptSelect.vue`) is no longer triggered by focusing the input field. Instead, it appears only when the user types a `/` character at the beginning of the `CopilotInput.vue` field.
2.  **Keyboard Navigation:** When the panel appears (after typing `/`), focus is automatically transferred to the panel itself, allowing users to navigate the preset prompts using the up/down/left/right arrow keys and select with Enter.
3.  **Escape Key Dismissal:** Users can now press the `Esc` key to dismiss the preset prompt panel when it is visible. This clears the input field and hides the panel.
4.  **Updated Placeholder:** The placeholder text in the `CopilotInput.vue` field has been updated across all languages to inform users about the new `/` trigger (e.g., "Enter message, use / for preset prompts, ↩︎ to send").

This makes accessing preset prompts an explicit action initiated by the user with `/`, enables keyboard accessibility, and provides a standard way to close the panel, leading to a much smoother user experience.

<img width="666" alt="image" src="https://github.com/user-attachments/assets/84f00803-262e-47dd-8f0d-286195d49e39" />

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Reviewers should check:
*   The preset prompt panel appears *only* when `/` is the first character in the input.
*   Arrow key navigation works correctly within the panel once it appears.
*   Pressing `Esc` dismisses the panel and clears the input when the panel is visible.
*   Selecting a preset prompt replaces the `/` and potentially other text in the input field.
*   Clicking outside the panel still correctly dismisses it.
*   The updated placeholder text is displayed correctly.

#### Other information

This change modifies `src/components/ai/CopilotInput.vue` to handle the new trigger logic, focus management, and `Esc` key binding. It also modifies `src/components/ai/PresetPromptSelect.vue` to add a method for receiving focus, and updates translations in `src/lang/copilot.ts`.