### PR TITLE
fix(MsgItem): correct highlight logic to handle payload when no search params

### DIFF
--- a/src/components/MsgLeftItem.vue
+++ b/src/components/MsgLeftItem.vue
@@ -51,7 +51,8 @@
         </div>
       </template>
       <template v-else>
-        <pre v-if="!hightlight" v-html="highlightedPayload"></pre>
+        <pre v-if="!highlight && !searchParams.payload">{{ highlightedPayload }}</pre>
+        <pre v-else-if="!highlight" v-html="highlightedPayload"></pre>
         <pre v-else ref="highlightedCode"><code class="language-js">{{ payload }}</code></pre>
       </template>
     </div>
@@ -93,7 +94,7 @@ export default class MsgLeftItem extends Vue {
   @Getter('jsonHighlight') private jsonHighlight!: boolean
   @Getter('currentTheme') private theme!: Theme
 
-  public hightlight: boolean = false
+  public highlight: boolean = false
 
   private showFullMsg: boolean = false
 
@@ -166,7 +167,7 @@ export default class MsgLeftItem extends Vue {
   }
 
   private applyHighlighting() {
-    if (this.hightlight && this.searchParams.payload) {
+    if (this.highlight && this.searchParams.payload) {
       const codeElement = this.$refs.highlightedCode as HTMLElement
       if (codeElement) {
         this.clearHighlights(codeElement)
@@ -186,20 +187,20 @@ export default class MsgLeftItem extends Vue {
     })
   }
 
-  private hightlightJSON() {
+  private highlightJSON() {
     if (this.jsonHighlight === false) {
       return
     }
     try {
       if (this.payload && ['JSON', 'CBOR', 'MsgPack'].includes(this.msgType) && !this.msgError) {
-        this.hightlight = true
+        this.highlight = true
         this.$nextTick(() => {
           Prism.highlightAllUnder(this.$refs.msgLeftItem as HTMLElement)
           this.applyHighlighting()
         })
       }
     } catch (e) {
-      this.hightlight = false
+      this.highlight = false
     }
   }
 
@@ -208,7 +209,7 @@ export default class MsgLeftItem extends Vue {
   }
 
   private mounted() {
-    this.hightlightJSON()
+    this.highlightJSON()
   }
 }
 </script>

--- a/src/components/MsgRightItem.vue
+++ b/src/components/MsgRightItem.vue
@@ -20,7 +20,8 @@
         <span class="qos">QoS: {{ qos }}</span>
       </p>
       <MqttProperties class="meta" :properties="properties" direction="right" />
-      <pre v-html="highlightedPayload"></pre>
+      <pre v-if="!searchParams.payload">{{ highlightedPayload }}</pre>
+      <pre v-else v-html="highlightedPayload"></pre>
     </div>
     <p class="right-time time">{{ createAt }}</p>
   </div>

--- a/src/utils/highlightSearch.ts
+++ b/src/utils/highlightSearch.ts
@@ -7,14 +7,20 @@
  */
 export function highlightSearchTerm(text: string, searchTerm: string, className: string = 'search-highlight'): string {
   if (!searchTerm || !text) {
-    return escapeHtml(text)
+    return text
   }
 
-  const escapedText = escapeHtml(text)
   const escapedSearchTerm = escapeRegExp(searchTerm)
   const regex = new RegExp(`(${escapedSearchTerm})`, 'gi')
-
-  return escapedText.replace(regex, `<span class="${className}">$1</span>`)
+  const parts = text.split(regex)
+  const processedParts = parts.map((part, index) => {
+    if (index % 2 === 1) {
+      return `<span class="${className}">${escapeHtml(part)}</span>`
+    } else {
+      return escapeHtml(part)
+    }
+  })
+  return processedParts.join('')
 }
 
 /**


### PR DESCRIPTION
# Handle highlighting when no search parameters and fix typos

### PR Checklist

#### What is the current behavior?

Broken display for messages consisting of tags

#### Issue Number

Fixes #1963 

#### What is the new behavior?

Fixes the render of messages, XML tags and special characters now highlight correctly when searched. The `highlightSearchTerm` function now searches in original text. 

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
