### PR TITLE
fix(KeyValueEditor.vue): fix a User Property display bug in Topics Tree

### DIFF
--- a/src/components/KeyValueEditor.vue
+++ b/src/components/KeyValueEditor.vue
@@ -59,7 +59,7 @@ export default class KeyValueEditor extends Vue {
     val: ClientPropertiesModel['userProperties'],
     oldVal: ClientPropertiesModel['userProperties'],
   ) {
-    if (oldVal === undefined && val) {
+    if (this.disabled || oldVal === undefined && val) {
       this.processObjToArry()
     }
   }

--- a/src/components/KeyValueEditor.vue
+++ b/src/components/KeyValueEditor.vue
@@ -59,7 +59,7 @@ export default class KeyValueEditor extends Vue {
     val: ClientPropertiesModel['userProperties'],
     oldVal: ClientPropertiesModel['userProperties'],
   ) {
-    if (this.disabled || oldVal === undefined && val) {
+    if (oldVal !== val) {
       this.processObjToArry()
     }
   }


### PR DESCRIPTION
**What is the current behavior?**

When navigating in the Topics Tree from one leaf with User Properties to another one with User Properties they don't get updated. (in the topic-info-card)

**What is the new behavior?**

Now when switching from one leaf to another the User Properties get updated as disabled is set to true in this view.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No