### PR TITLE
fix(TopicTree): improve long host name display with ellipsis and tooltip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ vetur.config.js
 
 # Electron-builder output
 /dist_electron
+
+# AI
+CLAUDE.md
+.cursorrules
+.todos
+.cursor/

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@ vetur.config.js
 # Electron-builder output
 /dist_electron
 
-# AI
+# AI assistant configurations - excluded from open source repository
+# These files contain local development assistant settings and should remain private
 CLAUDE.md
 .cursorrules
 .todos

--- a/babel.config.js
+++ b/babel.config.js
@@ -30,6 +30,7 @@ const plugins = [
         'yaml',
         'erlang',
         'dart',
+        'xml',
       ],
       // plugins: ['line-numbers'],
       // theme: 'funky',

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -5,17 +5,14 @@ export const isXML = (str: string): boolean => {
 
   const trimmed = str.trim()
 
-  // Check basic XML structure
   if (!trimmed.startsWith('<') || !trimmed.endsWith('>')) {
     return false
   }
 
-  // Check for XML declaration
   if (trimmed.startsWith('<?xml')) {
     return true
   }
 
-  // Simple regex to check XML-like structure
   // Matches: <!-- comment --><tag>...</tag>, <tag>...</tag>, or <tag/>
   const xmlPattern =
     /^(<!--[\s\S]*?-->)*<([^\/\s>!]+)(?:\s[^>]*)?>[\s\S]*?<\/\2>$|^(<!--[\s\S]*?-->)*<[^\/\s>!]+(?:\s[^>]*)?\/?>$/

--- a/src/utils/xmlUtils.ts
+++ b/src/utils/xmlUtils.ts
@@ -1,0 +1,37 @@
+export const isXML = (str: string): boolean => {
+  if (!str || typeof str !== 'string') {
+    return false
+  }
+
+  const trimmed = str.trim()
+
+  // Check basic XML structure
+  if (!trimmed.startsWith('<') || !trimmed.endsWith('>')) {
+    return false
+  }
+
+  // Check for XML declaration
+  if (trimmed.startsWith('<?xml')) {
+    return true
+  }
+
+  // Simple regex to check XML-like structure
+  // Matches: <!-- comment --><tag>...</tag>, <tag>...</tag>, or <tag/>
+  const xmlPattern =
+    /^(<!--[\s\S]*?-->)*<([^\/\s>!]+)(?:\s[^>]*)?>[\s\S]*?<\/\2>$|^(<!--[\s\S]*?-->)*<[^\/\s>!]+(?:\s[^>]*)?\/?>$/
+
+  return xmlPattern.test(trimmed)
+}
+
+export const escapeXmlForHtml = (str: string): string => {
+  if (!str || typeof str !== 'string') {
+    return str
+  }
+
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/widgets/TreeNodeInfo.vue
+++ b/src/widgets/TreeNodeInfo.vue
@@ -104,11 +104,9 @@ export default class TreeNodeInfo extends Vue {
       const message = this.node.message?.payload || ''
       const messageStr = message.toString()
 
-      // Check if it's JSON first (keep original logic)
       JSON.parse(messageStr)
       return 'json'
     } catch (e) {
-      // Check if it's XML
       const message = this.node.message?.payload || ''
       const messageStr = message.toString()
       if (isXML(messageStr)) {

--- a/src/widgets/TreeNodeInfo.vue
+++ b/src/widgets/TreeNodeInfo.vue
@@ -173,6 +173,14 @@ body.night {
     padding: 6px 12px;
     margin: 6px 0 12px 0;
     border-radius: 8px;
+    word-break: break-all;
+    overflow-wrap: break-word;
+  }
+  .node-info-item.ellipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: normal;
   }
   .no-payload-alert {
     padding: 6px 12px;

--- a/src/widgets/TreeView.vue
+++ b/src/widgets/TreeView.vue
@@ -281,10 +281,8 @@ export default class TreeView extends Vue {
   }
 
   private isTextOverflow(data: TopicTreeNode, node: any): boolean {
-    // Check if text is likely to overflow based on content length
     const fullText =
       data.connectionInfo && data.connectionInfo.name ? `${data.connectionInfo.name}@${node.label}` : node.label
-    // Rough estimate: if text is longer than 50 characters, it's likely to overflow
     return fullText.length > 50
   }
 

--- a/src/widgets/TreeView.vue
+++ b/src/widgets/TreeView.vue
@@ -54,10 +54,22 @@
       <template #default="{ node, data }">
         <span class="custom-tree-node">
           <span class="tree-node-info">
-            <span>
-              <span v-if="data.connectionInfo && data.connectionInfo.name">{{ data.connectionInfo.name }}@</span
-              >{{ node.label }}
-            </span>
+            <el-tooltip
+              :content="
+                data.connectionInfo && data.connectionInfo.name
+                  ? `${data.connectionInfo.name}@${node.label}`
+                  : node.label
+              "
+              placement="top"
+              :effect="currentTheme !== 'light' ? 'light' : 'dark'"
+              :disabled="!isTextOverflow(data, node)"
+              :open-delay="500"
+            >
+              <span class="tree-node-label" :ref="`treeLabel_${data.id}`">
+                <span v-if="data.connectionInfo && data.connectionInfo.name">{{ data.connectionInfo.name }}@</span
+                >{{ node.label }}
+              </span>
+            </el-tooltip>
             <el-tag v-if="data.message && !checkPayloadEmpty(data.message.payload)" size="mini" class="value-tag ml-2">
               {{ data.message.payload }}
             </el-tag>
@@ -268,6 +280,14 @@ export default class TreeView extends Vue {
     return isPayloadEmpty(payload)
   }
 
+  private isTextOverflow(data: TopicTreeNode, node: any): boolean {
+    // Check if text is likely to overflow based on content length
+    const fullText =
+      data.connectionInfo && data.connectionInfo.name ? `${data.connectionInfo.name}@${node.label}` : node.label
+    // Rough estimate: if text is longer than 50 characters, it's likely to overflow
+    return fullText.length > 50
+  }
+
   private handleCommand(command: string) {
     switch (command) {
       case 'clearTree':
@@ -399,20 +419,30 @@ export default class TreeView extends Vue {
     min-width: 0;
     .tree-node-meta {
       color: var(--color-text-light);
+      flex-shrink: 0;
+      margin-left: 8px;
     }
     .tree-node-info {
-      width: 100%;
       display: flex;
       align-items: center;
       min-width: 0;
+      flex: 1;
+      overflow: hidden;
+      .tree-node-label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+        flex: 1;
+      }
       .value-tag {
-        max-width: 75%;
+        max-width: 200px;
         width: auto;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
-        flex: 0 1 auto;
-        min-width: 0;
+        flex-shrink: 0;
+        margin-left: 8px;
       }
     }
   }

--- a/tests/unit/utils/xmlUtils.spec.ts
+++ b/tests/unit/utils/xmlUtils.spec.ts
@@ -1,0 +1,173 @@
+import { expect } from 'chai'
+import { isXML, escapeXmlForHtml } from '@/utils/xmlUtils'
+
+describe('xmlUtils', () => {
+  describe('isXML', () => {
+    it('should return true for valid XML with declaration', () => {
+      const xml = '<?xml version="1.0" encoding="UTF-8"?><root><child>content</child></root>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return true for valid simple XML', () => {
+      const xml = '<root><child>content</child></root>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return true for self-closing XML tags', () => {
+      const xml = '<element/>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return true for XML with attributes', () => {
+      const xml = '<root attr="value"><child id="1">content</child></root>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return true for XML with namespace', () => {
+      const xml = '<ns:root xmlns:ns="http://example.com"><ns:child>content</ns:child></ns:root>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return true for XML with multiple levels', () => {
+      const xml = `
+        <root>
+          <level1>
+            <level2>
+              <level3>deep content</level3>
+            </level2>
+          </level1>
+        </root>
+      `
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return true for XML with CDATA', () => {
+      const xml = '<root><![CDATA[Some <text> with special characters]]></root>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should return false for empty string', () => {
+      expect(isXML('')).to.be.false
+    })
+
+    it('should return false for null', () => {
+      expect(isXML(null as any)).to.be.false
+    })
+
+    it('should return false for undefined', () => {
+      expect(isXML(undefined as any)).to.be.false
+    })
+
+    it('should return false for non-string types', () => {
+      expect(isXML(123 as any)).to.be.false
+      expect(isXML({} as any)).to.be.false
+      expect(isXML([] as any)).to.be.false
+    })
+
+    it('should return false for plain text', () => {
+      expect(isXML('This is plain text')).to.be.false
+    })
+
+    it('should return false for JSON string', () => {
+      const json = '{"key": "value", "number": 123}'
+      expect(isXML(json)).to.be.false
+    })
+
+    it('should return false for malformed XML', () => {
+      const malformed = '<root><child>content</child>'
+      expect(isXML(malformed)).to.be.false
+    })
+
+    it('should return false for unclosed tags', () => {
+      const unclosed = '<root><child>content'
+      expect(isXML(unclosed)).to.be.false
+    })
+
+    it('should return false for HTML-like content without proper XML structure', () => {
+      const html = '<div>Hello World'
+      expect(isXML(html)).to.be.false
+    })
+
+    it('should handle XML with comments', () => {
+      const xml = '<!-- comment --><root>content</root>'
+      expect(isXML(xml)).to.be.true
+    })
+
+    it('should handle whitespace properly', () => {
+      const xmlWithSpace = '   <root>content</root>   '
+      expect(isXML(xmlWithSpace)).to.be.true
+    })
+
+    it('should return false for string starting with < but not ending with >', () => {
+      expect(isXML('<root>content')).to.be.false
+    })
+
+    it('should return false for string ending with > but not starting with <', () => {
+      expect(isXML('content</root>')).to.be.false
+    })
+  })
+
+  describe('escapeXmlForHtml', () => {
+    it('should escape basic XML entities', () => {
+      const xml = '<root attr="value">content & more</root>'
+      const expected = '&lt;root attr=&quot;value&quot;&gt;content &amp; more&lt;/root&gt;'
+      expect(escapeXmlForHtml(xml)).to.equal(expected)
+    })
+
+    it('should escape single quotes', () => {
+      const xml = "<root attr='value'>content</root>"
+      const expected = '&lt;root attr=&#39;value&#39;&gt;content&lt;/root&gt;'
+      expect(escapeXmlForHtml(xml)).to.equal(expected)
+    })
+
+    it('should handle empty string', () => {
+      expect(escapeXmlForHtml('')).to.equal('')
+    })
+
+    it('should handle null input', () => {
+      expect(escapeXmlForHtml(null as any)).to.equal(null)
+    })
+
+    it('should handle undefined input', () => {
+      expect(escapeXmlForHtml(undefined as any)).to.equal(undefined)
+    })
+
+    it('should handle non-string input', () => {
+      expect(escapeXmlForHtml(123 as any)).to.equal(123)
+      expect(escapeXmlForHtml({} as any)).to.deep.equal({})
+    })
+
+    it('should escape all XML entities in complex content', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <element attr="value" attr2='value2'>
+    Content with & ampersand, < less than, > greater than
+    <nested>More "content" & 'text'</nested>
+  </element>
+</root>`
+
+      const result = escapeXmlForHtml(xml)
+      expect(result).to.include('&lt;?xml')
+      expect(result).to.include('&lt;root&gt;')
+      expect(result).to.include('attr=&quot;value&quot;')
+      expect(result).to.include('attr2=&#39;value2&#39;')
+      expect(result).to.include('&amp; ampersand')
+      expect(result).to.include('&lt; less than')
+      expect(result).to.include('&gt; greater than')
+      expect(result).to.include('&lt;nested&gt;')
+      expect(result).to.include('&quot;content&quot;')
+      expect(result).to.include('&#39;text&#39;')
+    })
+
+    it('should handle text without XML characters', () => {
+      const text = 'This is plain text without XML characters'
+      expect(escapeXmlForHtml(text)).to.equal(text)
+    })
+
+    it('should handle mixed content', () => {
+      const mixed = 'Before XML <tag>content</tag> after XML & ampersand'
+      const expected = 'Before XML &lt;tag&gt;content&lt;/tag&gt; after XML &amp; ampersand'
+      expect(escapeXmlForHtml(mixed)).to.equal(expected)
+    })
+  })
+})


### PR DESCRIPTION
### PR Checklist

  If you have any questions, you can refer to the
  [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

  #### What is the current behavior?

  In the Topics Tree view, when connection names with
  long hostnames are displayed (e.g., `FlowMQ@fmq0c7b67ec
  fcef4ecd.tiger.dev.us-east-1.flowmq.link`), the text
  overflows and pushes the message count (`3 msgs`) and
  sub-topics count out of view, making them unreadable.
  Additionally, long URLs in the right panel
  (TreeNodeInfo) don't wrap properly and overflow their
  container.

  #### Issue Number

  N/A

  #### What is the new behavior?

  - Long connection names in the topic tree now display
  with text truncation and ellipsis when they exceed
  available space
  - A tooltip appears on hover (after 500ms delay)
  showing the full `connectionName@host` when text length
   exceeds 50 characters
  - The message count and sub-topics count are now always
   visible on the right side with `flex-shrink: 0`
  - Long URLs in the TreeNodeInfo panel now wrap properly
   with `word-break: break-all`

  **Screenshots:**
  - Before: Long hostnames pushed the message count out
  of view
  - After: Text is truncated with ellipsis, message count
   always visible, tooltip shows full text on hover

  #### Does this PR introduce a breaking change?

  - [ ] Yes
  - [x] No

  #### Specific Instructions

  The tooltip only appears when the full text (connection
   name + host) exceeds 50 characters. This behavior is
  similar to the connection list implementation.

  #### Other information

  - Added text truncation with ellipsis for long
  connection names in topic tree
  - Added tooltip to show full connection info when text
  overflows (>50 chars)
  - Fixed word-break issue in TreeNodeInfo for long URLs
  - Optimized flex layout to ensure message count always
  visible