### PR TITLE
fix(log): add no-drag region to select input on log page

### DIFF
--- a/src/assets/scss/base.scss
+++ b/src/assets/scss/base.scss
@@ -22,10 +22,6 @@ body {
   color: var(--color-text-default);
 }
 
-body::-webkit-scrollbar {
-  display: none;
-}
-
 body.select-none {
   -moz-user-select: none;
   -khtml-user-select: none;
@@ -37,18 +33,15 @@ body.select-none {
   :focus {
     outline: none;
   }
-  &::-webkit-scrollbar {
-    width: 8px;
-    height: 8px;
-  }
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-bg-scrollbar) transparent;
+
   &::-webkit-scrollbar-track {
-    width: 8px;
+    background: transparent;
   }
   &::-webkit-scrollbar-thumb {
     border-radius: 4px;
     background: var(--color-bg-scrollbar);
-    width: 8px;
-    height: 8px;
   }
   &::-webkit-scrollbar-corner {
     background: transparent;

--- a/src/components/KeyValueEditor.vue
+++ b/src/components/KeyValueEditor.vue
@@ -159,7 +159,7 @@ export default class KeyValueEditor extends Vue {
     align-items: center;
   }
   .editor-row {
-    overflow-y: scroll;
+    overflow: scroll;
     white-space: nowrap;
     .editor-row {
       overflow: hidden;
@@ -175,10 +175,6 @@ export default class KeyValueEditor extends Vue {
           padding: 4px 15px;
           background: transparent;
           border-radius: 4px;
-          overflow-y: hidden;
-          &:hover {
-            overflow-y: overlay;
-          }
         }
       }
     }

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -128,25 +128,7 @@ export default class MessageList extends Vue {
 .message-list {
   padding: 0 16px;
   overflow-x: hidden;
-  overflow-y: overlay;
-  &.scrolling {
-    &::-webkit-scrollbar {
-      width: 8px;
-    }
-    &::-webkit-scrollbar-track {
-      width: 8px;
-    }
-    &::-webkit-scrollbar-thumb {
-      border-radius: 4px;
-      background: var(--color-bg-scrollbar);
-      width: 8px;
-    }
-  }
-  &.still {
-    &::-webkit-scrollbar {
-      display: none;
-    }
-  }
+  overflow: scroll;
 
   .loading-icon {
     position: absolute;

--- a/src/components/ai/CopilotMessages.vue
+++ b/src/components/ai/CopilotMessages.vue
@@ -185,9 +185,7 @@ body.night {
     padding: 16px;
     padding-bottom: 0px;
     margin-bottom: 82px;
-    &:hover {
-      overflow-y: overlay;
-    }
+    overflow: scroll;
     .chat-title {
       color: var(--color-text-light);
       i {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

After upgrading to Electron 33.0.0, scrollbars cause layout width issues when they appear/disappear. The content area width jumps when scrollbars are shown or hidden, creating a jarring user experience. This is caused by the fixed `width: 8px` setting in the global scrollbar styles conflicting with the new Chromium layout calculation mechanism.

#### Issue Number

Example: #123 (if there's a related issue)

#### What is the new behavior?

Replaced fixed-width scrollbar styling with modern CSS properties:
- Removed `width: 8px` and `height: 8px` from `-webkit-scrollbar` rules to prevent layout conflicts
- Added `scrollbar-width: thin` for better cross-browser compatibility
- Added `scrollbar-color: var(--color-bg-scrollbar) transparent` for consistent theming
- Maintained visual styling (border-radius, background color) while allowing the browser to control scrollbar dimensions

The layout now remains stable when scrollbars appear/disappear, while still providing a visually appealing scrollbar design.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Specific Instructions

This change affects the global scrollbar styling. Please test scrolling behavior in different areas of the application:
- Connection list sidebar
- Message list
- Subscription topics list
- AI copilot chat
- Any other scrollable containers

Verify that:
1. Layout no longer jumps when scrollbars appear/disappear
2. Scrollbars still have the custom styling (colors, rounded corners)
3. Scrolling performance remains smooth

#### Other information

This fix specifically addresses compatibility issues with Electron 33.0.0 and newer Chromium versions. The modern CSS scrollbar properties (`scrollbar-width`, `scrollbar-color`) are now supported in Chromium and provide better layout stability compared to the legacy `-webkit-scrollbar-width` approach.