### PR TITLE
style: normalize quotes and formatting in web theme files

### DIFF
--- a/web/src/assets/scss/theme/dark.scss
+++ b/web/src/assets/scss/theme/dark.scss
@@ -65,5 +65,5 @@ body.dark {
   --color-shadow-card: #00000059;
   --color-shadow-message: #1f1f1f;
 
-  @import "./highlight/dark.scss";
+  @import './highlight/dark.scss';
 }

--- a/web/src/assets/scss/theme/highlight/default.scss
+++ b/web/src/assets/scss/theme/highlight/default.scss
@@ -48,7 +48,6 @@ code.hljs {
 .hljs-attribute,
 .hljs-selector-tag,
 .hljs-meta .hljs-keyword,
-
 .hljs-doctag,
 .hljs-name {
   font-weight: bold;

--- a/web/src/assets/scss/theme/highlight/night-owl.scss
+++ b/web/src/assets/scss/theme/highlight/night-owl.scss
@@ -47,7 +47,7 @@ SOFTWARE.
   color: #ff5874;
 }
 .hljs-number {
-  color: #F78C6C;
+  color: #f78c6c;
 }
 .hljs-regexp {
   color: #5ca7e4;
@@ -65,10 +65,10 @@ SOFTWARE.
   color: #ffcb8b;
 }
 .hljs-function {
-  color: #82AAFF;
+  color: #82aaff;
 }
 .hljs-title {
-  color: #DCDCAA;
+  color: #dcdcaa;
   font-style: italic;
 }
 .hljs-params {
@@ -87,7 +87,6 @@ SOFTWARE.
   color: #82aaff;
 }
 .hljs-meta .hljs-keyword {
-
   color: #82aaff;
 }
 .hljs-meta .hljs-string {
@@ -117,7 +116,7 @@ SOFTWARE.
   color: #d9f5dd;
 }
 .hljs-code {
-  color: #80CBC4;
+  color: #80cbc4;
 }
 .hljs-emphasis {
   color: #c792ea;
@@ -173,6 +172,6 @@ SOFTWARE.
 }
 
 .hljs-deletion {
-  color: #EF535090;
+  color: #ef535090;
   font-style: italic;
 }

--- a/web/src/assets/scss/theme/light.scss
+++ b/web/src/assets/scss/theme/light.scss
@@ -65,5 +65,5 @@ body.light {
   --color-shadow-card: #0000001a;
   --color-shadow-message: #dcdcdc;
 
-  @import "./highlight/default.scss";
+  @import './highlight/default.scss';
 }

--- a/web/src/assets/scss/theme/night.scss
+++ b/web/src/assets/scss/theme/night.scss
@@ -65,5 +65,5 @@ body.night {
   --color-shadow-card: #00000085;
   --color-shadow-message: #151515;
 
-  @import "./highlight/night-owl.scss";
+  @import './highlight/night-owl.scss';
 }

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -4,7 +4,7 @@ import 'element-ui/lib/theme-chalk/index.css'
 
 import hljs from 'highlight.js/lib/core'
 import hljsVuePlugin from '@highlightjs/vue-plugin'
-import json from 'highlight.js/lib/languages/json';
+import json from 'highlight.js/lib/languages/json'
 
 import ElementLocale from 'element-ui/lib/locale'
 import App from './App.vue'
@@ -18,7 +18,7 @@ import VueVirtualScroller from 'vue-virtual-scroller'
 import VueRx from 'vue-rx'
 import VueGtm, { VueGtmUseOptions } from '@gtm-support/vue2-gtm'
 
-hljs.registerLanguage('json', json);
+hljs.registerLanguage('json', json)
 Vue.use(hljsVuePlugin)
 
 Vue.use(element)


### PR DESCRIPTION
- Use single quotes consistently in SCSS imports
- Lowercase hex color values in night-owl theme
- Remove extra blank lines in highlight files
- Remove trailing semicolons in main.ts imports