### PR TITLE
test(copilot): expand unit tests for AI model providers

### DIFF
--- a/tests/unit/utils/ai/copilot.spec.ts
+++ b/tests/unit/utils/ai/copilot.spec.ts
@@ -1,5 +1,11 @@
 import { expect } from 'chai'
+import { createAzure } from '@ai-sdk/azure'
 import { AImodelsOptions, AIAPIHostOptions, loadSystemPrompt, getModelProvider } from '@/utils/ai/copilot'
+import { createOpenAI } from '@ai-sdk/openai'
+import { createDeepSeek } from '@ai-sdk/deepseek'
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { createXai } from '@ai-sdk/xai'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
 
 describe('copilot', () => {
   describe('loadSystemPrompt', () => {
@@ -45,56 +51,64 @@ describe('copilot', () => {
   describe('AImodelsOptions', () => {
     it('should contain all supported providers', () => {
       const providerNames = AImodelsOptions.map((provider) => provider.value)
-
-      expect(providerNames).to.include('OpenAI')
-      expect(providerNames).to.include('DeepSeek')
-      expect(providerNames).to.include('Anthropic')
-      expect(providerNames).to.include('xAI')
-      expect(providerNames).to.include('SiliconFlow')
+      expect(providerNames).to.have.members([
+        'OpenAI',
+        'DeepSeek',
+        'Anthropic',
+        'xAI',
+        'Google',
+        'Azure OpenAI',
+        'SiliconFlow',
+      ])
     })
 
     it('should have valid model options for each provider', () => {
-      // Check OpenAI provider
       const openAI = AImodelsOptions.find((p) => p.value === 'OpenAI')
-      expect(openAI).to.exist
       expect(openAI?.children).to.be.an('array').that.is.not.empty
       expect(openAI?.children.map((c) => c.value)).to.include('gpt-4o')
 
-      // Check DeepSeek provider
       const deepSeek = AImodelsOptions.find((p) => p.value === 'DeepSeek')
-      expect(deepSeek).to.exist
       expect(deepSeek?.children).to.be.an('array').that.is.not.empty
       expect(deepSeek?.children.map((c) => c.value)).to.include('deepseek-chat')
 
-      // Check Anthropic provider
       const anthropic = AImodelsOptions.find((p) => p.value === 'Anthropic')
-      expect(anthropic).to.exist
       expect(anthropic?.children).to.be.an('array').that.is.not.empty
       expect(anthropic?.children.map((c) => c.value)).to.include('claude-3-opus-latest')
-    })
 
-    it('should have provider creator functions', () => {
-      // Verify each provider has a creator function
-      AImodelsOptions.forEach((provider) => {
-        expect(provider.providerCreator).to.be.a('function')
-      })
-    })
+      const xai = AImodelsOptions.find((p) => p.value === 'xAI')
+      expect(xai?.children).to.be.an('array').that.is.not.empty
+      expect(xai?.children.map((c) => c.value)).to.include('grok-3-beta')
 
-    it('should contain Google provider', () => {
-      const providerNames = AImodelsOptions.map((provider) => provider.value)
-      expect(providerNames).to.include('Google')
-    })
-
-    it('should have valid model options for Google', () => {
       const google = AImodelsOptions.find((p) => p.value === 'Google')
-      expect(google).to.exist
       expect(google?.children).to.be.an('array').that.is.not.empty
       expect(google?.children.map((c) => c.value)).to.include('gemini-1.5-pro')
+
+      const azure = AImodelsOptions.find((p) => p.value === 'Azure OpenAI')
+      expect(azure?.children).to.be.an('array').that.is.not.empty
+      expect(azure?.children.map((c) => c.value)).to.include('deployment-gpt-4o')
+
+      const siliconFlow = AImodelsOptions.find((p) => p.value === 'SiliconFlow')
+      expect(siliconFlow?.children).to.be.an('array').that.is.not.empty
+      expect(siliconFlow?.children.map((c) => c.value)).to.include('deepseek-ai/DeepSeek-V3')
     })
 
-    it('should have provider creator function for Google', () => {
-      const google = AImodelsOptions.find((p) => p.value === 'Google')
-      expect(google?.providerCreator).to.be.a('function')
+    it('should have the correct provider creator function for each provider', () => {
+      const expectedCreators: Record<string, Function> = {
+        OpenAI: createOpenAI,
+        DeepSeek: createDeepSeek,
+        Anthropic: createAnthropic,
+        xAI: createXai,
+        Google: createGoogleGenerativeAI,
+        'Azure OpenAI': createAzure,
+        SiliconFlow: createOpenAI,
+      }
+
+      AImodelsOptions.forEach((provider) => {
+        expect(provider.providerCreator, `Creator for ${provider.value}`).to.be.a('function')
+        expect(provider.providerCreator, `Creator mismatch for ${provider.value}`).to.equal(
+          expectedCreators[provider.value],
+        )
+      })
     })
   })
 
@@ -102,6 +116,11 @@ describe('copilot', () => {
     it('should include the default Google API host', () => {
       const googleHost = AIAPIHostOptions.find((opt) => opt.value.includes('google'))?.value
       expect(googleHost).to.equal('https://generativelanguage.googleapis.com/v1beta')
+    })
+
+    it('should include the Azure API host placeholder/example', () => {
+      const azureHostExample = AIAPIHostOptions.find((opt) => opt.value.includes('azure'))?.value
+      expect(azureHostExample).to.equal('https://${resourceName}.openai.azure.com')
     })
   })
 
@@ -111,8 +130,41 @@ describe('copilot', () => {
         getModelProvider({
           model: 'gpt-4o',
           baseURL: 'https://api.openai.com/v1',
-          apiKey: 'test-key',
+          apiKey: 'test-key-openai',
           providerType: 'OpenAI',
+        })
+      }).not.to.throw()
+    })
+
+    it('should return a provider instance for DeepSeek', () => {
+      expect(() => {
+        getModelProvider({
+          model: 'deepseek-chat',
+          baseURL: 'https://api.deepseek.com/v1',
+          apiKey: 'test-key-deepseek',
+          providerType: 'DeepSeek',
+        })
+      }).not.to.throw()
+    })
+
+    it('should return a provider instance for Anthropic', () => {
+      expect(() => {
+        getModelProvider({
+          model: 'claude-3-opus-latest',
+          baseURL: 'https://api.anthropic.com/v1',
+          apiKey: 'test-key-anthropic',
+          providerType: 'Anthropic',
+        })
+      }).not.to.throw()
+    })
+
+    it('should return a provider instance for xAI', () => {
+      expect(() => {
+        getModelProvider({
+          model: 'grok-3-beta',
+          baseURL: 'https://api.x.ai/v1',
+          apiKey: 'test-key-xai',
+          providerType: 'xAI',
         })
       }).not.to.throw()
     })
@@ -128,15 +180,46 @@ describe('copilot', () => {
       }).not.to.throw()
     })
 
-    // Add similar tests for other providers (DeepSeek, Anthropic, xAI, SiliconFlow) if desired
-
-    it('should accept baseURL for applicable providers', () => {
+    it('should return a provider instance for Azure OpenAI using baseURL with api-version', () => {
       expect(() => {
         getModelProvider({
-          model: 'deepseek-chat',
-          baseURL: 'https://custom.deepseek.com/v1',
-          apiKey: 'test-key-deepseek',
-          providerType: 'DeepSeek',
+          model: 'deployment-gpt-4o',
+          baseURL: 'https://my-azure-resource.openai.azure.com/?api-version=2025-01-01-preview',
+          apiKey: 'test-key-azure',
+          providerType: 'Azure OpenAI',
+        })
+      }).not.to.throw()
+    })
+
+    it('should return a provider instance for Azure OpenAI using resource name with api-version', () => {
+      expect(() => {
+        getModelProvider({
+          model: 'deployment-gpt-4o',
+          baseURL: 'my-azure-resource?api-version=2025-01-01-preview',
+          apiKey: 'test-key-azure',
+          providerType: 'Azure OpenAI',
+        })
+      }).not.to.throw()
+    })
+
+    it('should return a provider instance for SiliconFlow', () => {
+      expect(() => {
+        getModelProvider({
+          model: 'deepseek-ai/DeepSeek-V3',
+          baseURL: 'https://api.siliconflow.cn/v1',
+          apiKey: 'test-key-siliconflow',
+          providerType: 'SiliconFlow',
+        })
+      }).not.to.throw()
+    })
+
+    it('should fallback to OpenAI if provider is misconfigured', () => {
+      expect(() => {
+        getModelProvider({
+          model: 'deployment-gpt-4o',
+          baseURL: '',
+          apiKey: 'test-key-azure',
+          providerType: 'Azure OpenAI',
         })
       }).not.to.throw()
     })


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Currently, MQTTX Copilot does not support using Azure OpenAI as an AI service provider. Users are limited to the existing providers like OpenAI, Google, Anthropic, etc.

#### Issue Number

Example: Closes \#XYZ (Please replace XYZ with the actual issue number if available)

#### What is the new behavior?

This PR introduces support for Azure OpenAI within MQTTX Copilot, allowing users to configure and utilize their Azure OpenAI deployments.

*   Adds "Azure OpenAI" to the list of available AI providers in the Copilot settings.
*   Enables configuration via Azure Endpoint URL or Resource Name (provided in the "API Host" field).
*   Requires the API Version to be appended as a query parameter (`?api-version=...`) to the API Host field.
*   Requires Azure Deployment Names to be prefixed with `deployment-` when entered in the "Model" field.
*   Includes a build-time patch to fix an upstream dependency issue in `@ai-sdk/azure`.
*   Updates unit tests to cover Azure OpenAI configuration and instantiation, and improves test coverage for other providers.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known before review?

**Azure OpenAI Integration Notes:**

*   **Goal:** The primary goal was to add Azure OpenAI support with **minimal changes** to the existing architecture, avoiding the introduction of a distinct "Provider" selection logic or adding new database fields/Vuex states specifically for Azure configuration where possible. This led to some non-standard configuration approaches.
*   **Configuration:**
    *   **Endpoint/Resource Name:** Azure's "Endpoint URL" (e.g., `https://your-resource.openai.azure.com/`) OR "Resource Name" (e.g., `your-resource`) should be entered into the existing **"API Host"** field in the settings.
    *   **API Version:** The Azure **"API Version"** (e.g., `2025-01-01-preview`) **must be appended as a query parameter** to the URL/Resource Name entered in the "API Host" field. Example: `https://your-resource.openai.azure.com/?api-version=2025-01-01-preview` or `your-resource?api-version=2025-01-01-preview`.
    *   **Rationale:** This approach avoids adding a separate "API Version" input field and associated state/DB changes. The `getAzureProviderOptions` helper function in `src/utils/ai/copilot.ts` parses the `api-version` from the `baseURL` string.
*   **Model Naming (Deployment Name):**
    *   Azure models (Deployments) **should be prefixed with `deployment-`** when entered into the "Model" field (e.g., `deployment-gpt-4o`).
    *   **Rationale:** This convention helps distinguish Azure Deployments from standard OpenAI model names within the same configuration structure and aids the `determineProviderType` logic in `AIAgent.ts` without needing a separate "Provider" field tied to the model selection. The `processModel` function in `AIAgent.ts` handles stripping this prefix before passing the actual deployment name to the Azure SDK.
*   **Patch Script:** Includes a build-time patch script `scripts/patch-azure-sdk.js` (run via `postinstall`) to fix an upstream dependency resolution issue in `@ai-sdk/azure` related to `@ai-sdk/openai/internal`.
*   **Documentation:** Due to these non-standard configuration requirements, **user documentation must clearly explain** how to correctly configure the "API Host" (including appending `?api-version=...`) and "Model" (using the `deployment-` prefix) fields for Azure OpenAI. Reference: Azure OpenAI.
*   **Testing:** Unit tests in `tests/unit/utils/ai/copilot.spec.ts` have been updated to cover the Azure OpenAI provider instantiation and the handling of its specific configuration parameters. Tests for other providers have also been made more explicit.

#### Other information

This implementation relies on parsing the API version from the user-provided Base URL/API Host string and uses a naming convention (`deployment-` prefix) for Azure models to integrate with the existing system structure with minimal disruption. Ensure UI labels/placeholders clearly guide the user on these specific Azure configuration steps.