### PR TITLE
fix(desktop): unify app data path handling to fix Windows %APPDATA% redirect issue

### DIFF
--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -1,6 +1,5 @@
 import { join } from 'path'
-import fs from 'fs-extra'
-import { getAppDataPath } from 'appdata-path'
+import { getUnifiedAppDataPath, ensureAppDataDir } from '../main/appDataPath'
 import ConnectionEntity from './models/ConnectionEntity'
 import MessageEntity from './models/MessageEntity'
 import SubscriptionEntity from './models/SubscriptionEntity'
@@ -51,14 +50,15 @@ import { changeDefaultLLMModel1727111519962 } from './migration/1727111519962-ch
 import { topicNodeTables1729246737362 } from './migration/1729246737362-topicNodeTables'
 import { reasonModelSupport1742835643809 } from './migration/1742835643809-reasonModelSupport'
 
-const STORE_PATH = getAppDataPath('MQTTX')
-try {
-  if (!fs.pathExistsSync(STORE_PATH)) {
-    fs.mkdirpSync(STORE_PATH)
-  }
-} catch (err) {
-  console.error(err)
-}
+// Get the unified store path using Electron's native API
+// This fixes the Windows %APPDATA% redirect issue
+const STORE_PATH = getUnifiedAppDataPath('MQTTX')
+
+// Ensure the directory exists
+ensureAppDataDir(STORE_PATH)
+
+// Log the path being used for debugging
+console.log('[Database] Using data path:', STORE_PATH)
 
 const ORMConfig = {
   type: 'sqlite',

--- a/src/main/appDataPath.ts
+++ b/src/main/appDataPath.ts
@@ -1,0 +1,196 @@
+import { app } from 'electron'
+import path from 'path'
+import fs from 'fs-extra'
+import { getAppDataPath as getLegacyAppDataPath } from 'appdata-path'
+
+/**
+ * Get the unified application data path
+ * This fixes the Windows %APPDATA% redirect issue by using Electron's native API
+ *
+ * @param subDir - Optional subdirectory name within the user data path
+ * @returns The application data path
+ */
+export const getUnifiedAppDataPath = (subDir?: string): string => {
+  // Handle both main and renderer process
+  const isRenderer = process.type === 'renderer'
+  const electronApp = isRenderer ? require('@electron/remote').app : app
+
+  // Use Electron's native API which handles Windows %APPDATA% redirection correctly
+  const userDataPath = electronApp.getPath('userData')
+
+  if (subDir) {
+    // For backward compatibility, if subDir is 'MQTTX' and it's already in the path, don't duplicate it
+    if (subDir === 'MQTTX' && userDataPath.includes('MQTTX')) {
+      return userDataPath
+    }
+    return path.join(userDataPath, subDir)
+  }
+
+  return userDataPath
+}
+
+/**
+ * Get the legacy path where data might have been stored
+ * This is used for migration purposes only
+ *
+ * @param subDir - Optional subdirectory name
+ * @returns The legacy application data path
+ */
+export const getLegacyDataPath = (subDir?: string): string => {
+  try {
+    return getLegacyAppDataPath(subDir || 'MQTTX')
+  } catch (error) {
+    console.warn('[AppDataPath] Failed to get legacy path:', error)
+    // Fallback to Electron's native path if legacy method fails
+    return getUnifiedAppDataPath(subDir)
+  }
+}
+
+/**
+ * Check if data migration is needed
+ *
+ * @param dbFileName - The database file name (default: 'MQTTX.db')
+ * @returns Whether migration is needed and the paths involved
+ */
+export const checkMigrationNeeded = (
+  dbFileName: string = 'MQTTX.db',
+): {
+  needed: boolean
+  legacyPath?: string
+  newPath?: string
+  legacyDbPath?: string
+  newDbPath?: string
+} => {
+  const newPath = getUnifiedAppDataPath('MQTTX')
+  const legacyPath = getLegacyDataPath('MQTTX')
+
+  // If paths are the same, no migration needed
+  if (newPath === legacyPath) {
+    return { needed: false }
+  }
+
+  const legacyDbPath = path.join(legacyPath, dbFileName)
+  const newDbPath = path.join(newPath, dbFileName)
+
+  // Check if legacy database exists but new one doesn't
+  const legacyExists = fs.pathExistsSync(legacyDbPath)
+  const newExists = fs.pathExistsSync(newDbPath)
+
+  if (legacyExists && !newExists) {
+    console.log('[AppDataPath] Migration needed:')
+    console.log('  From:', legacyDbPath)
+    console.log('  To:', newDbPath)
+    return {
+      needed: true,
+      legacyPath,
+      newPath,
+      legacyDbPath,
+      newDbPath,
+    }
+  }
+
+  return { needed: false }
+}
+
+/**
+ * Migrate data from legacy path to new path
+ *
+ * @param dbFileName - The database file name (default: 'MQTTX.db')
+ * @returns Success status and error message if failed
+ */
+export const migrateDataIfNeeded = async (
+  dbFileName: string = 'MQTTX.db',
+): Promise<{
+  success: boolean
+  migrated: boolean
+  error?: string
+}> => {
+  try {
+    const migrationCheck = checkMigrationNeeded(dbFileName)
+
+    if (!migrationCheck.needed) {
+      return { success: true, migrated: false }
+    }
+
+    const { legacyPath, newPath, legacyDbPath, newDbPath } = migrationCheck
+
+    if (!legacyPath || !newPath || !legacyDbPath || !newDbPath) {
+      return { success: true, migrated: false }
+    }
+
+    // Ensure new directory exists
+    await fs.ensureDir(newPath)
+
+    // Copy all files from legacy directory to new directory
+    console.log('[AppDataPath] Starting data migration...')
+
+    try {
+      // Get all files in legacy directory
+      const files = await fs.readdir(legacyPath)
+
+      for (const file of files) {
+        const srcFile = path.join(legacyPath, file)
+        const destFile = path.join(newPath, file)
+
+        // Skip if destination already exists
+        if (await fs.pathExists(destFile)) {
+          console.log(`[AppDataPath] Skipping ${file} (already exists in destination)`)
+          continue
+        }
+
+        // Copy file or directory
+        const stat = await fs.stat(srcFile)
+        if (stat.isDirectory()) {
+          await fs.copy(srcFile, destFile)
+        } else {
+          await fs.copyFile(srcFile, destFile)
+        }
+        console.log(`[AppDataPath] Migrated: ${file}`)
+      }
+
+      console.log('[AppDataPath] Data migration completed successfully')
+
+      // Optionally, rename old directory to indicate it's been migrated
+      const backupPath = `${legacyPath}_backup_${Date.now()}`
+      try {
+        await fs.rename(legacyPath, backupPath)
+        console.log(`[AppDataPath] Legacy directory renamed to: ${backupPath}`)
+      } catch (renameError) {
+        console.warn('[AppDataPath] Could not rename legacy directory:', renameError)
+        // Not critical, continue
+      }
+
+      return { success: true, migrated: true }
+    } catch (copyError) {
+      console.error('[AppDataPath] Migration failed:', copyError)
+      // If migration fails, we'll continue using the legacy path
+      return {
+        success: false,
+        migrated: false,
+        error: `Migration failed: ${copyError}`,
+      }
+    }
+  } catch (error) {
+    console.error('[AppDataPath] Error checking migration:', error)
+    return {
+      success: false,
+      migrated: false,
+      error: `Error checking migration: ${error}`,
+    }
+  }
+}
+
+/**
+ * Ensure the app data directory exists
+ *
+ * @param dirPath - The directory path to ensure exists
+ */
+export const ensureAppDataDir = (dirPath: string): void => {
+  try {
+    if (!fs.pathExistsSync(dirPath)) {
+      fs.mkdirpSync(dirPath)
+    }
+  } catch (err) {
+    console.error('[AppDataPath] Failed to create app data directory:', err)
+  }
+}

--- a/src/main/installCLI.ts
+++ b/src/main/installCLI.ts
@@ -3,14 +3,14 @@ import * as fs from 'fs'
 import * as path from 'path'
 import axios from 'axios'
 import { BrowserWindow, dialog } from 'electron'
-import { getAppDataPath } from 'appdata-path'
+import { getUnifiedAppDataPath } from './appDataPath'
 import sudo from 'sudo-prompt'
 import version from '@/version'
 import { exec } from 'child_process'
 import { compareVersions } from 'compare-versions'
 import { getCurrentLang } from './updateChecker'
 
-const STORE_PATH = getAppDataPath('MQTTX')
+const STORE_PATH = getUnifiedAppDataPath('MQTTX')
 const MQTTX_VERSION = `v${version}`
 
 /**


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

**Problem**
MQTTX on Windows had issues with application data storage due to %APPDATA% directory redirection. The `appdata-path` library doesn't handle Windows %APPDATA% redirection properly, causing:
1. Data location inconsistency
2. Data loss during Windows updates
3. Permission issues

**Root Cause**
Application relied on `appdata-path` npm package instead of Electron's native `app.getPath('userData')` API.

**Solution**
- Created unified app data path system using Electron's native API (`src/main/appDataPath.ts`)
- Added automatic data migration from legacy paths
- Updated database configuration and CLI installer
- Added migration logic in background process

#### Issue Number

https://github.com/emqx/MQTTX/issues/1941
https://github.com/emqx/MQTTX/issues/1957
https://github.com/emqx/MQTTX/issues/1960

#### What is the new behavior?

- Add new appDataPath.ts module with unified path management using Electron's native API
- Implement data migration from legacy appdata-path to Electron's userData path
- Update database config and CLI installer to use unified path system
- Add migration logic to background.ts for seamless data transition


#### Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

#### Specific Instructions

Are there any specific instructions or things that should be known prior to review?

#### Other information
