### PR TITLE
fix(desktop): prevent crash when restoring window on disconnected dis…

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "babel-plugin-component": "^1.1.1",
     "babel-plugin-prismjs": "^2.1.0",
     "chai": "^4.1.2",
-    "electron": "^33.0.0",
+    "electron": "33.4.11",
     "electron-devtools-installer": "^3.1.1",
     "eslint": "6.5.1",
     "eslint-config-prettier": "^6.11.0",

--- a/src/utils/windowStateManager.ts
+++ b/src/utils/windowStateManager.ts
@@ -24,7 +24,16 @@ export function restoreWindowState(win: BrowserWindow): void {
     const savedState = store.get('windowState') as WindowState | undefined
     if (!savedState || typeof savedState !== 'object') return
 
-    const screenArea = screen.getDisplayMatching(savedState.bounds).workArea
+    // Safely get display, fallback to primary if saved bounds are invalid
+    let display
+    try {
+      display = screen.getDisplayMatching(savedState.bounds)
+    } catch {
+      display = screen.getPrimaryDisplay()
+    }
+    const screenArea = display.workArea
+
+    // Adjust bounds to fit within screen
     if (savedState.bounds.width > screenArea.width) {
       savedState.bounds.width = screenArea.width
     }
@@ -37,6 +46,7 @@ export function restoreWindowState(win: BrowserWindow): void {
     if (savedState.bounds.y < screenArea.y) {
       savedState.bounds.y = screenArea.y
     }
+
     win.setBounds(savedState.bounds)
     if (savedState.isMaximized) {
       win.maximize()

--- a/yarn.lock
+++ b/yarn.lock
@@ -5454,10 +5454,10 @@ electron-updater@^5.3.0:
     semver "^7.3.5"
     typed-emitter "^2.1.0"
 
-electron@^33.0.0:
-  version "33.4.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-33.4.6.tgz#45eb4b0964f3c3ac3cf1184cf1030980c3565095"
-  integrity sha512-INNAYGkMWOb10FNMHaSdow0ekFiftFznpn6Cqo/vEgEapBMyNzGJa+0IVCezmgyRUW08FCHd+ngjvynALSndxQ==
+electron@33.4.11:
+  version "33.4.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-33.4.11.tgz#225d7f106ed3edf788ced318c63858d8b8a446dc"
+  integrity sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^20.9.0"


### PR DESCRIPTION
…play

- Upgrade Electron from 33.0.0 to 33.4.11 for macOS Sequoia compatibility
- Add fallback to primary display when getDisplayMatching fails
- Fixes NSRangeException crash when external monitor is disconnected