### PR TITLE
fix(log): add no-drag region to select input on log page

### DIFF
--- a/src/views/log/index.vue
+++ b/src/views/log/index.vue
@@ -135,6 +135,9 @@ export default class Logs extends Vue {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    .el-select {
+      -webkit-app-region: no-drag;
+    }
   }
   .log-editor {
     height: 90%;


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The el-select dropdown in the log page has unexpected dragging behavior. When users try to click and select log levels, they may accidentally trigger window dragging operations, which affects user experience. In the Electron application, the titlebar area has the `-webkit-app-region: drag` property to support window dragging, causing child elements to inherit the dragging behavior.

#### Issue Number

Example: #123 (Please replace with actual issue number)

#### What is the new behavior?

After the fix, the el-select dropdown in the log page will only respond to click operations and no longer trigger accidental dragging behavior. Users can now normally click the dropdown to select different log levels (DEBUG, INFO, WARN, ERROR) without worrying about triggering drag operations.

The fix is implemented by adding the `-webkit-app-region: no-drag` CSS property to the el-select component, explicitly disabling dragging behavior for this element.

#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No