### PR TITLE
Feat/json tree viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "vue-click-outside": "^1.1.0",
     "vue-clipboard2": "^0.3.1",
     "vue-i18n": "^8.11.2",
+    "vue-json-tree-view": "^2.1.6",
     "vue-markdown": "^2.2.4",
     "vue-property-decorator": "^8.5.1",
     "vue-router": "^3.4.9",

--- a/src/assets/scss/mixins.scss
+++ b/src/assets/scss/mixins.scss
@@ -181,3 +181,13 @@
     }
   }
 }
+
+@mixin search-highlight {
+  .search-highlight {
+    background-color: #ffeb3b !important;
+    color: #000 !important;
+    padding: 1px 2px;
+    border-radius: 2px;
+    font-weight: bold;
+  }
+}

--- a/src/components/MsgLeftItem.vue
+++ b/src/components/MsgLeftItem.vue
@@ -225,6 +225,7 @@ body.night {
 
 .msg-left-item {
   @include msg-item;
+  @include search-highlight;
   text-align: left;
   position: relative;
   .msg-tag:nth-child(2) {
@@ -267,13 +268,6 @@ body.night {
         color: var(--color-text-default);
       }
     }
-  }
-  .search-highlight {
-    background-color: #ffeb3b !important;
-    color: #000 !important;
-    padding: 1px 2px;
-    border-radius: 2px;
-    font-weight: bold;
   }
 }
 </style>

--- a/src/components/charts/TreeVisual.vue
+++ b/src/components/charts/TreeVisual.vue
@@ -128,20 +128,31 @@ export default class TreeVisual extends Vue {
   }
 
   private addJsonFeatures(baseOption: any, baseSeries: any) {
-    const rich = {
-      key: { color: '#2563eb', fontWeight: 'bold' },
-      string: { color: '#7c3aed' },
-      number: { color: '#065f46' },
-      boolean: { color: '#0d9488' },
-      null: { color: '#6b7280' },
-      meta: { color: '#1f2937' },
-    }
+    const isLightTheme = this.theme === 'light'
+
+    const rich = isLightTheme
+      ? {
+          key: { color: '#2563eb', fontWeight: 'bold' },
+          string: { color: '#7c3aed' },
+          number: { color: '#065f46' },
+          boolean: { color: '#0d9488' },
+          null: { color: '#6b7280' },
+          meta: { color: '#1f2937' },
+        }
+      : {
+          key: { color: '#93c5fd', fontWeight: 'bold' },
+          string: { color: '#c4b5fd' },
+          number: { color: '#86efac' },
+          boolean: { color: '#5eead4' },
+          null: { color: '#9ca3af' },
+          meta: { color: '#e5e7eb' },
+        }
 
     const jsonLabelStyle = {
       distance: 8,
       fontFamily: 'monospace',
-      backgroundColor: '#ffffff',
-      borderColor: '#cbd5e1',
+      backgroundColor: isLightTheme ? '#ffffff' : '#111827',
+      borderColor: isLightTheme ? '#cbd5e1' : '#475569',
       borderWidth: 1,
       borderRadius: 8,
       padding: [6, 8],
@@ -175,7 +186,7 @@ export default class TreeVisual extends Vue {
           orient: 'LR',
           roam: true,
           scaleLimit: { min: 0.1, max: 3 },
-          lineStyle: { width: 1.5, color: '#94a3b8' },
+          lineStyle: { width: 1.5, color: isLightTheme ? '#94a3b8' : '#64748b' },
           edgeShape: 'curve',
           edgeForkPosition: '60%',
           label: {

--- a/src/components/charts/TreeVisual.vue
+++ b/src/components/charts/TreeVisual.vue
@@ -6,11 +6,11 @@
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator'
 import { Getter } from 'vuex-class'
 import * as echarts from 'echarts/core'
-import { TooltipComponent, LegendComponent } from 'echarts/components'
+import { TooltipComponent, LegendComponent, DataZoomComponent } from 'echarts/components'
 import { TreeChart } from 'echarts/charts'
 import { CanvasRenderer } from 'echarts/renderers'
 
-echarts.use([TooltipComponent, LegendComponent, TreeChart, CanvasRenderer])
+echarts.use([TooltipComponent, LegendComponent, DataZoomComponent, TreeChart, CanvasRenderer])
 
 @Component
 export default class TreeVisual extends Vue {
@@ -22,6 +22,9 @@ export default class TreeVisual extends Vue {
   @Prop({ default: 'transparent' }) public backgroundColor!: string
   @Prop({ default: () => ({}) }) public tooltipFormatter!: (params: any) => string | Record<string, any>
   @Prop({ default: 4 }) public defaultExpandLevel!: number
+  // Add new props for JSON mode
+  @Prop({ default: false }) public isJsonMode!: boolean
+  @Prop({ default: false }) public enableZoom!: boolean
 
   @Getter('currentTheme') private theme!: string
 
@@ -37,12 +40,34 @@ export default class TreeVisual extends Vue {
     this.updateChart()
   }
 
+  @Watch('isJsonMode')
+  private onJsonModeChanged() {
+    this.updateChart()
+  }
+
+  @Watch('enableZoom')
+  private onZoomChanged() {
+    this.updateChart()
+  }
+
   private generateChartOption() {
     const isLightTheme = this.theme === 'light'
     const textColor = isLightTheme ? '#616161' : '#e6e8f1'
     const backgroundColor = isLightTheme ? '#fff' : this.theme === 'dark' ? '#262729' : '#292b33'
 
-    return {
+    // Common series configuration
+    const baseSeries = {
+      type: 'tree',
+      data: [this.data],
+      symbolSize: this.symbolSize,
+      initialTreeDepth: this.defaultExpandLevel,
+      expandAndCollapse: true,
+      animationDuration: 550,
+      animationDurationUpdate: 750,
+    }
+
+    // Base option for regular tree mode
+    const baseOption = {
       backgroundColor: this.backgroundColor,
       tooltip: {
         trigger: 'item',
@@ -52,10 +77,7 @@ export default class TreeVisual extends Vue {
       },
       series: [
         {
-          type: 'tree',
-          data: [this.data],
-          symbolSize: this.symbolSize,
-          initialTreeDepth: this.defaultExpandLevel,
+          ...baseSeries,
           itemStyle: {
             color: '#53daa2',
             borderColor: '#53daa2',
@@ -90,13 +112,90 @@ export default class TreeVisual extends Vue {
               color: '#53daa2',
             },
           },
-          expandAndCollapse: true,
-          animationDuration: 550,
-          animationDurationUpdate: 750,
           left: '130px',
           right: '130px',
           top: 0,
           bottom: 0,
+        },
+      ],
+    }
+
+    if (this.isJsonMode) {
+      return this.addJsonFeatures(baseOption, baseSeries)
+    }
+
+    return baseOption
+  }
+
+  private addJsonFeatures(baseOption: any, baseSeries: any) {
+    const rich = {
+      key: { color: '#2563eb', fontWeight: 'bold' },
+      string: { color: '#7c3aed' },
+      number: { color: '#065f46' },
+      boolean: { color: '#0d9488' },
+      null: { color: '#6b7280' },
+      meta: { color: '#1f2937' },
+    }
+
+    const jsonLabelStyle = {
+      distance: 8,
+      fontFamily: 'monospace',
+      backgroundColor: '#ffffff',
+      borderColor: '#cbd5e1',
+      borderWidth: 1,
+      borderRadius: 8,
+      padding: [6, 8],
+      rich,
+      formatter: (params: any) => params.data.name,
+    }
+
+    return {
+      ...baseOption,
+      dataZoom: this.enableZoom
+        ? [
+            {
+              type: 'inside',
+              orient: 'horizontal',
+              start: 0,
+              end: 100,
+              zoomLock: false,
+            },
+            {
+              type: 'inside',
+              orient: 'vertical',
+              start: 0,
+              end: 100,
+              zoomLock: false,
+            },
+          ]
+        : undefined,
+      series: [
+        {
+          ...baseSeries,
+          orient: 'LR',
+          roam: true,
+          scaleLimit: { min: 0.1, max: 3 },
+          lineStyle: { width: 1.5, color: '#94a3b8' },
+          edgeShape: 'curve',
+          edgeForkPosition: '60%',
+          label: {
+            ...jsonLabelStyle,
+            position: 'left',
+            verticalAlign: 'middle',
+            align: 'right',
+          },
+          leaves: {
+            label: {
+              ...jsonLabelStyle,
+              position: 'right',
+              verticalAlign: 'middle',
+              align: 'left',
+            },
+          },
+          emphasis: {
+            focus: 'descendant',
+          },
+          right: '250px',
         },
       ],
     }
@@ -113,7 +212,20 @@ export default class TreeVisual extends Vue {
   public updateChart() {
     if (this.chart) {
       const option = this.generateChartOption()
-      this.chart.setOption(option)
+      this.chart.setOption(option, true)
+
+      // Auto-fit for JSON mode
+      if (this.isJsonMode) {
+        setTimeout(() => {
+          if (this.chart) {
+            this.chart.dispatchAction({
+              type: 'dataZoom',
+              start: 0,
+              end: 100,
+            })
+          }
+        }, 100)
+      }
     }
   }
 

--- a/src/lang/viewer.ts
+++ b/src/lang/viewer.ts
@@ -20,6 +20,20 @@ export default {
     ja: 'ペイロードインスペクター',
     hu: 'Üzenetgövde figyelő',
   },
+  diffView: {
+    zh: '差异视图',
+    en: 'Diff View',
+    tr: 'Fark Görünümü',
+    ja: '差分ビュー',
+    hu: 'Különbség nézet',
+  },
+  jsonTree: {
+    zh: 'JSON 树',
+    en: 'JSON Tree',
+    tr: 'JSON Ağacı',
+    ja: 'JSON ツリー',
+    hu: 'JSON fa',
+  },
   invalidJsonFormat: {
     zh: '无效的 JSON 格式',
     en: 'Invalid JSON format',
@@ -95,12 +109,33 @@ export default {
     ja: 'トピックツリーを視覚化',
     hu: 'Témafa vizualizálása',
   },
+  visualizeJsonTree: {
+    zh: '可视化 JSON 树',
+    en: 'Visualize JSON Tree',
+    tr: 'JSON Ağacını Görselleştir',
+    ja: 'JSON ツリーを視覚化',
+    hu: 'JSON fa vizualizálása',
+  },
+  visualize: {
+    zh: '可视化',
+    en: 'Visualize',
+    tr: 'Görselleştir',
+    ja: '視覚化',
+    hu: 'Vizualizálás',
+  },
   visualizeTreeTooltip: {
     zh: '选择根节点并设置展开层级来可视化主题树。点击节点可展开或折叠子主题。',
     en: 'Select a root node and set the expand level to visualize the topic tree. Click on nodes to expand or collapse subtopics.',
     tr: 'Konu ağacını görselleştirmek için bir kök düğüm seçin ve genişletme seviyesini ayarlayın. Alt konuları genişletmek veya daraltmak için düğümlere tıklayın.',
     ja: 'ルートノードを選択し、展開レベルを設定してトピックツリーを視覚化します。ノードをクリックしてサブトピックを展開または折りたたみます。',
     hu: 'Válasszon egy gyökércsomópontot és állítsa be a kibontási szintet a témafa vizualizálásához. Kattintson a csomópontokra az altémák kibontásához vagy összecsukásához.',
+  },
+  visualizeJsonTreeTooltip: {
+    zh: '设置展开层级以可视化 JSON 树。点击节点可展开或折叠子树。',
+    en: 'Set the expand level to visualize the JSON tree. Click on nodes to expand or collapse subtree.',
+    tr: 'JSON ağacını görselleştirmek için genişletme seviyesini ayarlayın. Alt ağaçları genişletmek veya daraltmak için düğümlere tıklayın.',
+    ja: '展開レベルを設定して JSON ツリーを視覚化します。ノードをクリックしてサブツリーを展開または折りたたみます。',
+    hu: 'Állítsa be a kibontási szintet a JSON fa vizualizálásához. Kattintson a csomópontokra az alfa kibontásához vagy összecsukásához.',
   },
   trafficMonitor: {
     zh: '流量监控',
@@ -199,6 +234,13 @@ export default {
     tr: 'Mesaj Geçmişi',
     ja: 'メッセージ履歴',
     hu: 'Üzenet történet',
+  },
+  messageJsonViewer: {
+    zh: '消息 JSON 查看器',
+    en: 'Message JSON Viewer',
+    tr: 'Mesaj JSON Görüntüleyici',
+    ja: 'メッセージ JSON ビューア',
+    hu: 'Üzenet JSON Megjelenítő',
   },
   previous: {
     zh: '上一个:',

--- a/src/lang/viewer.ts
+++ b/src/lang/viewer.ts
@@ -34,6 +34,13 @@ export default {
     ja: 'JSON ツリー',
     hu: 'JSON fa',
   },
+  searchInJson: {
+    zh: '在 JSON 中搜索',
+    en: 'Search in JSON',
+    tr: 'JSON da arama',
+    ja: 'JSON で検索',
+    hu: 'JSON-ban keresés',
+  },
   invalidJsonFormat: {
     zh: '无效的 JSON 格式',
     en: 'Invalid JSON format',
@@ -131,11 +138,11 @@ export default {
     hu: 'Válasszon egy gyökércsomópontot és állítsa be a kibontási szintet a témafa vizualizálásához. Kattintson a csomópontokra az altémák kibontásához vagy összecsukásához.',
   },
   visualizeJsonTreeTooltip: {
-    zh: '设置展开层级以可视化 JSON 树。点击节点可展开或折叠子树。',
-    en: 'Set the expand level to visualize the JSON tree. Click on nodes to expand or collapse subtree.',
-    tr: 'JSON ağacını görselleştirmek için genişletme seviyesini ayarlayın. Alt ağaçları genişletmek veya daraltmak için düğümlere tıklayın.',
-    ja: '展開レベルを設定して JSON ツリーを視覚化します。ノードをクリックしてサブツリーを展開または折りたたみます。',
-    hu: 'Állítsa be a kibontási szintet a JSON fa vizualizálásához. Kattintson a csomópontokra az alfa kibontásához vagy összecsukásához.',
+    zh: '设置展开层级以可视化 JSON 树。点击节点可展开或折叠子树。右键点击可复制子树为 JSON。',
+    en: 'Set the expand level to visualize the JSON tree. Click on nodes to expand or collapse subtree. Right click to copy subtree as JSON.',
+    tr: 'JSON ağacını görselleştirmek için genişletme seviyesini ayarlayın. Alt ağaçları genişletmek veya daraltmak için düğümlere tıklayın. Alt ağacı JSON olarak kopyalamak için sağ tıklayın.',
+    ja: '展開レベルを設定して JSON ツリーを視覚化します。ノードをクリックしてサブツリーを展開または折りたたみます。右クリックでサブツリーをJSONとしてコピーします。',
+    hu: 'Állítsa be a kibontási szintet a JSON fa vizualizálásához. Kattintson a csomópontokra az alfa kibontásához vagy összecsukásához. Jobb kattintással másolja az alfát JSON-ként.',
   },
   trafficMonitor: {
     zh: '流量监控',

--- a/src/types/vue-json-tree-view.d.ts
+++ b/src/types/vue-json-tree-view.d.ts
@@ -1,0 +1,24 @@
+declare module 'vue-json-tree-view/src/TreeView.vue' {
+  import Vue from 'vue'
+
+  interface TreeViewOptions {
+    maxDepth?: number
+    rootObjectKey?: string
+    modifiable?: boolean
+    link?: boolean
+    limitRenderDepth?: boolean
+  }
+
+  interface TreeViewEvents {
+    'change-data': (data: any) => void
+  }
+
+  class TreeView extends Vue {
+    data: any
+    options: TreeViewOptions
+
+    $emit(event: 'change-data', data: any): this
+  }
+
+  export default TreeView
+}

--- a/src/utils/jsonTreeConverter.ts
+++ b/src/utils/jsonTreeConverter.ts
@@ -26,7 +26,7 @@ export class JsonTreeConverter {
   }
 
   private static valBadge(v: any): string {
-    const t = this.valueType(v)
+    const t = JsonTreeConverter.valueType(v)
     if (t === 'string') return `{string|"${v}"}`
     if (t === 'number') return `{number|${String(v)}}`
     if (t === 'boolean') return `{boolean|${String(v)}}`
@@ -60,7 +60,7 @@ export class JsonTreeConverter {
 
   static convertJsonToTreeData(value: any, key: string = 'root', path: string = ''): JsonTreeNode {
     const id = path || key
-    const t = this.valueType(value)
+    const t = JsonTreeConverter.valueType(value)
 
     const node: JsonTreeNode = {
       id,
@@ -69,31 +69,32 @@ export class JsonTreeConverter {
       raw: value,
       name: '',
       itemStyle: {
-        color: this.colorForType(t),
+        color: JsonTreeConverter.colorForType(t),
         borderColor: '#cbd5e1',
         borderWidth: 1,
         borderRadius: 8,
       },
-      label: { color: '#1f2937', fontSize: 12 },
+      label: {},
     }
 
     if (t === 'object') {
       const c = Object.keys(value).length
-      node.name = `${this.keyBadge(key)} ${this.typeBadge('{' + c + '}')}`
+      node.name = `${JsonTreeConverter.keyBadge(key)} ${JsonTreeConverter.typeBadge('{' + c + '}')}`
     } else if (t === 'array') {
-      node.name = `${this.keyBadge(key)} ${this.typeBadge('[' + value.length + ']')}`
+      node.name = `${JsonTreeConverter.keyBadge(key)} ${JsonTreeConverter.typeBadge('[' + value.length + ']')}`
     } else {
-      node.name = `${this.keyBadge(key)}: ${this.valBadge(value)}`
+      node.name = `${JsonTreeConverter.keyBadge(key)}: ${JsonTreeConverter.valBadge(value)}`
     }
 
     if (t === 'object') {
       const entries = Object.entries(value)
       const primitiveObject: any = {}
       const nonPrimitiveChildren: JsonTreeNode[] = []
+      const basePath = path || key
       entries.forEach(([k, v]) => {
-        const vt = this.valueType(v)
+        const vt = JsonTreeConverter.valueType(v)
         if (vt === 'object' || vt === 'array') {
-          nonPrimitiveChildren.push(this.convertJsonToTreeData(v, k, `${path}.${k}`))
+          nonPrimitiveChildren.push(JsonTreeConverter.convertJsonToTreeData(v, k, `${basePath}.${k}`))
         } else {
           primitiveObject[k] = v
         }
@@ -106,9 +107,16 @@ export class JsonTreeConverter {
           key: '(primitives)',
           vtype: 'group',
           raw: primitiveObject,
-          name: primitiveKeys.map((k) => `${this.keyBadge(k)}: ${this.valBadge(primitiveObject[k])}`).join('\n'),
-          itemStyle: { color: this.colorForType('group'), borderColor: '#cbd5e1', borderWidth: 1, borderRadius: 8 },
-          label: { color: '#1f2937', fontSize: 12 },
+          name: primitiveKeys
+            .map((k) => `${JsonTreeConverter.keyBadge(k)}: ${JsonTreeConverter.valBadge(primitiveObject[k])}`)
+            .join('\n'),
+          itemStyle: {
+            color: JsonTreeConverter.colorForType('group'),
+            borderColor: '#cbd5e1',
+            borderWidth: 1,
+            borderRadius: 8,
+          },
+          label: {},
         })
       }
       children.push(...nonPrimitiveChildren)
@@ -116,10 +124,11 @@ export class JsonTreeConverter {
     } else if (t === 'array') {
       const primitiveArray: any[] = []
       const complexChildren: JsonTreeNode[] = []
+      const basePath = path || key
       value.forEach((v: any, i: number) => {
-        const vt = this.valueType(v)
+        const vt = JsonTreeConverter.valueType(v)
         if (vt === 'object' || vt === 'array') {
-          complexChildren.push(this.convertJsonToTreeData(v, String(i), `${path}.${i}`))
+          complexChildren.push(JsonTreeConverter.convertJsonToTreeData(v, String(i), `${basePath}.${i}`))
         } else {
           primitiveArray.push({ index: i, value: v })
         }
@@ -131,9 +140,16 @@ export class JsonTreeConverter {
           key: '(primitives)',
           vtype: 'group',
           raw: primitiveArray.map((p) => p.value),
-          name: primitiveArray.map((p) => `${this.keyBadge(String(p.index))}: ${this.valBadge(p.value)}`).join('\n'),
-          itemStyle: { color: this.colorForType('group'), borderColor: '#cbd5e1', borderWidth: 1, borderRadius: 8 },
-          label: { color: '#1f2937', fontSize: 12 },
+          name: primitiveArray
+            .map((p) => `${JsonTreeConverter.keyBadge(String(p.index))}: ${JsonTreeConverter.valBadge(p.value)}`)
+            .join('\n'),
+          itemStyle: {
+            color: JsonTreeConverter.colorForType('group'),
+            borderColor: '#cbd5e1',
+            borderWidth: 1,
+            borderRadius: 8,
+          },
+          label: {},
         })
       }
       children.push(...complexChildren)

--- a/src/utils/jsonTreeConverter.ts
+++ b/src/utils/jsonTreeConverter.ts
@@ -1,0 +1,145 @@
+export interface JsonTreeNode {
+  id: string
+  key: string
+  vtype: string
+  raw: any
+  name: string
+  children?: JsonTreeNode[]
+  itemStyle?: any
+  label?: any
+}
+
+export class JsonTreeConverter {
+  private static valueType(v: any): string {
+    if (v === null) return 'null'
+    if (Array.isArray(v)) return 'array'
+    if (typeof v === 'object') return 'object'
+    return typeof v
+  }
+
+  private static keyBadge(text: string): string {
+    return `{key|${text}}`
+  }
+
+  private static typeBadge(text: string): string {
+    return `{meta|${text}}`
+  }
+
+  private static valBadge(v: any): string {
+    const t = this.valueType(v)
+    if (t === 'string') return `{string|"${v}"}`
+    if (t === 'number') return `{number|${String(v)}}`
+    if (t === 'boolean') return `{boolean|${String(v)}}`
+    if (t === 'null') return `{null|null}`
+    if (t === 'undefined') return `{null|undefined}`
+    if (t === 'array') return `{meta|Array[${v.length}]}`
+    if (t === 'object') return `{meta|Object{${Object.keys(v).length}}}`
+    return `{meta|${String(v)}}`
+  }
+
+  private static colorForType(t: string): string {
+    switch (t) {
+      case 'object':
+        return '#eef2ff'
+      case 'array':
+        return '#e0f2fe'
+      case 'string':
+        return '#ecfccb'
+      case 'number':
+        return '#fef3c7'
+      case 'boolean':
+        return '#dcfce7'
+      case 'null':
+        return '#f1f5f9'
+      case 'group':
+        return '#e7f3ff'
+      default:
+        return '#ffffff'
+    }
+  }
+
+  static convertJsonToTreeData(value: any, key: string = 'root', path: string = ''): JsonTreeNode {
+    const id = path || key
+    const t = this.valueType(value)
+
+    const node: JsonTreeNode = {
+      id,
+      key,
+      vtype: t,
+      raw: value,
+      name: '',
+      itemStyle: {
+        color: this.colorForType(t),
+        borderColor: '#cbd5e1',
+        borderWidth: 1,
+        borderRadius: 8,
+      },
+      label: { color: '#1f2937', fontSize: 12 },
+    }
+
+    if (t === 'object') {
+      const c = Object.keys(value).length
+      node.name = `${this.keyBadge(key)} ${this.typeBadge('{' + c + '}')}`
+    } else if (t === 'array') {
+      node.name = `${this.keyBadge(key)} ${this.typeBadge('[' + value.length + ']')}`
+    } else {
+      node.name = `${this.keyBadge(key)}: ${this.valBadge(value)}`
+    }
+
+    if (t === 'object') {
+      const entries = Object.entries(value)
+      const primitiveObject: any = {}
+      const nonPrimitiveChildren: JsonTreeNode[] = []
+      entries.forEach(([k, v]) => {
+        const vt = this.valueType(v)
+        if (vt === 'object' || vt === 'array') {
+          nonPrimitiveChildren.push(this.convertJsonToTreeData(v, k, `${path}.${k}`))
+        } else {
+          primitiveObject[k] = v
+        }
+      })
+      const children: JsonTreeNode[] = []
+      const primitiveKeys = Object.keys(primitiveObject)
+      if (primitiveKeys.length > 0) {
+        children.push({
+          id: path || key,
+          key: '(primitives)',
+          vtype: 'group',
+          raw: primitiveObject,
+          name: primitiveKeys.map((k) => `${this.keyBadge(k)}: ${this.valBadge(primitiveObject[k])}`).join('\n'),
+          itemStyle: { color: this.colorForType('group'), borderColor: '#cbd5e1', borderWidth: 1, borderRadius: 8 },
+          label: { color: '#1f2937', fontSize: 12 },
+        })
+      }
+      children.push(...nonPrimitiveChildren)
+      if (children.length > 0) node.children = children
+    } else if (t === 'array') {
+      const primitiveArray: any[] = []
+      const complexChildren: JsonTreeNode[] = []
+      value.forEach((v: any, i: number) => {
+        const vt = this.valueType(v)
+        if (vt === 'object' || vt === 'array') {
+          complexChildren.push(this.convertJsonToTreeData(v, String(i), `${path}.${i}`))
+        } else {
+          primitiveArray.push({ index: i, value: v })
+        }
+      })
+      const children: JsonTreeNode[] = []
+      if (primitiveArray.length > 0) {
+        children.push({
+          id: path || key,
+          key: '(primitives)',
+          vtype: 'group',
+          raw: primitiveArray.map((p) => p.value),
+          name: primitiveArray.map((p) => `${this.keyBadge(String(p.index))}: ${this.valBadge(p.value)}`).join('\n'),
+          itemStyle: { color: this.colorForType('group'), borderColor: '#cbd5e1', borderWidth: 1, borderRadius: 8 },
+          label: { color: '#1f2937', fontSize: 12 },
+        })
+      }
+      children.push(...complexChildren)
+      if (children.length > 0) node.children = children
+    }
+
+    return node
+  }
+}

--- a/src/utils/jsonUtils.ts
+++ b/src/utils/jsonUtils.ts
@@ -27,3 +27,32 @@ export const jsonStringify: typeof JSON.stringify = (...args: any[]) => {
     return JSONBigNumber.stringify(...args)
   }
 }
+
+/**
+ * Interface representing a node-like object for ECharts JSON tree.
+ * The node may contain a 'raw' property holding the original data,
+ * along with any other arbitrary properties.
+ */
+export interface EChartsJsonTreeNodeLike {
+  raw?: any
+  [key: string]: any
+}
+
+/**
+ * Stringifies the subtree of a given node-like object.
+ * If the object has a 'raw' property, it will be stringified;
+ * otherwise, the object itself is stringified.
+ *
+ * @param nodeLike - The node-like object to stringify.
+ * @param space - Number of spaces to use for indentation (default: 2).
+ * @returns The JSON string representation of the subtree.
+ */
+export function stringifySubtree(nodeLike: EChartsJsonTreeNodeLike, space: number = 2): string {
+  // Use the 'raw' property if it exists, otherwise use the node itself
+  const raw = nodeLike && Object.prototype.hasOwnProperty.call(nodeLike, 'raw') ? nodeLike.raw : nodeLike
+  try {
+    return jsonStringify(raw, null, space)
+  } catch (_err) {
+    return JSON.stringify(raw, null, space)
+  }
+}

--- a/src/views/viewer/PayloadInspector.vue
+++ b/src/views/viewer/PayloadInspector.vue
@@ -7,14 +7,14 @@
           :class="{ active: activeViewMode === 'diff' }"
           @click="activeViewMode = 'diff'"
         >
-          Diff View
+          {{ $t('viewer.diffView') }}
         </button>
         <button
           class="view-mode-button"
           :class="{ active: activeViewMode === 'tree' }"
           @click="activeViewMode = 'tree'"
         >
-          JSON Tree
+          {{ $t('viewer.jsonTree') }}
         </button>
       </div>
       <div class="control-group">

--- a/src/widgets/DiffView.vue
+++ b/src/widgets/DiffView.vue
@@ -30,30 +30,36 @@
 
     <div class="diff-content-wrapper" v-if="messages.length >= 2">
       <div class="navigation-controls">
-        <button
-          class="nav-button nav-button--prev"
-          :disabled="!canGoToPrevious && !hasMore"
-          @click="goToPrevious"
-          :title="$t('viewer.olderMessage')"
+        <el-tooltip
+          :effect="theme !== 'light' ? 'light' : 'dark'"
+          placement="bottom"
+          :open-delay="300"
+          :content="$t('viewer.olderMessage')"
         >
-          <i class="el-icon-arrow-left"></i>
-        </button>
-        <button
-          class="nav-button nav-button--next"
-          :disabled="!canGoToNext"
-          @click="goToNext"
-          :title="$t('viewer.newerMessage')"
+          <button class="nav-button nav-button--prev" :disabled="!canGoToPrevious && !hasMore" @click="goToPrevious">
+            <i class="el-icon-arrow-left"></i>
+          </button>
+        </el-tooltip>
+        <el-tooltip
+          :effect="theme !== 'light' ? 'light' : 'dark'"
+          placement="bottom"
+          :open-delay="300"
+          :content="$t('viewer.newerMessage')"
         >
-          <i class="el-icon-arrow-right"></i>
-        </button>
-        <button
-          class="nav-button nav-button--latest"
-          :disabled="currentIndex === 0"
-          @click="goToLatest"
-          :title="$t('viewer.goToLatestMessage')"
+          <button class="nav-button nav-button--next" :disabled="!canGoToNext" @click="goToNext">
+            <i class="el-icon-arrow-right"></i>
+          </button>
+        </el-tooltip>
+        <el-tooltip
+          :effect="theme !== 'light' ? 'light' : 'dark'"
+          placement="bottom"
+          :open-delay="300"
+          :content="$t('viewer.goToLatestMessage')"
         >
-          <i class="el-icon-top"></i>
-        </button>
+          <button class="nav-button nav-button--latest" :disabled="currentIndex === 0" @click="goToLatest">
+            <i class="el-icon-top"></i>
+          </button>
+        </el-tooltip>
       </div>
 
       <div class="diff-content">
@@ -167,6 +173,28 @@ export default class DiffView extends Vue {
 
   private getPayloadSize(payload: string): string {
     return calculateTextSize(payload)
+  }
+
+  private handleKeydown = (e: KeyboardEvent) => {
+    const active = document.activeElement as HTMLElement | null
+    const isEditable =
+      !!active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)
+    if (isEditable) return
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      this.goToPrevious()
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      this.goToNext()
+    }
+  }
+
+  mounted() {
+    window.addEventListener('keydown', this.handleKeydown)
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('keydown', this.handleKeydown)
   }
 }
 </script>

--- a/src/widgets/DiffView.vue
+++ b/src/widgets/DiffView.vue
@@ -3,17 +3,8 @@
     <div class="diff-header">
       <div class="header-content">
         <h3>{{ $t('viewer.messageHistory') }}</h3>
-        <el-select v-model="messageType" size="mini" @change="onMessageTypeChange">
-          <el-option label="All" value="all"></el-option>
-          <el-option label="Recieved" value="recieved"></el-option>
-          <el-option label="Published" value="publish"></el-option>
-        </el-select>
       </div>
       <div class="message-info" v-if="currentMessage && previousMessage">
-        <div class="info-item">
-          <span class="label">Topic:</span>
-          <span class="value">{{ currentMessage.topic }}</span>
-        </div>
         <div class="info-item">
           <span class="label">{{ $t('viewer.previous') }}</span>
           <span class="value">{{ formatTime(previousMessage.createAt) }}</span>
@@ -103,18 +94,6 @@ export default class DiffView extends Vue {
   @Getter('currentTheme') private theme!: Theme
 
   private currentIndex = 0
-  private messageType = 'all'
-
-  get filteredMessages(): MessageModel[] {
-    if (this.messageType === 'all') {
-      return this.messages
-    } else if (this.messageType === 'recieved') {
-      return this.messages.filter((message) => !message.out)
-    } else if (this.messageType === 'publish') {
-      return this.messages.filter((message) => message.out)
-    }
-    return []
-  }
 
   get currentMessage(): MessageModel | null {
     return this.messages[this.currentIndex] || null
@@ -189,11 +168,6 @@ export default class DiffView extends Vue {
   private getPayloadSize(payload: string): string {
     return calculateTextSize(payload)
   }
-
-  private onMessageTypeChange(type: MessageType): void {
-    this.messageType = type
-    this.$emit('message-type-change', type)
-  }
 }
 </script>
 
@@ -265,25 +239,26 @@ export default class DiffView extends Vue {
     .navigation-controls {
       display: flex;
       align-items: center;
+      gap: 8px;
       justify-content: center;
-      gap: 12px;
-      padding: 12px 16px;
+      padding: 0 16px;
       background: var(--color-bg-primary);
       border-bottom: 1px solid var(--color-border-default);
+      height: 57px; // Match .message-header height in JSONTreeView.vue
 
       .nav-button {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 32px;
-        height: 32px;
+        width: 28px;
+        height: 28px;
         border: 1px solid var(--color-border-default);
         background: var(--color-bg-normal);
         color: var(--color-text-default);
-        border-radius: 6px;
+        border-radius: 4px;
         cursor: pointer;
         transition: all 0.2s ease;
-        font-size: 14px;
+        font-size: 12px;
 
         &:hover:not(:disabled) {
           background: var(--color-bg-item);
@@ -305,7 +280,7 @@ export default class DiffView extends Vue {
         }
 
         i {
-          font-size: 12px;
+          font-size: 10px;
         }
       }
     }

--- a/src/widgets/JSONViewer.vue
+++ b/src/widgets/JSONViewer.vue
@@ -31,49 +31,65 @@
             <div class="header-left">
               <el-input
                 v-model="searchQuery"
-                placeholder="Search in JSON..."
+                :placeholder="$t('viewer.searchInJson')"
                 size="small"
                 prefix-icon="el-icon-search"
                 clearable
                 @input="onSearchInput"
                 class="search-input"
               />
-              <el-button
-                type="primary"
-                size="small"
-                icon="el-icon-view"
-                @click="openVisualTreeModal"
-                class="visualize-btn"
-                title="Visualize JSON Tree"
+              <el-tooltip
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                placement="bottom"
+                :open-delay="500"
+                :content="$t('viewer.visualizeJsonTree')"
               >
-                {{ $t('viewer.visualize') }}
-              </el-button>
+                <el-button
+                  type="primary"
+                  size="small"
+                  icon="el-icon-view"
+                  @click="openVisualTreeModal"
+                  class="visualize-btn"
+                >
+                  {{ $t('viewer.visualize') }}
+                </el-button>
+              </el-tooltip>
             </div>
             <div class="navigation-controls">
-              <button
-                class="nav-button nav-button--prev"
-                :disabled="!canGoToPrevious && !hasMore"
-                @click="goToPrevious"
-                title="Older Message"
+              <el-tooltip
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                placement="bottom"
+                :open-delay="300"
+                :content="$t('viewer.olderMessage')"
               >
-                <i class="el-icon-arrow-left"></i>
-              </button>
-              <button
-                class="nav-button nav-button--next"
-                :disabled="!canGoToNext"
-                @click="goToNext"
-                title="Newer Message"
+                <button
+                  class="nav-button nav-button--prev"
+                  :disabled="!canGoToPrevious && !hasMore"
+                  @click="goToPrevious"
+                >
+                  <i class="el-icon-arrow-left"></i>
+                </button>
+              </el-tooltip>
+              <el-tooltip
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                placement="bottom"
+                :open-delay="300"
+                :content="$t('viewer.newerMessage')"
               >
-                <i class="el-icon-arrow-right"></i>
-              </button>
-              <button
-                class="nav-button nav-button--latest"
-                :disabled="currentIndex === 0"
-                @click="goToLatest"
-                title="Go to Latest Message"
+                <button class="nav-button nav-button--next" :disabled="!canGoToNext" @click="goToNext">
+                  <i class="el-icon-arrow-right"></i>
+                </button>
+              </el-tooltip>
+              <el-tooltip
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                placement="bottom"
+                :open-delay="300"
+                :content="$t('viewer.goToLatestMessage')"
               >
-                <i class="el-icon-top"></i>
-              </button>
+                <button class="nav-button nav-button--latest" :disabled="currentIndex === 0" @click="goToLatest">
+                  <i class="el-icon-top"></i>
+                </button>
+              </el-tooltip>
             </div>
             <div class="header-right">
               <el-tooltip
@@ -109,7 +125,7 @@
       top="30px"
       :fullscreen="true"
       :visible.sync="showVisualTreeModal"
-      :title="$t('viewer.visualizeTree')"
+      :title="$t('viewer.visualizeJsonTree')"
       width="96%"
       class="visualize-tree-dialog"
       :btn-disabled="true"
@@ -355,6 +371,28 @@ export default class JsonViewer extends Vue {
     this.defaultExpandLevel = value
     localStorage.setItem('json-tree-expand-level', value.toString())
   }
+
+  private handleKeydown = (e: KeyboardEvent) => {
+    const active = document.activeElement as HTMLElement | null
+    const isEditable =
+      !!active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)
+    if (isEditable) return
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault()
+      this.goToPrevious()
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault()
+      this.goToNext()
+    }
+  }
+
+  mounted() {
+    window.addEventListener('keydown', this.handleKeydown)
+  }
+
+  beforeDestroy() {
+    window.removeEventListener('keydown', this.handleKeydown)
+  }
 }
 </script>
 
@@ -452,8 +490,8 @@ export default class JsonViewer extends Vue {
         margin-right: 16px;
         i {
           font-size: 20px;
-          color: var(--color-text-title);
-          font-weight: 400;
+          color: var(--color-text-default);
+          font-weight: 200;
         }
         &.copied {
           i {

--- a/src/widgets/JSONViewer.vue
+++ b/src/widgets/JSONViewer.vue
@@ -1,0 +1,438 @@
+<template>
+  <div class="json-tree-view">
+    <div class="json-header">
+      <div class="header-content">
+        <h3>Message JSON Viewer</h3>
+      </div>
+      <div class="message-info" v-if="currentMessage">
+        <div class="info-item">
+          <span class="label">Time:</span>
+          <span class="value">{{ formatTime(currentMessage.createAt) }}</span>
+        </div>
+        <div class="info-item">
+          <span class="label">QoS:</span>
+          <span class="value">{{ currentMessage.qos }}</span>
+        </div>
+        <div class="info-item">
+          <span class="label">Retain:</span>
+          <span class="value">{{ currentMessage.retain ? 'Yes' : 'No' }}</span>
+        </div>
+        <div class="info-item">
+          <span class="label">Size:</span>
+          <span class="value">{{ getPayloadSize(currentMessage.payload) }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="json-content-wrapper" v-if="messages.length > 0">
+      <div class="json-content">
+        <div class="message-tree">
+          <div class="message-header">
+            <div class="header-left">
+              <el-input
+                v-model="searchQuery"
+                placeholder="Search in JSON..."
+                size="small"
+                prefix-icon="el-icon-search"
+                clearable
+                @input="onSearchInput"
+                class="search-input"
+              />
+            </div>
+            <div class="navigation-controls">
+              <button
+                class="nav-button nav-button--prev"
+                :disabled="!canGoToPrevious && !hasMore"
+                @click="goToPrevious"
+                title="Older Message"
+              >
+                <i class="el-icon-arrow-left"></i>
+              </button>
+              <button
+                class="nav-button nav-button--next"
+                :disabled="!canGoToNext"
+                @click="goToNext"
+                title="Newer Message"
+              >
+                <i class="el-icon-arrow-right"></i>
+              </button>
+              <button
+                class="nav-button nav-button--latest"
+                :disabled="currentIndex === 0"
+                @click="goToLatest"
+                title="Go to Latest Message"
+              >
+                <i class="el-icon-top"></i>
+              </button>
+            </div>
+            <div class="header-right">
+              <el-button
+                size="mini"
+                :icon="copiedJson ? 'el-icon-check' : 'el-icon-document-copy'"
+                @click="copyPayload(currentMessage.payload, 'json')"
+                :disabled="copiedJson"
+              >
+                {{ copiedJson ? 'Copied' : 'Copy JSON' }}
+              </el-button>
+            </div>
+          </div>
+          <div class="json-container">
+            <tree-view :data="parseJson(currentMessage.payload)" :options="treeOptions" />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div v-else class="no-messages">
+      <p>No messages available.</p>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator'
+import { Getter } from 'vuex-class'
+import TreeView from 'vue-json-tree-view/src/TreeView.vue'
+import { calculateTextSize } from '@/utils/data'
+
+@Component({
+  components: {
+    TreeView,
+  },
+})
+export default class JsonViewer extends Vue {
+  @Prop({ type: Array, default: () => [] }) private messages!: MessageModel[]
+  @Prop({ type: Boolean, default: false }) private hasMore!: boolean
+
+  @Getter('currentTheme') private theme!: string
+
+  private searchQuery = ''
+  private currentIndex = 0
+  private copiedJson = false
+  private copiedRaw = false
+
+  get currentTheme(): string {
+    return this.theme || 'light'
+  }
+
+  get treeOptions(): any {
+    return {
+      maxDepth: 4,
+      rootObjectKey: 'message',
+      modifiable: false,
+      link: false,
+      limitRenderDepth: false,
+    }
+  }
+
+  get currentMessage(): MessageModel {
+    return this.messages[this.currentIndex] || ({} as MessageModel)
+  }
+
+  get canGoToPrevious(): boolean {
+    return this.currentIndex < this.messages.length - 1
+  }
+
+  get canGoToNext(): boolean {
+    return this.currentIndex > 0
+  }
+
+  goToPrevious(): void {
+    console.log('goToPrevious', this.canGoToPrevious, this.hasMore)
+    if (this.canGoToPrevious) {
+      this.currentIndex++
+    } else if (this.hasMore) {
+      this.$emit('request-older')
+    }
+  }
+
+  goToNext(): void {
+    if (this.canGoToNext) {
+      this.currentIndex--
+    }
+  }
+
+  goToLatest(): void {
+    this.currentIndex = 0
+  }
+
+  private formatTime(timeString: string): string {
+    try {
+      return new Date(timeString).toLocaleString()
+    } catch {
+      return timeString
+    }
+  }
+
+  private parseJson(payload: string): any {
+    try {
+      return JSON.parse(payload)
+    } catch {
+      return payload
+    }
+  }
+
+  private copyPayload(payload: string, type: 'json' | 'raw'): void {
+    navigator.clipboard.writeText(payload).then(() => {
+      if (type === 'json') {
+        this.copiedJson = true
+        setTimeout(() => (this.copiedJson = false), 1200)
+      } else {
+        this.copiedRaw = true
+        setTimeout(() => (this.copiedRaw = false), 1200)
+      }
+    })
+  }
+
+  private onSearchInput(): void {
+    console.log('onSearchInput', this.searchQuery)
+  }
+
+  private getPayloadSize(payload: string): string {
+    return calculateTextSize(payload)
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.json-tree-view {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-normal);
+  color: var(--color-text-default);
+
+  .json-header {
+    padding: 16px;
+    border-bottom: 1px solid var(--color-border-default);
+    background: var(--color-bg-primary);
+
+    .header-content {
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      h3 {
+        margin: 0;
+        font-size: 16px;
+        font-weight: 500;
+        color: var(--color-text-title);
+      }
+    }
+
+    .message-info {
+      display: flex;
+      gap: 20px;
+      flex-wrap: wrap;
+
+      .info-item {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+
+        .label {
+          font-size: 12px;
+          color: var(--color-text-light);
+          font-weight: 500;
+        }
+
+        .value {
+          font-size: 12px;
+          color: var(--color-text-default);
+          max-width: 200px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+
+  .json-content-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .json-content {
+    flex: 1;
+    min-height: 0;
+    background: var(--color-bg-normal);
+  }
+
+  .message-tree {
+    overflow: hidden;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .message-header {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    padding: 12px 16px;
+    background: var(--color-bg-primary);
+    border-bottom: 1px solid var(--color-border-default);
+    position: relative;
+
+    .header-left {
+      justify-self: start;
+    }
+
+    .header-right {
+      justify-self: end;
+    }
+
+    .search-input {
+      width: 300px;
+      max-width: 100%;
+    }
+
+    .navigation-controls {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      justify-self: center;
+
+      .nav-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border: 1px solid var(--color-border-default);
+        background: var(--color-bg-normal);
+        color: var(--color-text-default);
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.2s ease;
+        font-size: 12px;
+
+        &:hover:not(:disabled) {
+          background: var(--color-bg-item);
+          border-color: var(--color-main-green);
+          color: var(--color-main-green);
+        }
+
+        &:active:not(:disabled) {
+          transform: translateY(0);
+          box-shadow: 0 1px 4px var(--color-shadow-card);
+        }
+
+        &:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+          background: var(--color-bg-primary);
+          border-color: var(--color-border-default);
+          color: var(--color-text-light);
+        }
+
+        i {
+          font-size: 10px;
+        }
+      }
+    }
+  }
+
+  .json-container {
+    padding: 16px;
+    background: var(--color-bg-normal);
+    flex: 1;
+    overflow: auto;
+  }
+
+  .non-json {
+    padding: 16px;
+    color: var(--color-text-light);
+    background: var(--color-bg-normal);
+  }
+
+  .no-messages {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg-normal);
+
+    p {
+      margin: 0;
+      color: var(--color-text-light);
+      font-size: 14px;
+      text-align: center;
+      padding: 20px;
+      border: 1px dashed var(--color-border-default);
+      border-radius: 8px;
+      background: var(--color-bg-primary);
+    }
+  }
+}
+
+::v-deep .tree-view-item {
+  background: var(--color-bg-normal) !important;
+  color: var(--color-text-default) !important;
+  .tree-view-item-key {
+    color: var(--color-main-green) !important; // Keep MQTTX brand green
+  }
+  .tree-view-item-value {
+    &.tree-view-item-value-string {
+      color: hsl(119, 34%, 47%) !important; // From Prism theme
+    }
+    &.tree-view-item-value-number {
+      color: hsl(35, 99%, 36%) !important; // From Prism theme
+    }
+    &.tree-view-item-value-boolean {
+      color: hsl(301, 63%, 40%) !important; // From Prism theme
+    }
+    &.tree-view-item-value-null {
+      color: hsl(35, 99%, 36%) !important; // From Prism theme
+    }
+  }
+}
+
+.theme-dark .json-tree-view,
+.theme-night .json-tree-view {
+  .message-header {
+    .header-actions {
+      .navigation-controls {
+        .nav-button {
+          &:hover:not(:disabled) {
+            box-shadow: 0 2px 12px rgba(52, 195, 136, 0.25);
+          }
+        }
+      }
+    }
+  }
+}
+
+::v-deep .el-button--mini {
+  background: var(--color-bg-normal);
+  border-color: var(--color-border-default);
+  color: var(--color-text-default);
+
+  &:hover {
+    background: var(--color-bg-item);
+    border-color: var(--color-main-green);
+    color: var(--color-main-green);
+  }
+
+  &:active {
+    background: var(--color-bg-item);
+    border-color: var(--color-main-green);
+    color: var(--color-main-green);
+  }
+}
+
+.theme-dark ::v-deep .el-button--mini {
+  &:hover {
+    box-shadow: 0 2px 12px rgba(52, 195, 136, 0.2);
+  }
+}
+
+.theme-night ::v-deep .el-button--mini {
+  &:hover {
+    box-shadow: 0 2px 12px rgba(52, 195, 136, 0.3);
+  }
+}
+</style>

--- a/tests/unit/utils/jsonTreeConverter.spec.ts
+++ b/tests/unit/utils/jsonTreeConverter.spec.ts
@@ -1,0 +1,365 @@
+import { expect } from 'chai'
+import { JsonTreeConverter, JsonTreeNode } from '@/utils/jsonTreeConverter'
+
+describe('JsonTreeConverter', () => {
+  describe('convertJsonToTreeData', () => {
+    it('should convert primitive values correctly', () => {
+      const stringNode = JsonTreeConverter.convertJsonToTreeData('hello', 'greeting')
+      expect(stringNode.id).to.equal('greeting')
+      expect(stringNode.key).to.equal('greeting')
+      expect(stringNode.vtype).to.equal('string')
+      expect(stringNode.raw).to.equal('hello')
+      expect(stringNode.name).to.equal('{key|greeting}: {string|"hello"}')
+      expect(stringNode.children).to.be.undefined
+
+      const numberNode = JsonTreeConverter.convertJsonToTreeData(42, 'age')
+      expect(numberNode.vtype).to.equal('number')
+      expect(numberNode.name).to.equal('{key|age}: {number|42}')
+
+      const booleanNode = JsonTreeConverter.convertJsonToTreeData(true, 'active')
+      expect(booleanNode.vtype).to.equal('boolean')
+      expect(booleanNode.name).to.equal('{key|active}: {boolean|true}')
+
+      const nullNode = JsonTreeConverter.convertJsonToTreeData(null, 'empty')
+      expect(nullNode.vtype).to.equal('null')
+      expect(nullNode.name).to.equal('{key|empty}: {null|null}')
+    })
+
+    it('should convert empty array correctly', () => {
+      const node = JsonTreeConverter.convertJsonToTreeData([], 'items')
+      expect(node.id).to.equal('items')
+      expect(node.key).to.equal('items')
+      expect(node.vtype).to.equal('array')
+      expect(node.raw).to.deep.equal([])
+      expect(node.name).to.equal('{key|items} {meta|[0]}')
+      expect(node.children).to.be.undefined
+    })
+
+    it('should convert empty object correctly', () => {
+      const node = JsonTreeConverter.convertJsonToTreeData({}, 'config')
+      expect(node.id).to.equal('config')
+      expect(node.key).to.equal('config')
+      expect(node.vtype).to.equal('object')
+      expect(node.raw).to.deep.equal({})
+      expect(node.name).to.equal('{key|config} {meta|{0}}')
+      expect(node.children).to.be.undefined
+    })
+
+    it('should convert array with primitive values correctly', () => {
+      const array = [1, 'hello', true, null]
+      const node = JsonTreeConverter.convertJsonToTreeData(array, 'mixedArray')
+
+      expect(node.vtype).to.equal('array')
+      expect(node.name).to.equal('{key|mixedArray} {meta|[4]}')
+      expect(node.children).to.have.lengthOf(1)
+
+      const primitiveGroup = node.children![0]
+      expect(primitiveGroup.key).to.equal('(primitives)')
+      expect(primitiveGroup.vtype).to.equal('group')
+      expect(primitiveGroup.name).to.include('{key|0}: {number|1}')
+      expect(primitiveGroup.name).to.include('{key|1}: {string|"hello"}')
+      expect(primitiveGroup.name).to.include('{key|2}: {boolean|true}')
+      expect(primitiveGroup.name).to.include('{key|3}: {null|null}')
+    })
+
+    it('should convert array with complex values correctly', () => {
+      const array = [{ name: 'John' }, [1, 2, 3]]
+      const node = JsonTreeConverter.convertJsonToTreeData(array, 'complexArray')
+
+      expect(node.vtype).to.equal('array')
+      expect(node.children).to.have.lengthOf(2)
+
+      const objectChild = node.children!.find((n) => n.key === '0')
+      expect(objectChild).to.exist
+      expect(objectChild!.vtype).to.equal('object')
+      expect(objectChild!.id).to.equal('complexArray.0')
+
+      const arrayChild = node.children!.find((n) => n.key === '1')
+      expect(arrayChild).to.exist
+      expect(arrayChild!.vtype).to.equal('array')
+      expect(arrayChild!.id).to.equal('complexArray.1')
+    })
+
+    it('should convert object with primitive values correctly', () => {
+      const obj = {
+        name: 'John',
+        age: 30,
+        active: true,
+        data: null,
+      }
+      const node = JsonTreeConverter.convertJsonToTreeData(obj, 'user')
+
+      expect(node.vtype).to.equal('object')
+      expect(node.name).to.equal('{key|user} {meta|{4}}')
+      expect(node.children).to.have.lengthOf(1)
+
+      const primitiveGroup = node.children![0]
+      expect(primitiveGroup.key).to.equal('(primitives)')
+      expect(primitiveGroup.vtype).to.equal('group')
+      expect(primitiveGroup.name).to.include('{key|name}: {string|"John"}')
+      expect(primitiveGroup.name).to.include('{key|age}: {number|30}')
+      expect(primitiveGroup.name).to.include('{key|active}: {boolean|true}')
+      expect(primitiveGroup.name).to.include('{key|data}: {null|null}')
+    })
+
+    it('should convert object with mixed primitive and complex values correctly', () => {
+      const obj = {
+        name: 'John',
+        age: 30,
+        address: {
+          street: '123 Main St',
+          city: 'Anytown',
+        },
+        hobbies: ['reading', 'coding'],
+      }
+      const node = JsonTreeConverter.convertJsonToTreeData(obj, 'profile')
+
+      expect(node.vtype).to.equal('object')
+      expect(node.children).to.have.lengthOf(3)
+
+      const primitiveGroup = node.children!.find((n) => n.key === '(primitives)')
+      expect(primitiveGroup).to.exist
+      expect(primitiveGroup!.name).to.include('{key|name}: {string|"John"}')
+      expect(primitiveGroup!.name).to.include('{key|age}: {number|30}')
+
+      const addressNode = node.children!.find((n) => n.key === 'address')
+      expect(addressNode).to.exist
+      expect(addressNode!.vtype).to.equal('object')
+      expect(addressNode!.id).to.equal('profile.address')
+
+      const hobbiesNode = node.children!.find((n) => n.key === 'hobbies')
+      expect(hobbiesNode).to.exist
+      expect(hobbiesNode!.vtype).to.equal('array')
+      expect(hobbiesNode!.id).to.equal('profile.hobbies')
+    })
+
+    it('should handle nested structures correctly', () => {
+      const complexData = {
+        users: [
+          {
+            id: 1,
+            name: 'John',
+            tags: ['admin', 'user'],
+          },
+          {
+            id: 2,
+            name: 'Jane',
+            settings: {
+              theme: 'dark',
+              notifications: true,
+            },
+          },
+        ],
+        config: {
+          version: '1.0',
+          debug: false,
+        },
+      }
+
+      const node = JsonTreeConverter.convertJsonToTreeData(complexData, 'data')
+
+      expect(node.vtype).to.equal('object')
+      expect(node.children).to.have.lengthOf(2)
+
+      const usersNode = node.children!.find((n) => n.key === 'users')
+      expect(usersNode).to.exist
+      expect(usersNode!.vtype).to.equal('array')
+      expect(usersNode!.children).to.have.lengthOf(2)
+
+      const configNode = node.children!.find((n) => n.key === 'config')
+      expect(configNode).to.exist
+      expect(configNode!.vtype).to.equal('object')
+    })
+
+    it('should use default parameters correctly', () => {
+      const node = JsonTreeConverter.convertJsonToTreeData({ test: 'value' })
+      expect(node.key).to.equal('root')
+      expect(node.id).to.equal('root')
+    })
+
+    it('should generate correct paths for nested nodes', () => {
+      const obj = {
+        level1: {
+          level2: {
+            value: 'deep',
+          },
+        },
+      }
+
+      const node = JsonTreeConverter.convertJsonToTreeData(obj, 'root', 'rootPath')
+      expect(node.id).to.equal('rootPath')
+
+      const level1Node = node.children!.find((n) => n.key === 'level1')
+      expect(level1Node!.id).to.equal('rootPath.level1')
+
+      const level2Node = level1Node!.children!.find((n) => n.key === 'level2')
+      expect(level2Node!.id).to.equal('rootPath.level1.level2')
+    })
+
+    it('should handle arrays with mixed primitive and complex values', () => {
+      const array = ['simple string', 42, { complex: 'object' }, ['nested', 'array'], null, true]
+
+      const node = JsonTreeConverter.convertJsonToTreeData(array, 'mixedArray')
+
+      expect(node.children).to.have.lengthOf(3)
+
+      const primitiveGroup = node.children!.find((n) => n.key === '(primitives)')
+      expect(primitiveGroup).to.exist
+      expect(primitiveGroup!.name).to.include('{key|0}: {string|"simple string"}')
+      expect(primitiveGroup!.name).to.include('{key|1}: {number|42}')
+      expect(primitiveGroup!.name).to.include('{key|4}: {null|null}')
+      expect(primitiveGroup!.name).to.include('{key|5}: {boolean|true}')
+
+      const objectChild = node.children!.find((n) => n.key === '2')
+      expect(objectChild).to.exist
+      expect(objectChild!.vtype).to.equal('object')
+
+      const arrayChild = node.children!.find((n) => n.key === '3')
+      expect(arrayChild).to.exist
+      expect(arrayChild!.vtype).to.equal('array')
+    })
+
+    it('should handle object with mixed primitive and complex values', () => {
+      const obj = {
+        name: 'Test',
+        count: 5,
+        active: true,
+        metadata: null,
+        config: {
+          theme: 'dark',
+        },
+        items: [1, 2, 3],
+      }
+
+      const node = JsonTreeConverter.convertJsonToTreeData(obj, 'testObj')
+
+      expect(node.children).to.have.lengthOf(3) // primitives group + config + items
+
+      const primitiveGroup = node.children!.find((n) => n.key === '(primitives)')
+      expect(primitiveGroup).to.exist
+      expect(primitiveGroup!.name).to.include('{key|name}: {string|"Test"}')
+      expect(primitiveGroup!.name).to.include('{key|count}: {number|5}')
+      expect(primitiveGroup!.name).to.include('{key|active}: {boolean|true}')
+      expect(primitiveGroup!.name).to.include('{key|metadata}: {null|null}')
+
+      const configChild = node.children!.find((n) => n.key === 'config')
+      expect(configChild).to.exist
+      expect(configChild!.vtype).to.equal('object')
+
+      const itemsChild = node.children!.find((n) => n.key === 'items')
+      expect(itemsChild).to.exist
+      expect(itemsChild!.vtype).to.equal('array')
+    })
+
+    it('should set correct itemStyle properties for all nodes', () => {
+      const data = {
+        str: 'test',
+        num: 42,
+        arr: [1, 2],
+        obj: { nested: true },
+      }
+
+      const node = JsonTreeConverter.convertJsonToTreeData(data, 'testData')
+
+      expect(node.itemStyle).to.deep.include({
+        borderColor: '#cbd5e1',
+        borderWidth: 1,
+        borderRadius: 8,
+      })
+
+      const checkItemStyle = (n: JsonTreeNode) => {
+        expect(n.itemStyle).to.exist
+        expect(n.itemStyle.borderColor).to.equal('#cbd5e1')
+        expect(n.itemStyle.borderWidth).to.equal(1)
+        expect(n.itemStyle.borderRadius).to.equal(8)
+        expect(n.label).to.exist
+
+        if (n.children) {
+          n.children.forEach(checkItemStyle)
+        }
+      }
+
+      if (node.children) {
+        node.children.forEach(checkItemStyle)
+      }
+    })
+
+    it('should handle edge cases', () => {
+      const funcNode = JsonTreeConverter.convertJsonToTreeData(() => {}, 'func')
+      expect(funcNode.vtype).to.equal('function')
+      expect(funcNode.name).to.include('{key|func}: {meta|')
+
+      const dateObj = new Date('2024-01-01')
+      const dateNode = JsonTreeConverter.convertJsonToTreeData(dateObj, 'date')
+      expect(dateNode.vtype).to.equal('object')
+
+      const deepObj = { a: { b: { c: { d: 'deep' } } } }
+      const deepNode = JsonTreeConverter.convertJsonToTreeData(deepObj, 'deep')
+      expect(deepNode.children).to.have.lengthOf(1)
+
+      let current = deepNode.children![0]
+      expect(current.key).to.equal('a')
+      current = current.children![0]
+      expect(current.key).to.equal('b')
+      current = current.children![0]
+      expect(current.key).to.equal('c')
+      current = current.children![0]
+      expect(current.key).to.equal('(primitives)')
+      expect(current.name).to.include('{key|d}: {string|"deep"}')
+    })
+
+    it('should preserve raw values correctly', () => {
+      const originalData = {
+        string: 'test',
+        number: 42,
+        boolean: true,
+        null: null,
+        array: [1, 2, 3],
+        object: { nested: 'value' },
+      }
+
+      const node = JsonTreeConverter.convertJsonToTreeData(originalData, 'test')
+      expect(node.raw).to.deep.equal(originalData)
+
+      const primitiveGroup = node.children!.find((n) => n.key === '(primitives)')
+      expect(primitiveGroup!.raw).to.deep.equal({
+        string: 'test',
+        number: 42,
+        boolean: true,
+        null: null,
+      })
+
+      const arrayChild = node.children!.find((n) => n.key === 'array')
+      expect(arrayChild!.raw).to.deep.equal([1, 2, 3])
+
+      const objectChild = node.children!.find((n) => n.key === 'object')
+      expect(objectChild!.raw).to.deep.equal({ nested: 'value' })
+    })
+
+    it('should handle arrays with only primitive values', () => {
+      const array = ['a', 'b', 'c', 1, 2, 3]
+      const node = JsonTreeConverter.convertJsonToTreeData(array, 'primitiveArray')
+
+      expect(node.children).to.have.lengthOf(1)
+      const primitiveGroup = node.children![0]
+      expect(primitiveGroup.key).to.equal('(primitives)')
+      expect(primitiveGroup.raw).to.deep.equal(['a', 'b', 'c', 1, 2, 3])
+      expect(primitiveGroup.name.split('\n')).to.have.lengthOf(6)
+    })
+
+    it('should handle objects with only primitive values', () => {
+      const obj = {
+        str: 'value',
+        num: 123,
+        bool: false,
+      }
+      const node = JsonTreeConverter.convertJsonToTreeData(obj, 'primitiveObj')
+
+      expect(node.children).to.have.lengthOf(1)
+      const primitiveGroup = node.children![0]
+      expect(primitiveGroup.key).to.equal('(primitives)')
+      expect(primitiveGroup.raw).to.deep.equal(obj)
+      expect(primitiveGroup.name.split('\n')).to.have.lengthOf(3)
+    })
+  })
+})

--- a/tests/unit/utils/jsonUtils.spec.ts
+++ b/tests/unit/utils/jsonUtils.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { jsonParse, jsonStringify } from '@/utils/jsonUtils'
+import { jsonParse, jsonStringify, stringifySubtree } from '@/utils/jsonUtils'
 
 describe('jsonUtils', () => {
   describe('jsonParse', () => {
@@ -71,5 +71,42 @@ describe('jsonUtils', () => {
     //   const result = jsonStringify(arr)
     //   expect(result).to.equal('[9007199254740991,123.456,"test",true]')
     // })
+  })
+
+  describe('stringifySubtree', () => {
+    it('should stringify node.raw when present', () => {
+      const node = { raw: { a: 1, b: 'text', c: true } }
+      const result = stringifySubtree(node, 2)
+      expect(result).to.equal('{\n  "a": 1,\n  "b": "text",\n  "c": true\n}')
+    })
+
+    it('should stringify the node itself when raw is absent', () => {
+      const node = { a: 1, b: 'text', c: true }
+      const result = stringifySubtree(node, 2)
+      expect(result).to.equal('{\n  "a": 1,\n  "b": "text",\n  "c": true\n}')
+    })
+
+    it('should handle arrays and preserve order', () => {
+      const node = { raw: [1, 'two', true, null] }
+      const result = stringifySubtree(node, 2)
+      expect(result).to.equal('[\n  1,\n  "two",\n  true,\n  null\n]')
+    })
+
+    it('should handle nested structures', () => {
+      const node = { raw: { x: { y: [1, { z: 'ok' }] } } }
+      const result = stringifySubtree(node, 2)
+      expect(result).to.equal(
+        '{' +
+          '\n  "x": {' +
+          '\n    "y": [' +
+          '\n      1,' +
+          '\n      {' +
+          '\n        "z": "ok"' +
+          '\n      }' +
+          '\n    ]' +
+          '\n  }' +
+          '\n}',
+      )
+    })
   })
 })


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the new behavior?
This Pull Request adds new features to the Viewer. Specifically follows the addition of Diff View with JSON Viewer.
Functionality wise the following features are added:
JSON Tree View: 
a. It allows user to view payloads in expandable and collapsible form using `vue-json-tree-view` as the dependency to parse and view JSON as a tree. Additionally, there is a `copy` option added which will copy the JSON payload to the system clipboard. If the payload is Non-JSON, it is displayed as a single collapsible node. 
Please check the corresponding UI:

<img width="1094" height="793" alt="image" src="https://github.com/user-attachments/assets/f792920b-52e5-41d3-9f51-c410532206a7" />

Additionally, there is also a search feature implemented to search in the payload.

<img width="693" height="680" alt="image" src="https://github.com/user-attachments/assets/7e7b8889-d921-4d41-a1f9-2d116344fd44" />

b. Visualization: We use ECharts to visualize the JSON as a tree, the depth level can be set, and on right click of node, the subtree will be copied as JSON. It also supports dark theme. 
<img width="1285" height="981" alt="image" src="https://github.com/user-attachments/assets/75720951-6025-4fc0-bd2d-0dca0157192d" />
c. Navigation: The payload history navigation is controlled through Arrow keys, Left and Right. 

#### Key Summary of utility function changes:
1. New utilities added:
- jsonTreeConverter: Converts a JSON structure to EChartsNode, the corresponding unit tests are added as well.
2. Modified utils:
- jsonUtils: new utility function added to stringify the ECharts subtree to JSON to avail copy functionality. Unit tests for this new utility are covered as well.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

