### PR TITLE
feat: upgrade protobufjs to support Protobuf Editions 2023

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -41,7 +41,7 @@
     "msgpackr": "^1.11.0",
     "ora": "^5.4.1",
     "pbkdf2": "^3.1.5",
-    "protobufjs": "^7.2.3",
+    "protobufjs": "^7.5.4",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",
     "signale": "^1.4.0",

--- a/cli/src/__tests__/utils/mockData/mockEditions2023.proto
+++ b/cli/src/__tests__/utils/mockData/mockEditions2023.proto
@@ -1,0 +1,6 @@
+edition = "2023";
+
+message Response {
+  string body = 1;
+  int32 code = 2;
+}

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -2875,10 +2875,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@^7.2.3:
-  version "7.2.5"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz"
-  integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
+protobufjs@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
+  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "msgpackr": "^1.11.0",
     "pbkdf2": "^3.1.5",
     "prismjs": "^1.29.0",
-    "protobufjs": "^7.2.5",
+    "protobufjs": "^7.5.4",
     "reflect-metadata": "^0.1.13",
     "rxjs": "6.2.0",
     "sqlite3": "5.1.6",

--- a/tests/unit/utils/protobuf.spec.ts
+++ b/tests/unit/utils/protobuf.spec.ts
@@ -15,6 +15,15 @@ describe('Protobuf Utils', () => {
     }
   `
 
+  // Protobuf Editions 2023 syntax
+  const editionsProto = `
+    edition = "2023";
+    message Response {
+      string body = 1;
+      int32 code = 2;
+    }
+  `
+
   describe('checkProtobufInput', () => {
     it('should validate correct protobuf input', () => {
       const input = JSON.stringify({ name: 'Alice', age: 30 })
@@ -74,6 +83,35 @@ describe('Protobuf Utils', () => {
       expect(result).to.include('age: 35')
       expect(result).to.include('city: "New York"')
       expect(result).to.include('zip: "10001"')
+    })
+  })
+
+  describe('Protobuf Editions 2023', () => {
+    it('should validate correct editions 2023 protobuf input', () => {
+      const input = JSON.stringify({ body: 'test message', code: 200 })
+      const result = checkProtobufInput(editionsProto, input, 'Response')
+      expect(result).to.be.a('string')
+      expect(result).to.include('test message')
+      expect(result).to.include('200')
+    })
+
+    it('should serialize editions 2023 input to buffer', () => {
+      const input = JSON.stringify({ body: 'hello', code: 100 })
+      const result = serializeProtobufToBuffer(input, editionsProto, 'Response')
+      expect(result).to.be.instanceof(Buffer)
+    })
+
+    it('should deserialize buffer to editions 2023 protobuf object', () => {
+      const input = JSON.stringify({ body: 'world', code: 300 })
+      const buffer = serializeProtobufToBuffer(input, editionsProto, 'Response')
+      if (buffer) {
+        const result = deserializeBufferToProtobuf(buffer, editionsProto, 'Response')
+        expect(result).to.be.a('string')
+        expect(result).to.include('world')
+        expect(result).to.include('300')
+      } else {
+        expect.fail('Buffer should not be undefined')
+      }
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -10871,10 +10871,10 @@ promise-retry@^2.0.1:
     err-code "^2.0.2"
     retry "^0.12.0"
 
-protobufjs@^7.2.5:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.2.5.tgz#45d5c57387a6d29a17aab6846dcc283f9b8e7f2d"
-  integrity sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==
+protobufjs@^7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
+  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
- Upgrade protobufjs from ^7.2.x to ^7.5.4
- Add test cases for Protobuf Editions 2023 syntax

### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

MQTTX does not support Protobuf Editions 2023 syntax. When using `edition = "2023"` in proto files, it throws error: `illegal token 'edition'`

#### Issue Number

#2008

#### What is the new behavior?

MQTTX now supports Protobuf Editions 2023 syntax after upgrading protobufjs to ^7.5.4

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Specific Instructions

N/A

#### Other information

N/A