### PR TITLE
feat(web): add collapsible connections list pane

### DIFF
--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -41,7 +41,12 @@ const getShowConnectionList = (): boolean => {
   if (!_showConnectionList) {
     return true
   }
-  return JSON.parse(_showConnectionList)
+  try {
+    const parsedShowConnectionList: unknown = JSON.parse(_showConnectionList)
+    return typeof parsedShowConnectionList === 'boolean' ? parsedShowConnectionList : true
+  } catch (error) {
+    return true
+  }
 }
 
 const settingData = getGlobal('sharedData')

--- a/web/src/components/Leftbar.vue
+++ b/web/src/components/Leftbar.vue
@@ -7,7 +7,7 @@
         </a>
       </div>
       <div :class="[{ active: isConnection }, 'leftbar-item']">
-        <a href="javascript:;" @click="routeToPage('/recent_connections')">
+        <a href="javascript:;" @click="openConnections">
           <i class="iconfont icon-connections"></i>
         </a>
       </div>
@@ -40,11 +40,16 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
-import { Getter } from 'vuex-class'
+import { Getter, Action } from 'vuex-class'
 
 @Component
 export default class Leftbar extends Vue {
   @Getter('currentLang') private getterLang!: Language
+  @Getter('showConnectionList') private showConnectionList!: boolean
+
+  @Action('TOGGLE_SHOW_CONNECTION_LIST') private toggleShowConnectionList!: (payload: {
+    showConnectionList: boolean
+  }) => void
 
   get siteLink(): string {
     return this.getterLang === 'zh' ? 'https://mqttx.app/zh' : 'https://mqttx.app/'
@@ -71,6 +76,14 @@ export default class Leftbar extends Vue {
         path,
       })
       .catch(() => {})
+  }
+
+  private openConnections() {
+    if (this.isConnection) {
+      this.toggleShowConnectionList({ showConnectionList: !this.showConnectionList })
+    } else {
+      this.routeToPage('/recent_connections')
+    }
   }
 }
 </script>

--- a/web/src/lang/connections.ts
+++ b/web/src/lang/connections.ts
@@ -9,6 +9,16 @@ export default {
     en: 'New Connection',
     ja: '新規接続',
   },
+  hideConnections: {
+    zh: '隐藏连接列表',
+    en: 'Hide Connections',
+    ja: '接続リストを非表示',
+  },
+  showConnections: {
+    zh: '显示连接列表',
+    en: 'Show Connections',
+    ja: '接続リストを表示',
+  },
   search: {
     zh: '搜索',
     en: 'Search',

--- a/web/src/store/getter.ts
+++ b/web/src/store/getter.ts
@@ -14,6 +14,7 @@ const getters = {
   allConnections: (state: State) => state.app.allConnections,
   multiTopics: (state: State) => state.app.multiTopics,
   topicWhitespaceDetection: (state: State) => state.app.topicWhitespaceDetection,
+  showConnectionList: (state: State) => state.app.showConnectionList,
 }
 
 export default getters

--- a/web/src/store/modules/app.ts
+++ b/web/src/store/modules/app.ts
@@ -18,6 +18,15 @@ const TOGGLE_ADVANCED_VISIBLE = 'TOGGLE_ADVANCED_VISIBLE'
 const CHANGE_ALL_CONNECTIONS = 'CHANGE_ALL_CONNECTIONS'
 const TOGGLE_MULTI_TOPICS = 'TOGGLE_MULTI_TOPICS'
 const TOGGLE_TOPIC_WHITESPACE_DETECTION = 'TOGGLE_TOPIC_WHITESPACE_DETECTION'
+const TOGGLE_SHOW_CONNECTION_LIST = 'TOGGLE_SHOW_CONNECTION_LIST'
+
+const getShowConnectionList = (): boolean => {
+  const _showConnectionList: string | null = localStorage.getItem('showConnectionList')
+  if (!_showConnectionList) {
+    return true
+  }
+  return JSON.parse(_showConnectionList)
+}
 
 const stateRecord: App = loadSettings()
 
@@ -38,6 +47,7 @@ const app = {
     advancedVisible: true,
     willMessageVisible: true,
     allConnections: [],
+    showConnectionList: getShowConnectionList(),
   },
   mutations: {
     [TOGGLE_THEME](state: App, currentTheme: Theme) {
@@ -115,6 +125,10 @@ const app = {
     [CHANGE_ALL_CONNECTIONS](state: App, allConnections: ConnectionModel[] | []) {
       state.allConnections = allConnections
     },
+    [TOGGLE_SHOW_CONNECTION_LIST](state: App, showConnectionList: boolean) {
+      state.showConnectionList = showConnectionList
+      localStorage.setItem('showConnectionList', JSON.stringify(state.showConnectionList))
+    },
   },
   actions: {
     TOGGLE_THEME({ commit }: any, payload: App) {
@@ -176,6 +190,9 @@ const app = {
     },
     CHANGE_ALL_CONNECTIONS({ commit }: any, payload: App) {
       commit(CHANGE_ALL_CONNECTIONS, payload.allConnections)
+    },
+    TOGGLE_SHOW_CONNECTION_LIST({ commit }: any, payload: App) {
+      commit(TOGGLE_SHOW_CONNECTION_LIST, payload.showConnectionList)
     },
   },
 }

--- a/web/src/store/modules/app.ts
+++ b/web/src/store/modules/app.ts
@@ -25,7 +25,12 @@ const getShowConnectionList = (): boolean => {
   if (!_showConnectionList) {
     return true
   }
-  return JSON.parse(_showConnectionList)
+  try {
+    const parsedShowConnectionList: unknown = JSON.parse(_showConnectionList)
+    return typeof parsedShowConnectionList === 'boolean' ? parsedShowConnectionList : true
+  } catch (error) {
+    return true
+  }
 }
 
 const stateRecord: App = loadSettings()

--- a/web/src/types/global.d.ts
+++ b/web/src/types/global.d.ts
@@ -134,6 +134,7 @@ declare global {
     willMessageVisible: boolean
     advancedVisible: boolean
     allConnections: ConnectionModel[] | []
+    showConnectionList: boolean
   }
 
   interface State {

--- a/web/src/views/connections/ConnectionsDetail.vue
+++ b/web/src/views/connections/ConnectionsDetail.vue
@@ -261,6 +261,7 @@ export default class ConnectionsDetail extends Vue {
   @Getter('showClientInfo') private clientInfoVisibles!: {
     [id: string]: boolean
   }
+  @Getter('showConnectionList') private showConnectionList!: boolean
 
   /**
    * Notice: when we jump order by `other page` -> `creation page` -> `connection page`,
@@ -490,8 +491,17 @@ export default class ConnectionsDetail extends Vue {
   }
 
   get marginLeft(): string {
-    const left = this.showSubs ? (this.largeDesktop ? '916px' : '676px') : this.largeDesktop ? '517px' : '397px'
-    return left
+    if (!this.showConnectionList) {
+      // ConnectionsList hidden: subtract its width (320px / 400px) from the offsets.
+      return this.showSubs
+        ? this.largeDesktop
+          ? '516px'
+          : '356px'
+        : this.largeDesktop
+        ? '116px'
+        : '76px'
+    }
+    return this.showSubs ? (this.largeDesktop ? '916px' : '676px') : this.largeDesktop ? '517px' : '397px'
   }
 
   get subListRef(): SubscriptionsList {

--- a/web/src/views/connections/index.vue
+++ b/web/src/views/connections/index.vue
@@ -1,11 +1,32 @@
 <template>
   <div class="connections">
-    <div class="left-list">
-      <h1 class="titlebar">{{ $t('connections.connections') }}</h1>
-      <ConnectionsList :data="records" :connectionId="connectionId" @delete="onDelete" />
-    </div>
+    <transition name="slide">
+      <div v-show="showConnectionList" class="left-list">
+        <h1 class="titlebar">{{ $t('connections.connections') }}</h1>
+        <ConnectionsList :data="records" :connectionId="connectionId" @delete="onDelete" />
+      </div>
+    </transition>
 
-    <div class="connections-view">
+    <el-tooltip
+      placement="bottom"
+      :effect="theme !== 'light' ? 'light' : 'dark'"
+      :open-delay="500"
+      :content="showConnectionList ? $t('connections.hideConnections') : $t('connections.showConnections')"
+    >
+      <a
+        href="javascript:;"
+        :class="['toggle-list-btn', 'collapse-btn', showConnectionList ? 'top' : 'bottom']"
+        @click="
+          toggleShowConnectionList({
+            showConnectionList: !showConnectionList,
+          })
+        "
+      >
+        <i class="el-icon-d-arrow-left"></i>
+      </a>
+    </el-tooltip>
+
+    <div :class="['connections-view', { 'is-list-hidden': !showConnectionList }]">
       <EmptyPage
         v-if="isEmpty && !oper"
         name="connections"
@@ -28,7 +49,7 @@
 
 <script lang="ts">
 import { Component, Vue, Watch } from 'vue-property-decorator'
-import { Action } from 'vuex-class'
+import { Action, Getter } from 'vuex-class'
 import { loadConnections, loadConnection } from '@/utils/api/connection'
 import EmptyPage from '@/components/EmptyPage.vue'
 import ConnectionsList from './ConnectionsList.vue'
@@ -49,6 +70,12 @@ export default class Connections extends Vue {
   @Action('CHANGE_ALL_CONNECTIONS') private changeAllConnections!: (payload: {
     allConnections: ConnectionModel[] | []
   }) => void
+  @Action('TOGGLE_SHOW_CONNECTION_LIST') private toggleShowConnectionList!: (payload: {
+    showConnectionList: boolean
+  }) => void
+
+  @Getter('currentTheme') private theme!: Theme
+  @Getter('showConnectionList') private showConnectionList!: boolean
 
   private isEmpty: boolean = false
   private records: ConnectionModel[] | [] = []
@@ -122,9 +149,73 @@ export default class Connections extends Vue {
 </script>
 
 <style lang="scss">
+@import '~@/assets/scss/mixins.scss';
+
+$collapse-ease: cubic-bezier(0.4, 0, 0.2, 1);
+$collapse-duration: 0.3s;
+
 .connections {
   .titlebar {
     padding: 16px;
+  }
+  a.toggle-list-btn {
+    position: fixed;
+    top: 21px;
+    left: 369px;
+    z-index: 1001;
+    font-size: 18px;
+    line-height: 1;
+    transition: left $collapse-duration $collapse-ease, transform $collapse-duration $collapse-ease;
+    @media (min-width: 1920px) {
+      left: 489px;
+    }
+  }
+  @include collapse-btn-transform(0deg, 180deg);
+  .connections-view {
+    .right-topbar {
+      transition: left $collapse-duration $collapse-ease;
+    }
+    .connections-detail-main {
+      transition: margin-left $collapse-duration $collapse-ease, padding-top 0.3s;
+    }
+    .connections-detail-main .connections-body .filter-bar {
+      transition: left $collapse-duration $collapse-ease;
+    }
+    .connections-footer {
+      transition: margin-left $collapse-duration $collapse-ease;
+    }
+    .left-panel > div {
+      transition: left $collapse-duration $collapse-ease;
+    }
+  }
+  .connections-view.is-list-hidden {
+    .right-topbar,
+    .connections-detail-main .connections-body .filter-bar,
+    .left-panel > div {
+      left: 76px;
+    }
+    .right-content {
+      margin-left: 76px;
+    }
+    .right-topbar .topbar .connection-head {
+      padding-left: 32px;
+    }
+    @media (min-width: 1920px) {
+      .right-topbar,
+      .connections-detail-main .connections-body .filter-bar,
+      .left-panel > div {
+        left: 116px;
+      }
+      .right-content {
+        margin-left: 116px;
+      }
+    }
+  }
+}
+.connections a.toggle-list-btn.bottom {
+  left: 92px;
+  @media (min-width: 1920px) {
+    left: 132px;
   }
 }
 .left-list {
@@ -149,5 +240,14 @@ export default class Connections extends Vue {
     left: 40%;
     color: var(--color-text-light);
   }
+}
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform $collapse-duration $collapse-ease, opacity $collapse-duration $collapse-ease;
+}
+.slide-enter,
+.slide-leave-to {
+  transform: translateX(-100%);
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
## Summary

Brings the desktop app's "show/hide connections list" feature to the web build. The connections list pane on the left can now be collapsed to give more horizontal space to messages, subscriptions, and the publish editor — which is especially useful for long topic trees or wide payloads.

State is persisted to `localStorage` (`showConnectionList`) so the layout sticks across reloads.

## Behavior

- A single rotating chevron sits at the top-left of the detail pane. Clicking it slides the list out (or back in) — same `.collapse-btn` + `collapse-btn-transform(...)` pattern used for the inner client-info collapse, so the feel is consistent with the existing topbar behavior.
- All affected layout offsets (`.right-topbar`, `.connections-detail-main` margin, `.filter-bar`, the subscriptions `LeftPanel`, plus the dynamic `marginLeft` getter that accounts for `showSubs` + `largeDesktop`) reflow with matching `0.3s cubic-bezier(0.4, 0, 0.2, 1)` transitions.
- The Leftbar's connections icon is now route-aware: if you're already on `/recent_connections` **or any of its subpages** (i.e. a connection detail / form at `/recent_connections/:id`, including the `?oper=create` form), clicking it **toggles** the pane in-place; from anywhere else (settings, help, about) it routes to `/recent_connections` as before without toggling. This means you can collapse/expand the list without leaving the connection you're currently viewing or editing.

## Why this exists in desktop but not web

The desktop variant (`src/`) already has this feature (`showConnectionList` in `store/modules/app.ts`, `iconfont icon-hide-connections` / `icon-show-connections` in `ConnectionsList.vue` and `ConnectionsDetail.vue`). The web variant (`web/src/`) shipped without it — the `.left-list` div in `web/src/views/connections/index.vue` had no toggle wrapper, no Vuex state, and no buttons. This PR closes that parity gap.

## Files

| File | Change |
| --- | --- |
| `web/src/store/modules/app.ts` | `showConnectionList` state, `TOGGLE_SHOW_CONNECTION_LIST` mutation + action, `localStorage` persistence |
| `web/src/store/getter.ts` | new `showConnectionList` getter |
| `web/src/types/global.d.ts` | `App.showConnectionList: boolean` |
| `web/src/lang/connections.ts` | `hideConnections` / `showConnections` (zh, en, ja) |
| `web/src/views/connections/index.vue` | transition wrapper, toggle button, layout overrides, transitions |
| `web/src/views/connections/ConnectionsDetail.vue` | `showConnectionList` getter wired into the existing `marginLeft` getter so the right-side reflows correctly |
| `web/src/components/Leftbar.vue` | route-aware toggle on the connections icon |

## Test plan

- [ ] Toggle the chevron — list slides out, detail/empty/form pane fills the freed space
- [ ] Reload the page — state is restored from `localStorage`
- [ ] With a connection open and subscriptions visible, toggle — filter bar, footer, message list, and subscriptions popup all reflow smoothly
- [ ] Switch to settings / help / about with list hidden — return via the Leftbar connections icon → routes there without changing the toggle state
- [ ] On `/recent_connections` (list view), click the Leftbar connections icon → toggles in place
- [ ] On `/recent_connections/:id` (connection detail or `?oper=create` form), click the Leftbar connections icon → toggles in place without navigating away
- [ ] Try at <1920px and ≥1920px viewports — offsets adapt for both breakpoints
- [ ] Light / dark / night themes — chevron color follows `var(--color-main-green)`

## Screenshots

**Collapsed** — list hidden, chevron points right; the detail / publish / subscriptions area expands into the freed space.
<img width="264" height="772" alt="collapsed" src="https://github.com/user-attachments/assets/db5abf28-207f-439e-9923-a9a7639c6b5a" />

**Expanded** — list visible (default state), chevron points left and rotates 180° on toggle, matching the inner topbar's collapse animation.
<img width="920" height="744" alt="expanded" src="https://github.com/user-attachments/assets/8303a713-4a4f-425d-9c4b-d4227b5b8994" />
