### PR TITLE
feat(copilot): add Azure OpenAI support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "electron:build-mac": "export NODE_OPTIONS=\"--openssl-legacy-provider --experimental-fetch\" && yarn run gen:version && vue-cli-service electron:build --mac",
     "electron:serve": "export NODE_OPTIONS=\"--dns-result-order=ipv4first --experimental-fetch\" && yarn run gen:version && vue-cli-service electron:serve",
     "electron:serve:sql_debug": "export VUE_APP_SQL_DEBUG=true && yarn electron:serve",
-    "postinstall": "electron-builder install-app-deps && node scripts/patch-mcp-sdk.js && node scripts/patch-monaco-clipboard.js",
-    "postuninstall": "electron-builder install-app-deps && node scripts/patch-mcp-sdk.js && node scripts/patch-monaco-clipboard.js",
+    "postinstall": "electron-builder install-app-deps && node scripts/patch-mcp-sdk.js && node scripts/patch-monaco-clipboard.js && node scripts/patch-azure-sdk.js",
+    "postuninstall": "electron-builder install-app-deps && node scripts/patch-mcp-sdk.js && node scripts/patch-monaco-clipboard.js && node scripts/patch-azure-sdk.js",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.vue\" \"src/**/*.scss\" \"web/**/*.ts\" \"web/**/*.vue\" \"web/**/*.scss\" \"cli/**/*.ts\" \"cli/**/*.js\"",
     "lint": "eslint --fix --ext .ts,.vue src",
     "test:e2e": "vue-cli-service test:e2e",
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.1.11",
+    "@ai-sdk/azure": "^1.3.13",
     "@ai-sdk/deepseek": "^0.1.12",
     "@ai-sdk/google": "^1.2.10",
     "@ai-sdk/openai": "^1.3.12",

--- a/scripts/patch-azure-sdk.js
+++ b/scripts/patch-azure-sdk.js
@@ -1,0 +1,32 @@
+// scripts/patch-azure-sdk.js
+const fs = require('fs')
+const path = require('path')
+
+const targetFilePath = path.join(__dirname, '..', 'node_modules', '@ai-sdk', 'azure', 'dist', 'index.mjs')
+const incorrectImport = 'from "@ai-sdk/openai/internal";'
+const correctImport = 'from "@ai-sdk/openai/internal/dist/index.js";' // Our successful fix
+
+try {
+  if (fs.existsSync(targetFilePath)) {
+    console.log(`🔍 Processing file: ${targetFilePath}`)
+    let content = fs.readFileSync(targetFilePath, 'utf8')
+
+    if (content.includes(incorrectImport)) {
+      content = content.replace(incorrectImport, correctImport)
+      fs.writeFileSync(targetFilePath, content, 'utf8')
+      console.log(`✅ Successfully patched ${targetFilePath} with correct import path.`)
+    } else if (content.includes(correctImport)) {
+      console.log(`☑️ File already patched or has correct import: ${targetFilePath}. Skipping.`)
+    } else {
+      console.warn(
+        `⚠️ Could not find the expected incorrect import statement in ${targetFilePath}. Patch script might need an update.`,
+      )
+    }
+  } else {
+    console.warn(`⚠️ Target file not found: ${targetFilePath}. Skipping patch. Maybe run yarn install?`)
+  }
+  console.log('🎉 Azure SDK patch process completed.')
+} catch (error) {
+  console.error(`❌ Error during Azure SDK patch process for ${targetFilePath}:`, error)
+  process.exit(1) // Exit with error code if patching fails
+}

--- a/scripts/patch-azure-sdk.js
+++ b/scripts/patch-azure-sdk.js
@@ -1,4 +1,30 @@
-// scripts/patch-azure-sdk.js
+/**
+ * Azure SDK ESM Import Compatibility Patch Script
+ *
+ * This script addresses an issue with unsupported ESM import paths in the Azure SDK module by replacing them
+ * with compatible paths. This ensures that the module can be correctly resolved and executed in environments
+ * that do not fully support ESM imports.
+ *
+ * The script performs the following actions:
+ * - Checks if the target file exists in the specified path.
+ * - Reads the file content and searches for the unsupported ESM import statement.
+ * - Replaces the unsupported import with a compatible one if found.
+ * - Logs the status of the patch process, indicating success, already patched, or if the target file is missing.
+ * - Exits with an error code if the patching process encounters an error.
+ *
+ * Common error before patching:
+ * ERROR  Failed to compile with 1 error                                         5:12:59 PM
+ *
+ * This dependency was not found:
+ *
+ * * @ai-sdk/openai/internal in ./node_modules/@ai-sdk/azure/dist/index.mjs
+ *
+ * To install it, you can run: npm install --save @ai-sdk/openai/internal
+ * No type errors found
+ * Version: typescript 4.9.5
+ * Time: 4294ms
+ */
+
 const fs = require('fs')
 const path = require('path')
 
@@ -14,12 +40,12 @@ try {
     if (content.includes(incorrectImport)) {
       content = content.replace(incorrectImport, correctImport)
       fs.writeFileSync(targetFilePath, content, 'utf8')
-      console.log(`✅ Successfully patched ${targetFilePath} with correct import path.`)
+      console.log(`✅ Successfully patched ${targetFilePath} with compatible import path.`)
     } else if (content.includes(correctImport)) {
-      console.log(`☑️ File already patched or has correct import: ${targetFilePath}. Skipping.`)
+      console.log(`☑️ File already patched or has compatible import: ${targetFilePath}. Skipping.`)
     } else {
       console.warn(
-        `⚠️ Could not find the expected incorrect import statement in ${targetFilePath}. Patch script might need an update.`,
+        `⚠️ Could not find the expected unsupported import statement in ${targetFilePath}. Patch script might need an update.`,
       )
     }
   } else {
@@ -28,5 +54,6 @@ try {
   console.log('🎉 Azure SDK patch process completed.')
 } catch (error) {
   console.error(`❌ Error during Azure SDK patch process for ${targetFilePath}:`, error)
+  console.error(`📄 Error details: ${error.message}`)
   process.exit(1) // Exit with error code if patching fails
 }

--- a/src/types/copilot.ts
+++ b/src/types/copilot.ts
@@ -195,7 +195,7 @@ export interface SiliconFlowOptionsModel extends BaseProviderOptionsModel {
  * Configuration for Azure OpenAI models
  */
 export interface AzureOptionsModel extends BaseProviderOptionsModel {
-  value: 'Azure'
+  value: 'Azure OpenAI'
   children: { value: Parameters<ReturnType<typeof createAzure>>[0] }[]
   providerCreator: typeof createAzure
 }

--- a/src/types/copilot.ts
+++ b/src/types/copilot.ts
@@ -3,6 +3,7 @@ import { createDeepSeek } from '@ai-sdk/deepseek'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createXai } from '@ai-sdk/xai'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createAzure } from '@ai-sdk/azure'
 import { MCPPromptData } from '@/types/mcp'
 
 import VueI18n from 'vue-i18n'
@@ -191,6 +192,15 @@ export interface SiliconFlowOptionsModel extends BaseProviderOptionsModel {
 }
 
 /**
+ * Configuration for Azure OpenAI models
+ */
+export interface AzureOptionsModel extends BaseProviderOptionsModel {
+  value: 'Azure'
+  children: { value: Parameters<ReturnType<typeof createAzure>>[0] }[]
+  providerCreator: typeof createAzure
+}
+
+/**
  * Union type of all AI model option configurations
  */
 export type AImodelsOptionsModel = (
@@ -200,6 +210,7 @@ export type AImodelsOptionsModel = (
   | XaiOptionsModel
   | GoogleOptionsModel
   | SiliconFlowOptionsModel
+  | AzureOptionsModel
 )[]
 
 /**

--- a/src/utils/ai/AIAgent.ts
+++ b/src/utils/ai/AIAgent.ts
@@ -296,7 +296,6 @@ export class AIAgent {
         baseURL: this.openAIAPIHost,
         apiKey,
         providerType,
-        azureApiVersion: isAzure ? '2025-01-01-preview' : undefined,
       }),
       providerOptions: {
         anthropic: {

--- a/src/utils/ai/AIAgent.ts
+++ b/src/utils/ai/AIAgent.ts
@@ -200,7 +200,7 @@ export class AIAgent {
    *
    * @param model - The AI model identifier (could be a base model name or an Azure deployment name).
    * @param host - The API host URL.
-   * @returns The provider type ('Azure', 'OpenAI', 'Google', 'Anthropic', etc.).
+   * @returns The provider type ('Azure OpenAI', 'OpenAI', 'Google', 'Anthropic', etc.).
    */
   /**
    * Determines the AI provider type based on the model name and API host.
@@ -215,7 +215,7 @@ export class AIAgent {
    * @param model - The AI model identifier (base model name or deployment name)
    * @param host - The API host URL
    * @param isAzure - Optional flag indicating if this is an Azure deployment
-   * @returns The provider type ('Azure', 'OpenAI', 'Google', 'Anthropic', 'DeepSeek', 'xAI', 'SiliconFlow')
+   * @returns The provider type ('Azure OpenAI', 'OpenAI', 'Google', 'Anthropic', 'DeepSeek', 'xAI', 'SiliconFlow')
    */
   private determineProviderType(
     model: AIModel,
@@ -224,7 +224,7 @@ export class AIAgent {
   ): typeof AImodelsOptions[number]['value'] {
     // **Priority 1: Check for Azure host pattern**
     if (isAzure) {
-      return 'Azure'
+      return 'Azure OpenAI'
     }
 
     // **Priority 2: Check if the model name matches a known model for a specific provider**

--- a/src/utils/ai/copilot.ts
+++ b/src/utils/ai/copilot.ts
@@ -4,6 +4,8 @@ import { createDeepSeek } from '@ai-sdk/deepseek'
 import { createAnthropic } from '@ai-sdk/anthropic'
 import { createXai } from '@ai-sdk/xai'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createAzure } from '@ai-sdk/azure'
+
 import basePrompt from './prompts/base.txt'
 import clientCodeGen from './prompts/clientCodeGen.txt'
 import payloadGen from './prompts/payloadGen.txt'
@@ -154,6 +156,21 @@ export const AImodelsOptions: AImodelsOptionsModel = [
     providerCreator: createGoogleGenerativeAI,
   },
   {
+    value: 'Azure' as const,
+    children: [
+      { value: 'gpt-4o' },
+      { value: 'gpt-4o-mini' },
+      { value: 'gpt-4.1' },
+      { value: 'gpt-4.1-mini' },
+      { value: 'gpt-4.1-nano' },
+      { value: 'o1' },
+      { value: 'o1-mini' },
+      { value: 'o1-preview' },
+      { value: 'o3-mini' },
+    ],
+    providerCreator: createAzure,
+  },
+  {
     value: 'SiliconFlow' as const,
     children: [
       { value: 'deepseek-ai/DeepSeek-V3' },
@@ -175,6 +192,7 @@ export const AImodelsOptions: AImodelsOptionsModel = [
  * - xAI API endpoint
  * - Google API endpoint
  * - SiliconFlow API endpoint
+ * - Azure OpenAI (constructed dynamically from resource name)
  *
  * These URLs are used when configuring the API client for each provider.
  */
@@ -185,6 +203,7 @@ export const AIAPIHostOptions = [
   { value: 'https://api.x.ai/v1' },
   { value: 'https://generativelanguage.googleapis.com/v1beta' },
   { value: 'https://api.siliconflow.cn/v1' },
+  { value: 'https://${resourceName}.azure.com' },
 ]
 
 export const REASONING_MODEL_REGEX = /thinking|reasoner|r1/i
@@ -203,10 +222,11 @@ export const isReasoningModel = (model: AIModel) => {
  * Gets the appropriate LanguageModelV1 instance for the specified provider.
  *
  * @param opts - The options for creating the model provider
- * @param opts.model - The AI model to use
- * @param opts.baseURL - The base URL/endpoint for the API
+ * @param opts.model - The AI model to use (Deployment Name for Azure)
+ * @param opts.baseURL - The base URL/endpoint for the API (Endpoint URL for Azure)
  * @param opts.apiKey - The API key for authentication
  * @param opts.providerType - Explicitly specify the provider type
+ * @param opts.azureApiVersion - Optional Azure API Version
  * @returns A LanguageModelV1 compatible provider instance
  */
 export const getModelProvider = (opts: {
@@ -214,8 +234,11 @@ export const getModelProvider = (opts: {
   baseURL: string
   apiKey: string
   providerType: typeof AImodelsOptions[number]['value']
+  azureApiVersion?: string
 }): LanguageModelV1 => {
-  const { model, baseURL, apiKey, providerType } = opts
+  const { model, baseURL, apiKey, providerType, azureApiVersion } = opts
+
+  console.log(providerType)
 
   const providerConfig = AImodelsOptions.find((p) => p.value === providerType)
 

--- a/src/utils/ai/copilot.ts
+++ b/src/utils/ai/copilot.ts
@@ -156,7 +156,7 @@ export const AImodelsOptions: AImodelsOptionsModel = [
     providerCreator: createGoogleGenerativeAI,
   },
   {
-    value: 'Azure' as const,
+    value: 'Azure OpenAI' as const,
     children: [
       { value: 'deployment-gpt-4o' },
       { value: 'deployment-gpt-4o-mini' },
@@ -203,7 +203,7 @@ export const AIAPIHostOptions = [
   { value: 'https://api.x.ai/v1' },
   { value: 'https://generativelanguage.googleapis.com/v1beta' },
   { value: 'https://api.siliconflow.cn/v1' },
-  { value: 'https://${resourceName}.azure.com' },
+  { value: 'https://${resourceName}.openai.azure.com' },
 ]
 
 export const REASONING_MODEL_REGEX = /thinking|reasoner|r1/i
@@ -257,7 +257,7 @@ export const getModelProvider = (opts: {
     apiKey,
   }
 
-  if (providerType === 'Azure' && azureApiVersion) {
+  if (providerType === 'Azure OpenAI' && azureApiVersion) {
     creatorOptions.apiVersion = azureApiVersion
 
     if (baseURL) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,15 @@
     "@ai-sdk/provider" "1.0.9"
     "@ai-sdk/provider-utils" "2.1.10"
 
+"@ai-sdk/azure@^1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/azure/-/azure-1.3.13.tgz#2ee38c3927df29262ad772217407c3c953a3ffbd"
+  integrity sha512-PS96YEC3MOwpJHSC+mrMY31S7PA+outPmrFZljSbzdYf4/gd0rKQjHnqnV8K7/1GmxjkueoYRH2QfWLT5eaO8Q==
+  dependencies:
+    "@ai-sdk/openai" "1.3.12"
+    "@ai-sdk/provider" "1.1.3"
+    "@ai-sdk/provider-utils" "2.2.7"
+
 "@ai-sdk/deepseek@^0.1.12":
   version "0.1.12"
   resolved "https://registry.yarnpkg.com/@ai-sdk/deepseek/-/deepseek-0.1.12.tgz#40578a4efa0d08b9b47443e43911e932dcef40a5"
@@ -40,7 +49,7 @@
     "@ai-sdk/provider" "1.0.9"
     "@ai-sdk/provider-utils" "2.1.10"
 
-"@ai-sdk/openai@^1.3.12":
+"@ai-sdk/openai@1.3.12", "@ai-sdk/openai@^1.3.12":
   version "1.3.12"
   resolved "https://registry.yarnpkg.com/@ai-sdk/openai/-/openai-1.3.12.tgz#d51df2e3adef7e5ff50846102e4113f296975adb"
   integrity sha512-ueAP69p8a/ZR2ns+pmlr9h/nyV2/DAwzfnPUGZiLpXbxWnLXd2g3a7l38CuEhBydH/nOfDb/byMgpS8+bnJHTg==


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The application currently does not support Azure OpenAI as an AI provider option. Users cannot configure or utilize Azure OpenAI models for AI features like Copilot.

#### Issue Number

None

#### What is the new behavior?

This PR introduces support for Azure OpenAI as an AI provider. Users can now select 'Azure OpenAI' in the AI settings and configure their Azure endpoint (either via Resource Name or full URL) and API key. This enables the use of various Azure OpenAI models (e.g., `deployment-gpt-4o`, `deployment-gpt-4.1-mini`, etc.) within the application's AI features.

<img width="457" alt="image" src="https://github.com/user-attachments/assets/9165ae40-124f-40b0-86a2-f99a2456a66d" />

Key changes include:
*   Added 'Azure OpenAI' to `AImodelsOptions` in `src/utils/ai/copilot.ts`.
*   The corresponding Azure OpenAI models with the `deployment-` prefix are included.
*   Added a helper function `getAzureProviderOptions` to parse the host/resource name and API version.
*   Updated `getModelProvider` to handle the creation of the Azure OpenAI client using `createAzure` from `@ai-sdk/azure`, passing the correctly parsed options.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Azure OpenAI configuration has some specific requirements due to minimizing changes to the existing provider structure:

1.  **Host Field:** The `Host` configuration field for Azure OpenAI can accept either the **Resource Name** (e.g., `your-resource-name`) or the full **Endpoint URL** (e.g., `https://your-resource-name.openai.azure.com`).
2.  **API Version:** The desired **API Version** must be specified as a query parameter appended to the `Host` field. For example: `your-resource-name?api-version=2025-01-01-preview` or `https://your-resource-name.openai.azure.com/?api-version=2025-01-01-preview`. If not provided, it defaults to `2025-01-01-preview`. This approach was chosen to avoid larger structural changes like adding a dedicated `Provider` field or modifying database schemas.
3.  **Model Names:** Model names for Azure OpenAI are prefixed with `deployment-` (e.g., `deployment-gpt-4o`). This reflects that models in Azure are deployments and helps prevent naming collisions with standard OpenAI models, given the absence of a distinct `Provider` field in the current setup.

These configuration steps are non-standard compared to other providers and **must be documented** for users intending to use Azure OpenAI.

#### Other information

Consider updating the official documentation to guide users through the Azure OpenAI configuration process outlined in the "Specific Instructions" section.