### PR TITLE
refactor(background): enable devTools in BrowserWindow configuration

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -196,7 +196,7 @@ async function createWindow() {
   win = new BrowserWindow({
     ...defaultWindowSize,
     webPreferences: {
-      devTools: isDevelopment,
+      devTools: true,
       webSecurity: false,
       nodeIntegration: true,
       contextIsolation: false,


### PR DESCRIPTION
### PR Checklist

> For any questions, see our [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### Current Behavior

DevTools are disabled by default in both development and production builds.  
When a white screen or rendering error occurs, contributors cannot open the console, inspect network traffic, or profile performance, making root-cause analysis slow and screenshot-dependent.

#### Issue Number

<!-- Example: Fixes #123 -->
Fixes：

#### New Behavior

- Production builds keep the shortcut **Ctrl + Shift + I / Cmd + Opt + I** to allow on-site debugging.

<img width="1460" alt="image" src="https://github.com/user-attachments/assets/656183a4-20bc-4366-9b0a-22cb5c20978b" />


#### Breaking Changes?

- [ ] Yes
- [x] No

#### Other Information

- DevTools load only when explicitly enabled, so default performance and bundle size remain unchanged.
- A future improvement could capture `console.error` messages and upload them automatically, reducing manual log collection.