### PR TITLE
fix: adjust history navigation button layout to prevent right arrow f…

### DIFF
--- a/src/components/MsgPublish.vue
+++ b/src/components/MsgPublish.vue
@@ -784,7 +784,7 @@ export default class MsgPublish extends Vue {
         }
 
         &.history-btn-center {
-          width: 24px;
+          min-width: 24px;
           font-size: 13px;
           color: var(--color-text-default);
 


### PR DESCRIPTION
…rom being squeezed

- Changed center button from fixed width (24px) to min-width (24px)
- Prevents right arrow button from being compressed when showing 10/10 vs 1/10
- Maintains consistent spacing between navigation elements