### PR TITLE
fix(subscriptions): prevent newlines in topic and alias textarea inputs

### DIFF
--- a/src/components/SubscriptionsList.vue
+++ b/src/components/SubscriptionsList.vue
@@ -112,7 +112,15 @@
                   <i class="el-icon-warning-outline"></i>
                 </a>
               </el-tooltip>
-              <el-input v-model="topicInput" type="textarea" placeholder="testtopic/#" size="small"> </el-input>
+              <el-input
+                v-model="topicInput"
+                type="textarea"
+                placeholder="testtopic/#"
+                size="small"
+                @keydown.enter.native.prevent
+                @keyup.enter.native.prevent
+              >
+              </el-input>
               <div v-if="topicHasWhitespace" class="topic-whitespace-hint">
                 <span class="topic-whitespace-label">{{ $t('connections.topicWhitespaceHint') }}</span>
                 <span class="topic-whitespace-marker">
@@ -159,7 +167,14 @@
                   <i class="el-icon-warning-outline"></i>
                 </a>
               </el-tooltip>
-              <el-input v-model.trim="subRecord.alias" type="textarea" size="small"> </el-input>
+              <el-input
+                v-model.trim="subRecord.alias"
+                type="textarea"
+                size="small"
+                @keydown.enter.native.prevent
+                @keyup.enter.native.prevent
+              >
+              </el-input>
             </el-form-item>
           </el-col>
           <!-- MQTT 5.0 -->
@@ -380,6 +395,8 @@ export default class SubscriptionsList extends Vue {
 
   private saveSubs(): void | boolean {
     this.getCurrentConnection(this.connectionId)
+    this.subRecord.topic = this.subRecord.topic.replace(/[\r\n]+/g, '')
+    this.subRecord.alias = this.subRecord.alias?.replace(/[\r\n]+/g, '') || ''
     const form = this.getSubForm()
     form.validate(async (valid: boolean) => {
       if (!valid) {

--- a/web/src/components/SubscriptionsList.vue
+++ b/web/src/components/SubscriptionsList.vue
@@ -101,7 +101,15 @@
                   <i class="el-icon-warning-outline"></i>
                 </a>
               </el-tooltip>
-              <el-input v-model="topicInput" type="textarea" placeholder="testtopic/#" size="small"> </el-input>
+              <el-input
+                v-model="topicInput"
+                type="textarea"
+                placeholder="testtopic/#"
+                size="small"
+                @keydown.enter.native.prevent
+                @keyup.enter.native.prevent
+              >
+              </el-input>
               <div v-if="topicHasWhitespace" class="topic-whitespace-hint">
                 <span class="topic-whitespace-label">{{ $t('connections.topicWhitespaceHint') }}</span>
                 <span class="topic-whitespace-marker">
@@ -148,7 +156,14 @@
                   <i class="el-icon-warning-outline"></i>
                 </a>
               </el-tooltip>
-              <el-input v-model.trim="subRecord.alias" type="textarea" size="small"> </el-input>
+              <el-input
+                v-model.trim="subRecord.alias"
+                type="textarea"
+                size="small"
+                @keydown.enter.native.prevent
+                @keyup.enter.native.prevent
+              >
+              </el-input>
             </el-form-item>
           </el-col>
           <!-- MQTT 5.0 -->
@@ -346,6 +361,8 @@ export default class SubscriptionsList extends Vue {
 
   private saveSubs(): void | boolean {
     this.getCurrentConnection(this.connectionId)
+    this.subRecord.topic = this.subRecord.topic.replace(/[\r\n]+/g, '')
+    this.subRecord.alias = this.subRecord.alias?.replace(/[\r\n]+/g, '') || ''
     if (!this.client || !this.client.connected) {
       this.$message.warning(this.$tc('connections.notConnect'))
       return false


### PR DESCRIPTION
## Summary
- Prevent Enter key from inserting newlines in subscription topic and alias textarea fields
- Strip any existing newline characters when saving subscriptions
- Applied to both desktop and web versions

Related to #2001 and #1874

## Test plan
- [x] Open a subscription form and try pressing Enter in the topic field - should not insert newline
- [x] Open a subscription form and try pressing Enter in the alias field - should not insert newline
- [x] Paste text with newlines into topic/alias fields and save - newlines should be stripped