### PR TITLE
ci(win): add portable version for windows

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -104,9 +104,10 @@ module.exports = {
           allowToChangeInstallationDirectory: true,
           createDesktopShortcut: true,
           createStartMenuShortcut: true,
+          artifactName: 'MQTTX-Setup-${version}-${arch}.${ext}',
         },
         win: {
-          artifactName: 'MQTTX-Setup-${version}-${arch}.${ext}',
+          artifactName: 'MQTTX-${version}-${arch}-win.${ext}',
           icon: './public/icons/app.ico',
           target: [
             {
@@ -118,6 +119,10 @@ module.exports = {
                 // Issue: https://github.com/TryGhost/node-sqlite3/issues/1799
                 // 'arm64'
               ],
+            },
+            {
+              target: 'zip',
+              arch: ['x64', 'ia32'],
             },
           ],
         },


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

The Windows build configuration only outputs NSIS installers (`.exe`). It does not generate a standard portable `.zip` archive containing the unpacked application.

#### What is the new behavior?

Added 'zip' to the `win.target` configuration in `vue.config.js`. Now, the build process will generate a portable `.zip` file for Windows (both x64 and ia32 architectures) alongside the existing installers. This provides a "green," strictly portable option without the self-extracting overhead of the portable .exe. The newly added files should be named like the following:  
```bash
MQTTX-${version}-${arch}-win.zip
```

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
