### PR TITLE
feat(desktop): add highlighting on active topic and payload search

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -11,10 +11,17 @@
           v-if="!item.out"
           :key="item.id"
           :msgId="item.id"
+          :searchParams="searchParams"
           v-bind="item"
           @showmenu="handleShowContextMenu(arguments, item)"
         />
-        <MsgRightItem v-else :key="item.id" v-bind="item" @showmenu="handleShowContextMenu(arguments, item)" />
+        <MsgRightItem
+          v-else
+          :key="item.id"
+          :searchParams="searchParams"
+          v-bind="item"
+          @showmenu="handleShowContextMenu(arguments, item)"
+        />
       </template>
     </div>
     <span v-show="showAfterLoadingIcon" class="loading-icon after"><i class="el-icon-loading"></i></span>
@@ -40,6 +47,10 @@ export default class MessageList extends Vue {
   @Prop({ required: true }) height!: number
   @Prop({ required: true }) subscriptions!: SubscriptionModel[]
   @Prop({ required: true }) marginTop!: number
+  @Prop({ required: false, default: () => ({ topic: '', payload: '' }) }) searchParams!: {
+    topic: string
+    payload: string
+  }
 
   public showMessages: MessageModel[] = []
   public showBeforeLoadingIcon: boolean = false

--- a/src/components/MsgRightItem.vue
+++ b/src/components/MsgRightItem.vue
@@ -16,11 +16,11 @@
     </div>
     <div class="right-payload payload" @contextmenu.prevent="customMenu($event)">
       <p class="right-info">
-        <span class="topic">Topic: {{ topic }}</span>
+        <span class="topic">Topic: <span v-html="highlightedTopic"></span></span>
         <span class="qos">QoS: {{ qos }}</span>
       </p>
       <MqttProperties class="meta" :properties="properties" direction="right" />
-      <pre>{{ payload }}</pre>
+      <pre v-html="highlightedPayload"></pre>
     </div>
     <p class="right-time time">{{ createAt }}</p>
   </div>
@@ -29,19 +29,38 @@
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
 import MqttProperties from './MqttProperties.vue'
+import { highlightSearchTerm } from '@/utils/highlightSearch'
 
 @Component({
   components: {
     MqttProperties,
   },
 })
-export default class MsgrightItem extends Vue {
+export default class MsgRightItem extends Vue {
   @Prop({ required: true }) public topic!: string
   @Prop({ required: true }) public qos!: number
   @Prop({ required: true }) public payload!: string
   @Prop({ required: true }) public createAt!: string
   @Prop({ required: false }) public meta?: string
   @Prop({ required: false, default: () => ({}) }) public properties!: PushPropertiesModel
+  @Prop({ required: false, default: () => ({ topic: '', payload: '' }) }) public searchParams!: {
+    topic: string
+    payload: string
+  }
+
+  get highlightedTopic(): string {
+    if (this.searchParams.topic) {
+      return highlightSearchTerm(this.topic, this.searchParams.topic, 'search-highlight')
+    }
+    return this.topic
+  }
+
+  get highlightedPayload(): string {
+    if (this.searchParams.payload) {
+      return highlightSearchTerm(this.payload, this.searchParams.payload, 'search-highlight')
+    }
+    return this.payload
+  }
 
   public customMenu(event: MouseEvent) {
     this.$emit('showmenu', this.payload, event)
@@ -80,6 +99,13 @@ export default class MsgrightItem extends Vue {
       color: var(--color-text-active) !important;
       border: 1px solid var(--color-border-right_metainfo) !important;
     }
+  }
+  .search-highlight {
+    background-color: #ffeb3b !important;
+    color: #000 !important;
+    padding: 1px 2px;
+    border-radius: 2px;
+    font-weight: bold;
   }
 }
 </style>

--- a/src/utils/highlightSearch.ts
+++ b/src/utils/highlightSearch.ts
@@ -1,0 +1,68 @@
+/**
+ * Highlights search terms in text while preserving HTML structure
+ * @param text - The text to highlight
+ * @param searchTerm - The term to search for
+ * @param className - CSS class for highlighting
+ * @returns HTML string with highlighted terms
+ */
+export function highlightSearchTerm(text: string, searchTerm: string, className: string = 'search-highlight'): string {
+  if (!searchTerm || !text) {
+    return escapeHtml(text)
+  }
+
+  const escapedText = escapeHtml(text)
+  const escapedSearchTerm = escapeRegExp(searchTerm)
+  const regex = new RegExp(`(${escapedSearchTerm})`, 'gi')
+
+  return escapedText.replace(regex, `<span class="${className}">$1</span>`)
+}
+
+/**
+ * Highlights search terms in JSON-highlighted code
+ * @param element - The DOM element containing Prism-highlighted code
+ * @param searchTerm - The term to search for
+ * @param className - CSS class for highlighting
+ */
+export function highlightInPrismCode(
+  element: HTMLElement,
+  searchTerm: string,
+  className: string = 'search-highlight',
+): void {
+  if (!searchTerm || !element) return
+
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node: Node) => NodeFilter.FILTER_ACCEPT,
+  })
+
+  const textNodes: Text[] = []
+  let node: Node | null
+
+  while ((node = walker.nextNode())) {
+    textNodes.push(node as Text)
+  }
+
+  textNodes.forEach((textNode) => {
+    const text = textNode.textContent || ''
+    if (text.toLowerCase().includes(searchTerm.toLowerCase())) {
+      const highlightedHTML = highlightSearchTerm(text, searchTerm, className)
+      const tempDiv = document.createElement('div')
+      tempDiv.innerHTML = highlightedHTML
+
+      const fragment = document.createDocumentFragment()
+      while (tempDiv.firstChild) {
+        fragment.appendChild(tempDiv.firstChild)
+      }
+      textNode.parentNode?.replaceChild(fragment, textNode)
+    }
+  })
+}
+
+function escapeHtml(text: string): string {
+  const div = document.createElement('div')
+  div.textContent = text
+  return div.innerHTML
+}
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -277,6 +277,7 @@
           :messages="recordMsgs.list"
           :height="messageListHeight"
           :marginTop="messageListMarginTop"
+          :searchParams="searchParams"
           @showContextMenu="handleContextMenu"
           @loadMoreMsg="loadMoreMessages"
           @hideNewMsgsTip="hideNewMsgsTip"
@@ -2201,6 +2202,17 @@ export default class ConnectionsDetail extends Vue {
     window.removeEventListener('resize', () => {
       this.setMessageListHeight()
     })
+  }
+
+  get activeSearchTerms() {
+    const terms = []
+    if (this.searchParams.payload && this.searchParams.payload.trim()) {
+      terms.push(this.searchParams.payload.trim())
+    }
+    if (this.searchParams.topic && this.searchParams.topic.trim()) {
+      terms.push(this.searchParams.topic.trim())
+    }
+    return terms
   }
 }
 </script>


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

Currently, when searching through messages in MQTTX, there is no highlighting of matching text.

#### Issue Number

#1854 

#### What is the new behavior?

The search functionality now highlights the active payload in message items.

#### Preview
![image](https://github.com/user-attachments/assets/2c6e2d67-fbcf-4977-884d-59356223d624)

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
