### PR TITLE
chore: hide dashboard tab

### DIFF
--- a/src/views/viewer/index.vue
+++ b/src/views/viewer/index.vue
@@ -7,7 +7,7 @@
     <div class="viewer-view-tabs">
       <el-tabs v-model="activeTab" @tab-click="handleTabClick">
         <el-tab-pane :label="$t('viewer.topicsTree')" name="TopicTree"></el-tab-pane>
-        <el-tab-pane :label="$t('viewer.dashboard')" name="Dashboard"></el-tab-pane>
+        <!-- <el-tab-pane :label="$t('viewer.dashboard')" name="Dashboard"></el-tab-pane> -->
         <el-tab-pane :label="$t('viewer.trafficMonitor')" name="TrafficMonitor"></el-tab-pane>
         <el-tab-pane :label="$t('viewer.payloadInspector')" name="PayloadInspector"></el-tab-pane>
       </el-tabs>


### PR DESCRIPTION
## Summary
- hide the Dashboard tab from the Viewer menu to keep the feature out of the UI