### PR TITLE
feat(ui): redesign Everything about MQTT help page

### DIFF
--- a/src/views/help/index.vue
+++ b/src/views/help/index.vue
@@ -1,59 +1,132 @@
 <template>
   <div class="help-view rightbar">
-    <div class="help-view-header">
-      <h1 class="titlebar">{{ $t('help.helpMQTT') }}</h1>
-      <el-tooltip
-        v-if="getterLang === 'zh'"
-        placement="bottom"
-        :effect="theme !== 'light' ? 'light' : 'dark'"
-        content="2023 MQTT 协议入门教程"
-      >
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          class="ebook-link"
-          href="https://www.emqx.com/zh/resources/beginners-guide-to-the-mqtt-protocol?utm_source=mqttx&utm_medium=referral&utm_campaign=mqttx-to-mqtt-ebook-zh"
+    <!-- Background grid pattern -->
+    <div class="help-bg-pattern"></div>
+
+    <div class="help-content">
+      <div class="help-view-header">
+        <h1 class="titlebar">{{ $t('help.helpMQTT') }}</h1>
+        <el-tooltip
+          v-if="getterLang === 'zh'"
+          placement="bottom"
+          :effect="theme !== 'light' ? 'light' : 'dark'"
+          content="2023 MQTT 协议入门教程"
         >
-          下载 MQTT 电子书
-          <span>→</span>
-        </a>
-      </el-tooltip>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            class="ebook-link"
+            href="https://www.emqx.com/zh/resources/beginners-guide-to-the-mqtt-protocol?utm_source=mqttx&utm_medium=referral&utm_campaign=mqttx-to-mqtt-ebook-zh"
+          >
+            下载 MQTT 电子书
+            <span>→</span>
+          </a>
+        </el-tooltip>
+      </div>
+
+      <!-- Quick Access Cards -->
+      <section class="quick-access">
+        <div
+          v-for="(item, index) in helpTop"
+          :key="item.icon"
+          class="access-card"
+          :style="{ animationDelay: `${index * 0.1}s` }"
+          @click="goToLink(item.link)"
+        >
+          <div class="card-glow"></div>
+          <div class="card-content">
+            <div class="card-icon-wrap">
+              <img :src="require(`@/assets/images/help/${item.icon}.png`)" :alt="item.icon" />
+            </div>
+            <div class="card-info">
+              <h3>{{ item.title }}</h3>
+              <span class="card-arrow">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M5 12h14M12 5l7 7-7 7"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Beginner's Guide Section -->
+      <section class="guide-section">
+        <div class="section-header">
+          <div class="section-line"></div>
+          <div class="section-badge">GUIDE</div>
+          <h2>{{ $t('help.guideTitle') }}</h2>
+          <p>{{ $t('help.guideDesc') }}</p>
+        </div>
+
+        <div class="guide-grid">
+          <template v-for="(item, index) in helpGuide">
+            <article
+              v-if="item.link"
+              :key="item.link"
+              class="guide-card"
+              :style="{ animationDelay: `${index * 0.05}s` }"
+              @click="goToLink(`${item.link}${blogUtm}`)"
+            >
+              <span class="guide-number">{{ String(index + 1).padStart(2, '0') }}</span>
+              <div class="guide-content">
+                <h4>{{ item.title }}</h4>
+                <div class="guide-arrow">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path
+                      d="M7 17L17 7M17 7H7M17 7v10"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div class="guide-hover-line"></div>
+            </article>
+          </template>
+        </div>
+      </section>
+
+      <!-- Programming Section -->
+      <section class="practice-section">
+        <div class="section-header">
+          <div class="section-line"></div>
+          <div class="section-badge">CODE</div>
+          <h2>{{ $t('help.practiceTitle') }}</h2>
+          <p>{{ $t('help.practiceDesc') }}</p>
+        </div>
+
+        <div class="practice-grid">
+          <template v-for="(item, index) in helpPractice">
+            <div
+              v-if="item.link"
+              :key="item.icon"
+              class="practice-card"
+              :style="{ animationDelay: `${index * 0.03}s` }"
+              @click="goToLink(`${item.link}${blogUtm}`)"
+            >
+              <div class="practice-icon">
+                <img
+                  :class="[{ invert: item.invert && item.invert.includes(theme) }]"
+                  :src="require(`@/assets/images/help/${item.icon}.png`)"
+                  :alt="item.icon"
+                />
+              </div>
+              <span class="practice-name">{{ item.title }}</span>
+              <div class="practice-pulse"></div>
+            </div>
+          </template>
+        </div>
+      </section>
     </div>
-    <section class="help-top">
-      <div v-for="item in helpTop" :key="item.icon" class="card" @click="goToLink(item.link)">
-        <img :src="require(`@/assets/images/help/${item.icon}.png`)" :alt="item.icon" width="24" height="24" />
-        <h2>{{ item.title }}</h2>
-      </div>
-    </section>
-    <section class="help-guide">
-      <h2>{{ $t('help.guideTitle') }}</h2>
-      <p>{{ $t('help.guideDesc') }}</p>
-      <div class="guide-list">
-        <template v-for="item in helpGuide">
-          <div v-if="item.link" :key="item.link" class="card" @click="goToLink(`${item.link}${blogUtm}`)">
-            <p>{{ item.title }} <span>→</span></p>
-          </div>
-        </template>
-      </div>
-    </section>
-    <section class="help-practice">
-      <h2>{{ $t('help.practiceTitle') }}</h2>
-      <p>{{ $t('help.practiceDesc') }}</p>
-      <div class="practice-list">
-        <template v-for="item in helpPractice">
-          <div v-if="item.link" :key="item.icon" class="card" @click="goToLink(`${item.link}${blogUtm}`)">
-            <img
-              :class="[{ invert: item.invert && item.invert.includes(theme) }]"
-              :src="require(`@/assets/images/help/${item.icon}.png`)"
-              :alt="item.icon"
-              width="32"
-              height="32"
-            />
-            <p>{{ item.title }}</p>
-          </div>
-        </template>
-      </div>
-    </section>
   </div>
 </template>
 
@@ -257,92 +330,433 @@ export default class Help extends Vue {
 }
 </script>
 
-<style lang="scss" scope>
+<style lang="scss" scoped>
 .help-view {
   position: relative;
-  padding: 0 16px;
-  > section:not(:last-child) {
-    margin-bottom: 64px;
+  min-height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  // Background grid pattern
+  .help-bg-pattern {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0.35;
+    background-image: linear-gradient(to right, var(--color-border-default) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--color-border-default) 1px, transparent 1px);
+    background-size: 48px 48px;
+    mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 20%, transparent 70%);
   }
-  .help-view-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    .ebook-link {
-      display: block;
+
+  .help-content {
+    position: relative;
+    z-index: 1;
+    padding: 0 16px 80px;
+  }
+}
+
+// Header
+.help-view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+
+  .ebook-link {
+    display: block;
+    color: var(--color-main-green);
+    font-size: 13px;
+    text-decoration: none;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    span {
+      margin-left: 4px;
     }
   }
-  .help-top {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 24px;
-    margin-top: 24px;
-    text-align: center;
-    .card {
-      cursor: pointer;
-      padding: 24px 12px;
-      border-radius: 8px;
-      background: var(--color-bg-card-gradient);
+}
+
+// Quick Access Cards
+.quick-access {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-bottom: 64px;
+
+  .access-card {
+    position: relative;
+    padding: 28px 24px;
+    background: var(--color-bg-card-normal);
+    border: 1px solid var(--color-border-default);
+    border-radius: 16px;
+    cursor: pointer;
+    overflow: hidden;
+    animation: fadeInUp 0.6s ease-out both;
+    transition: all 0.3s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      border-color: var(--color-main-green);
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+
+      .card-glow {
+        opacity: 1;
+      }
+
+      .card-arrow svg {
+        transform: translateX(4px);
+      }
+    }
+
+    .card-glow {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 100%;
+      background: linear-gradient(135deg, var(--color-light-green) 0%, transparent 60%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      pointer-events: none;
+    }
+
+    .card-content {
+      position: relative;
+      z-index: 1;
+    }
+
+    .card-icon-wrap {
+      width: 48px;
+      height: 48px;
+      margin-bottom: 16px;
+      padding: 10px;
+      background: var(--color-bg-primary);
+      border-radius: 12px;
+      border: 1px solid var(--color-border-default);
+
       img {
-        margin-bottom: 12px;
-      }
-      h2 {
-        font-size: 14px;
-      }
-    }
-  }
-  .help-guide,
-  .help-practice {
-    > h2 {
-      margin-bottom: 8px;
-      font-size: 18px;
-    }
-    > p {
-      margin-bottom: 24px;
-    }
-  }
-  .help-guide {
-    .guide-list {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      grid-gap: 24px;
-      .card {
-        cursor: pointer;
+        width: 100%;
         height: 100%;
-        padding: 16px 24px;
-        border-radius: 8px;
+        object-fit: contain;
+      }
+    }
+
+    .card-info {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      h3 {
+        font-size: 15px;
         font-weight: 600;
         color: var(--color-text-title);
-        border: 1px solid var(--color-border-default);
-        span {
-          color: var(--color-main-green);
+        margin: 0;
+      }
+
+      .card-arrow {
+        width: 20px;
+        height: 20px;
+        color: var(--color-text-light);
+        transition: all 0.25s ease;
+
+        svg {
+          width: 100%;
+          height: 100%;
+          transition: transform 0.25s ease;
         }
       }
     }
   }
-  .help-practice {
-    padding-bottom: 64px;
-    .practice-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, 120px);
-      grid-gap: 28px;
-      text-align: center;
-      .card {
-        cursor: pointer;
-        padding: 24px 12px;
-        border-radius: 8px;
-        background: var(--color-bg-card-normal);
-        img {
-          margin-bottom: 12px;
-          &.invert {
-            filter: invert(100%);
-          }
-        }
-        h2 {
-          font-size: 14px;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Section Header Style
+.section-header {
+  position: relative;
+  margin-bottom: 32px;
+  padding-left: 20px;
+
+  .section-line {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: linear-gradient(180deg, var(--color-main-green) 0%, transparent 100%);
+    border-radius: 2px;
+  }
+
+  .section-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    margin-bottom: 12px;
+    background: var(--color-light-green);
+    border: 1px solid var(--color-minor-green);
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    color: var(--color-main-green);
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  }
+
+  h2 {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--color-text-title);
+    margin: 0 0 8px;
+    letter-spacing: -0.01em;
+  }
+
+  p {
+    font-size: 14px;
+    color: var(--color-text-light);
+    margin: 0;
+    line-height: 1.6;
+  }
+}
+
+// Guide Section
+.guide-section {
+  margin-bottom: 64px;
+
+  .guide-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+
+  .guide-card {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 20px 24px;
+    background: var(--color-bg-normal);
+    border: 1px solid var(--color-border-default);
+    border-radius: 12px;
+    cursor: pointer;
+    overflow: hidden;
+    animation: fadeInUp 0.5s ease-out both;
+    transition: all 0.25s ease;
+
+    &:hover {
+      border-color: var(--color-minor-green);
+      background: var(--color-bg-card-normal);
+
+      .guide-number {
+        color: var(--color-main-green);
+        background: var(--color-light-green);
+      }
+
+      .guide-arrow {
+        opacity: 1;
+        transform: translate(0, 0);
+      }
+
+      .guide-hover-line {
+        transform: scaleX(1);
+      }
+    }
+
+    .guide-number {
+      flex-shrink: 0;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--color-bg-primary);
+      border-radius: 8px;
+      font-size: 11px;
+      font-weight: 700;
+      color: var(--color-text-light);
+      font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+      transition: all 0.25s ease;
+    }
+
+    .guide-content {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+
+      h4 {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--color-text-title);
+        margin: 0;
+        line-height: 1.5;
+      }
+
+      .guide-arrow {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        color: var(--color-main-green);
+        opacity: 0;
+        transform: translate(-8px, 8px);
+        transition: all 0.25s ease;
+
+        svg {
+          width: 100%;
+          height: 100%;
         }
       }
     }
+
+    .guide-hover-line {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: var(--color-main-green);
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.3s ease;
+    }
+  }
+}
+
+// Practice Section
+.practice-section {
+  padding-bottom: 40px;
+
+  .practice-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 16px;
+  }
+
+  .practice-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px 16px 20px;
+    background: var(--color-bg-normal);
+    border: 1px solid var(--color-border-default);
+    border-radius: 12px;
+    cursor: pointer;
+    overflow: hidden;
+    animation: fadeInUp 0.4s ease-out both;
+    transition: all 0.25s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      border-color: var(--color-minor-green);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+
+      .practice-icon {
+        transform: scale(1.1);
+      }
+
+      .practice-pulse {
+        animation: pulseRing 1s ease-out;
+      }
+    }
+
+    .practice-icon {
+      width: 40px;
+      height: 40px;
+      margin-bottom: 12px;
+      transition: transform 0.25s ease;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+
+        &.invert {
+          filter: invert(100%);
+        }
+      }
+    }
+
+    .practice-name {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--color-text-title);
+      text-align: center;
+      line-height: 1.3;
+    }
+
+    .practice-pulse {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 60px;
+      height: 60px;
+      border: 2px solid var(--color-main-green);
+      border-radius: 50%;
+      transform: translate(-50%, -50%);
+      opacity: 0;
+      pointer-events: none;
+    }
+  }
+}
+
+@keyframes pulseRing {
+  0% {
+    opacity: 0.6;
+    transform: translate(-50%, -50%) scale(0.5);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(2);
+  }
+}
+
+// Responsive
+@media (max-width: 900px) {
+  .quick-access {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-section .guide-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .help-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 20px;
+
+    .header-main {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 16px;
+    }
+  }
+
+  .section-header h2 {
+    font-size: 18px;
+  }
+
+  .practice-section .practice-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 </style>

--- a/src/views/help/index.vue
+++ b/src/views/help/index.vue
@@ -739,16 +739,10 @@ export default class Help extends Vue {
 }
 
 @media (max-width: 600px) {
-  .help-header {
+  .help-view-header {
     flex-direction: column;
     align-items: flex-start;
-    gap: 20px;
-
-    .header-main {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 16px;
-    }
+    gap: 12px;
   }
 
   .section-header h2 {

--- a/web/src/components/Leftbar.vue
+++ b/web/src/components/Leftbar.vue
@@ -183,7 +183,7 @@ export default class Leftbar extends Vue {
     font-size: 22px;
   }
   .leftbar-bottom .iconfont {
-    font-size: 18px;
+    font-size: 22px;
   }
 
   @media (min-width: 1920px) {

--- a/web/src/views/help/index.vue
+++ b/web/src/views/help/index.vue
@@ -1,59 +1,132 @@
 <template>
   <div class="help-view rightbar">
-    <div class="help-view-header">
-      <h1 class="titlebar">{{ $t('help.helpMQTT') }}</h1>
-      <el-tooltip
-        v-if="getterLang === 'zh'"
-        placement="bottom"
-        :effect="theme !== 'light' ? 'light' : 'dark'"
-        content="2023 MQTT 协议入门教程"
-      >
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          class="ebook-link"
-          href="https://www.emqx.com/zh/resources/beginners-guide-to-the-mqtt-protocol?utm_source=mqttx&utm_medium=referral&utm_campaign=mqttx-to-mqtt-ebook-zh"
+    <!-- Background grid pattern -->
+    <div class="help-bg-pattern"></div>
+
+    <div class="help-content">
+      <div class="help-view-header">
+        <h1 class="titlebar">{{ $t('help.helpMQTT') }}</h1>
+        <el-tooltip
+          v-if="getterLang === 'zh'"
+          placement="bottom"
+          :effect="theme !== 'light' ? 'light' : 'dark'"
+          content="2023 MQTT 协议入门教程"
         >
-          下载 MQTT 电子书
-          <span>→</span>
-        </a>
-      </el-tooltip>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            class="ebook-link"
+            href="https://www.emqx.com/zh/resources/beginners-guide-to-the-mqtt-protocol?utm_source=mqttx&utm_medium=referral&utm_campaign=mqttx-to-mqtt-ebook-zh"
+          >
+            下载 MQTT 电子书
+            <span>→</span>
+          </a>
+        </el-tooltip>
+      </div>
+
+      <!-- Quick Access Cards -->
+      <section class="quick-access">
+        <div
+          v-for="(item, index) in helpTop"
+          :key="item.icon"
+          class="access-card"
+          :style="{ animationDelay: `${index * 0.1}s` }"
+          @click="goToLink(item.link)"
+        >
+          <div class="card-glow"></div>
+          <div class="card-content">
+            <div class="card-icon-wrap">
+              <img :src="require(`@/assets/images/help/${item.icon}.png`)" :alt="item.icon" />
+            </div>
+            <div class="card-info">
+              <h3>{{ item.title }}</h3>
+              <span class="card-arrow">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path
+                    d="M5 12h14M12 5l7 7-7 7"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Beginner's Guide Section -->
+      <section class="guide-section">
+        <div class="section-header">
+          <div class="section-line"></div>
+          <div class="section-badge">GUIDE</div>
+          <h2>{{ $t('help.guideTitle') }}</h2>
+          <p>{{ $t('help.guideDesc') }}</p>
+        </div>
+
+        <div class="guide-grid">
+          <template v-for="(item, index) in helpGuide">
+            <article
+              v-if="item.link"
+              :key="item.link"
+              class="guide-card"
+              :style="{ animationDelay: `${index * 0.05}s` }"
+              @click="goToLink(`${item.link}${blogUtm}`)"
+            >
+              <span class="guide-number">{{ String(index + 1).padStart(2, '0') }}</span>
+              <div class="guide-content">
+                <h4>{{ item.title }}</h4>
+                <div class="guide-arrow">
+                  <svg viewBox="0 0 24 24" fill="none">
+                    <path
+                      d="M7 17L17 7M17 7H7M17 7v10"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div class="guide-hover-line"></div>
+            </article>
+          </template>
+        </div>
+      </section>
+
+      <!-- Programming Section -->
+      <section class="practice-section">
+        <div class="section-header">
+          <div class="section-line"></div>
+          <div class="section-badge">CODE</div>
+          <h2>{{ $t('help.practiceTitle') }}</h2>
+          <p>{{ $t('help.practiceDesc') }}</p>
+        </div>
+
+        <div class="practice-grid">
+          <template v-for="(item, index) in helpPractice">
+            <div
+              v-if="item.link"
+              :key="item.icon"
+              class="practice-card"
+              :style="{ animationDelay: `${index * 0.03}s` }"
+              @click="goToLink(`${item.link}${blogUtm}`)"
+            >
+              <div class="practice-icon">
+                <img
+                  :class="[{ invert: item.invert && item.invert.includes(theme) }]"
+                  :src="require(`@/assets/images/help/${item.icon}.png`)"
+                  :alt="item.icon"
+                />
+              </div>
+              <span class="practice-name">{{ item.title }}</span>
+              <div class="practice-pulse"></div>
+            </div>
+          </template>
+        </div>
+      </section>
     </div>
-    <section class="help-top">
-      <div v-for="item in helpTop" :key="item.icon" class="card" @click="goToLink(item.link)">
-        <img :src="require(`@/assets/images/help/${item.icon}.png`)" :alt="item.icon" width="24" height="24" />
-        <h2>{{ item.title }}</h2>
-      </div>
-    </section>
-    <section class="help-guide">
-      <h2>{{ $t('help.guideTitle') }}</h2>
-      <p>{{ $t('help.guideDesc') }}</p>
-      <div class="guide-list">
-        <template v-for="item in helpGuide">
-          <div v-if="item.link" :key="item.link" class="card" @click="goToLink(`${item.link}${blogUtm}`)">
-            <p>{{ item.title }} <span>→</span></p>
-          </div>
-        </template>
-      </div>
-    </section>
-    <section class="help-practice">
-      <h2>{{ $t('help.practiceTitle') }}</h2>
-      <p>{{ $t('help.practiceDesc') }}</p>
-      <div class="practice-list">
-        <template v-for="item in helpPractice">
-          <div v-if="item.link" :key="item.icon" class="card" @click="goToLink(`${item.link}${blogUtm}`)">
-            <img
-              :class="[{ invert: item.invert && item.invert.includes(theme) }]"
-              :src="require(`@/assets/images/help/${item.icon}.png`)"
-              :alt="item.icon"
-              width="32"
-              height="32"
-            />
-            <p>{{ item.title }}</p>
-          </div>
-        </template>
-      </div>
-    </section>
   </div>
 </template>
 
@@ -257,92 +330,427 @@ export default class Help extends Vue {
 }
 </script>
 
-<style lang="scss" scope>
+<style lang="scss" scoped>
 .help-view {
   position: relative;
-  padding: 0 16px;
-  > section:not(:last-child) {
-    margin-bottom: 64px;
+  min-height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  // Background grid pattern
+  .help-bg-pattern {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+    z-index: 0;
+    opacity: 0.35;
+    background-image: linear-gradient(to right, var(--color-border-default) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--color-border-default) 1px, transparent 1px);
+    background-size: 48px 48px;
+    mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 20%, transparent 70%);
   }
-  .help-view-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    .ebook-link {
-      display: block;
+
+  .help-content {
+    position: relative;
+    z-index: 1;
+    padding: 0 16px 80px;
+  }
+}
+
+// Header
+.help-view-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+
+  .ebook-link {
+    display: block;
+    color: var(--color-main-green);
+    font-size: 13px;
+    text-decoration: none;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 0.8;
+    }
+
+    span {
+      margin-left: 4px;
     }
   }
-  .help-top {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 24px;
-    margin-top: 24px;
-    text-align: center;
-    .card {
-      cursor: pointer;
-      padding: 24px 12px;
-      border-radius: 8px;
-      background: var(--color-bg-card-gradient);
+}
+
+// Quick Access Cards
+.quick-access {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  margin-bottom: 64px;
+
+  .access-card {
+    position: relative;
+    padding: 28px 24px;
+    background: var(--color-bg-card-normal);
+    border: 1px solid var(--color-border-default);
+    border-radius: 16px;
+    cursor: pointer;
+    overflow: hidden;
+    animation: fadeInUp 0.6s ease-out both;
+    transition: all 0.3s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      border-color: var(--color-main-green);
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+
+      .card-glow {
+        opacity: 1;
+      }
+
+      .card-arrow svg {
+        transform: translateX(4px);
+      }
+    }
+
+    .card-glow {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 100%;
+      background: linear-gradient(135deg, var(--color-light-green) 0%, transparent 60%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      pointer-events: none;
+    }
+
+    .card-content {
+      position: relative;
+      z-index: 1;
+    }
+
+    .card-icon-wrap {
+      width: 48px;
+      height: 48px;
+      margin-bottom: 16px;
+      padding: 10px;
+      background: var(--color-bg-primary);
+      border-radius: 12px;
+      border: 1px solid var(--color-border-default);
+
       img {
-        margin-bottom: 12px;
-      }
-      h2 {
-        font-size: 14px;
-      }
-    }
-  }
-  .help-guide,
-  .help-practice {
-    > h2 {
-      margin-bottom: 8px;
-      font-size: 18px;
-    }
-    > p {
-      margin-bottom: 24px;
-    }
-  }
-  .help-guide {
-    .guide-list {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      grid-gap: 24px;
-      .card {
-        cursor: pointer;
+        width: 100%;
         height: 100%;
-        padding: 16px 24px;
-        border-radius: 8px;
+        object-fit: contain;
+      }
+    }
+
+    .card-info {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+
+      h3 {
+        font-size: 15px;
         font-weight: 600;
         color: var(--color-text-title);
-        border: 1px solid var(--color-border-default);
-        span {
-          color: var(--color-main-green);
+        margin: 0;
+      }
+
+      .card-arrow {
+        width: 20px;
+        height: 20px;
+        color: var(--color-text-light);
+        transition: all 0.25s ease;
+
+        svg {
+          width: 100%;
+          height: 100%;
+          transition: transform 0.25s ease;
         }
       }
     }
   }
-  .help-practice {
-    padding-bottom: 64px;
-    .practice-list {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, 120px);
-      grid-gap: 28px;
-      text-align: center;
-      .card {
-        cursor: pointer;
-        padding: 24px 12px;
-        border-radius: 8px;
-        background: var(--color-bg-card-normal);
-        img {
-          margin-bottom: 12px;
-          &.invert {
-            filter: invert(100%);
-          }
-        }
-        h2 {
-          font-size: 14px;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Section Header Style
+.section-header {
+  position: relative;
+  margin-bottom: 32px;
+  padding-left: 20px;
+
+  .section-line {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: linear-gradient(180deg, var(--color-main-green) 0%, transparent 100%);
+    border-radius: 2px;
+  }
+
+  .section-badge {
+    display: inline-block;
+    padding: 4px 10px;
+    margin-bottom: 12px;
+    background: var(--color-light-green);
+    border: 1px solid var(--color-minor-green);
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    color: var(--color-main-green);
+    font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+  }
+
+  h2 {
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--color-text-title);
+    margin: 0 0 8px;
+    letter-spacing: -0.01em;
+  }
+
+  p {
+    font-size: 14px;
+    color: var(--color-text-light);
+    margin: 0;
+    line-height: 1.6;
+  }
+}
+
+// Guide Section
+.guide-section {
+  margin-bottom: 64px;
+
+  .guide-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+  }
+
+  .guide-card {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 20px 24px;
+    background: var(--color-bg-normal);
+    border: 1px solid var(--color-border-default);
+    border-radius: 12px;
+    cursor: pointer;
+    overflow: hidden;
+    animation: fadeInUp 0.5s ease-out both;
+    transition: all 0.25s ease;
+
+    &:hover {
+      border-color: var(--color-minor-green);
+      background: var(--color-bg-card-normal);
+
+      .guide-number {
+        color: var(--color-main-green);
+        background: var(--color-light-green);
+      }
+
+      .guide-arrow {
+        opacity: 1;
+        transform: translate(0, 0);
+      }
+
+      .guide-hover-line {
+        transform: scaleX(1);
+      }
+    }
+
+    .guide-number {
+      flex-shrink: 0;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--color-bg-primary);
+      border-radius: 8px;
+      font-size: 11px;
+      font-weight: 700;
+      color: var(--color-text-light);
+      font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+      transition: all 0.25s ease;
+    }
+
+    .guide-content {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+
+      h4 {
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--color-text-title);
+        margin: 0;
+        line-height: 1.5;
+      }
+
+      .guide-arrow {
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        color: var(--color-main-green);
+        opacity: 0;
+        transform: translate(-8px, 8px);
+        transition: all 0.25s ease;
+
+        svg {
+          width: 100%;
+          height: 100%;
         }
       }
     }
+
+    .guide-hover-line {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      height: 2px;
+      background: var(--color-main-green);
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.3s ease;
+    }
+  }
+}
+
+// Practice Section
+.practice-section {
+  padding-bottom: 40px;
+
+  .practice-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 16px;
+  }
+
+  .practice-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 24px 16px 20px;
+    background: var(--color-bg-normal);
+    border: 1px solid var(--color-border-default);
+    border-radius: 12px;
+    cursor: pointer;
+    overflow: hidden;
+    animation: fadeInUp 0.4s ease-out both;
+    transition: all 0.25s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      border-color: var(--color-minor-green);
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+
+      .practice-icon {
+        transform: scale(1.1);
+      }
+
+      .practice-pulse {
+        animation: pulseRing 1s ease-out;
+      }
+    }
+
+    .practice-icon {
+      width: 40px;
+      height: 40px;
+      margin-bottom: 12px;
+      transition: transform 0.25s ease;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+
+        &.invert {
+          filter: invert(100%);
+        }
+      }
+    }
+
+    .practice-name {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--color-text-title);
+      text-align: center;
+      line-height: 1.3;
+    }
+
+    .practice-pulse {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 60px;
+      height: 60px;
+      border: 2px solid var(--color-main-green);
+      border-radius: 50%;
+      transform: translate(-50%, -50%);
+      opacity: 0;
+      pointer-events: none;
+    }
+  }
+}
+
+@keyframes pulseRing {
+  0% {
+    opacity: 0.6;
+    transform: translate(-50%, -50%) scale(0.5);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(2);
+  }
+}
+
+// Responsive
+@media (max-width: 900px) {
+  .quick-access {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-section .guide-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .help-view-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .section-header h2 {
+    font-size: 18px;
+  }
+
+  .practice-section .practice-grid {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Redesign the "Everything about MQTT" help page with improved visual design
- Add subtle grid background pattern for visual depth
- Redesign quick access cards with hover glow effects and staggered animations
- Add section headers with gradient accent lines and monospace badges (GUIDE/CODE)
- Implement guide cards with numbered indicators and smooth hover animations
- Refresh programming language cards with icon scaling and pulse animation on hover
- Increase web leftbar bottom navigation icon size from 18px to 22px for consistency
- Sync all design improvements from desktop to web version

## Test plan
- [ ] Verify help page displays correctly in desktop app (light/dark/night themes)
- [ ] Verify help page displays correctly in web app (light/dark/night themes)
- [ ] Test all card hover animations and interactions
- [ ] Verify external links open correctly
- [ ] Check responsive layout on different screen sizes
- [ ] Verify web leftbar icons are properly sized