### PR TITLE
feat(web): add collapsible connections list pane (desktop icon pattern)

### DIFF
--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -41,12 +41,7 @@ const getShowConnectionList = (): boolean => {
   if (!_showConnectionList) {
     return true
   }
-  try {
-    const parsedShowConnectionList: unknown = JSON.parse(_showConnectionList)
-    return typeof parsedShowConnectionList === 'boolean' ? parsedShowConnectionList : true
-  } catch (error) {
-    return true
-  }
+  return JSON.parse(_showConnectionList)
 }
 
 const settingData = getGlobal('sharedData')

--- a/src/store/modules/app.ts
+++ b/src/store/modules/app.ts
@@ -41,7 +41,12 @@ const getShowConnectionList = (): boolean => {
   if (!_showConnectionList) {
     return true
   }
-  return JSON.parse(_showConnectionList)
+  try {
+    const parsedShowConnectionList: unknown = JSON.parse(_showConnectionList)
+    return typeof parsedShowConnectionList === 'boolean' ? parsedShowConnectionList : true
+  } catch (error) {
+    return true
+  }
 }
 
 const settingData = getGlobal('sharedData')

--- a/web/src/components/Leftbar.vue
+++ b/web/src/components/Leftbar.vue
@@ -7,7 +7,7 @@
         </a>
       </div>
       <div :class="[{ active: isConnection }, 'leftbar-item']">
-        <a href="javascript:;" @click="routeToPage('/recent_connections')">
+        <a href="javascript:;" @click="openConnections">
           <i class="iconfont icon-connections"></i>
         </a>
       </div>
@@ -40,11 +40,16 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
-import { Getter } from 'vuex-class'
+import { Getter, Action } from 'vuex-class'
 
 @Component
 export default class Leftbar extends Vue {
   @Getter('currentLang') private getterLang!: Language
+  @Getter('showConnectionList') private showConnectionList!: boolean
+
+  @Action('TOGGLE_SHOW_CONNECTION_LIST') private toggleShowConnectionList!: (payload: {
+    showConnectionList: boolean
+  }) => void
 
   get siteLink(): string {
     return this.getterLang === 'zh' ? 'https://mqttx.app/zh' : 'https://mqttx.app/'
@@ -71,6 +76,14 @@ export default class Leftbar extends Vue {
         path,
       })
       .catch(() => {})
+  }
+
+  private openConnections() {
+    if (this.isConnection) {
+      this.toggleShowConnectionList({ showConnectionList: !this.showConnectionList })
+    } else {
+      this.routeToPage('/recent_connections')
+    }
   }
 }
 </script>

--- a/web/src/database/index.ts
+++ b/web/src/database/index.ts
@@ -11,6 +11,7 @@ interface Schema {
     autoCheck: boolean
     currentLang: string
     currentTheme: string
+    showConnectionList: boolean
   }
   connections: []
   suggestConnections: []
@@ -48,6 +49,9 @@ class DB {
     // Set auto scroll interval to 1 second by default
     if (!this.db.has('settings.autoScrollInterval').value()) {
       this.db.set('settings.autoScrollInterval', 0).write()
+    }
+    if (!this.db.has('settings.showConnectionList').value()) {
+      this.db.set('settings.showConnectionList', true).write()
     }
     // Set max reconnection times
     if (!this.db.get('settings.maxReconnectTimes').value()) {

--- a/web/src/lang/connections.ts
+++ b/web/src/lang/connections.ts
@@ -9,6 +9,16 @@ export default {
     en: 'New Connection',
     ja: '新規接続',
   },
+  hideConnections: {
+    zh: '隐藏连接列表',
+    en: 'Hide Connections',
+    ja: '接続リストを非表示',
+  },
+  showConnections: {
+    zh: '显示连接列表',
+    en: 'Show Connections',
+    ja: '接続リストを表示',
+  },
   search: {
     zh: '搜索',
     en: 'Search',

--- a/web/src/store/getter.ts
+++ b/web/src/store/getter.ts
@@ -14,6 +14,7 @@ const getters = {
   allConnections: (state: State) => state.app.allConnections,
   multiTopics: (state: State) => state.app.multiTopics,
   topicWhitespaceDetection: (state: State) => state.app.topicWhitespaceDetection,
+  showConnectionList: (state: State) => state.app.showConnectionList,
 }
 
 export default getters

--- a/web/src/store/modules/app.ts
+++ b/web/src/store/modules/app.ts
@@ -18,6 +18,15 @@ const TOGGLE_ADVANCED_VISIBLE = 'TOGGLE_ADVANCED_VISIBLE'
 const CHANGE_ALL_CONNECTIONS = 'CHANGE_ALL_CONNECTIONS'
 const TOGGLE_MULTI_TOPICS = 'TOGGLE_MULTI_TOPICS'
 const TOGGLE_TOPIC_WHITESPACE_DETECTION = 'TOGGLE_TOPIC_WHITESPACE_DETECTION'
+const TOGGLE_SHOW_CONNECTION_LIST = 'TOGGLE_SHOW_CONNECTION_LIST'
+
+const getShowConnectionList = (): boolean => {
+  const _showConnectionList: string | null = localStorage.getItem('showConnectionList')
+  if (!_showConnectionList) {
+    return true
+  }
+  return JSON.parse(_showConnectionList)
+}
 
 const stateRecord: App = loadSettings()
 
@@ -38,6 +47,7 @@ const app = {
     advancedVisible: true,
     willMessageVisible: true,
     allConnections: [],
+    showConnectionList: getShowConnectionList(),
   },
   mutations: {
     [TOGGLE_THEME](state: App, currentTheme: Theme) {
@@ -115,6 +125,10 @@ const app = {
     [CHANGE_ALL_CONNECTIONS](state: App, allConnections: ConnectionModel[] | []) {
       state.allConnections = allConnections
     },
+    [TOGGLE_SHOW_CONNECTION_LIST](state: App, showConnectionList: boolean) {
+      state.showConnectionList = showConnectionList
+      localStorage.setItem('showConnectionList', JSON.stringify(state.showConnectionList))
+    },
   },
   actions: {
     TOGGLE_THEME({ commit }: any, payload: App) {
@@ -176,6 +190,9 @@ const app = {
     },
     CHANGE_ALL_CONNECTIONS({ commit }: any, payload: App) {
       commit(CHANGE_ALL_CONNECTIONS, payload.allConnections)
+    },
+    TOGGLE_SHOW_CONNECTION_LIST({ commit }: any, payload: App) {
+      commit(TOGGLE_SHOW_CONNECTION_LIST, payload.showConnectionList)
     },
   },
 }

--- a/web/src/store/modules/app.ts
+++ b/web/src/store/modules/app.ts
@@ -20,19 +20,6 @@ const TOGGLE_MULTI_TOPICS = 'TOGGLE_MULTI_TOPICS'
 const TOGGLE_TOPIC_WHITESPACE_DETECTION = 'TOGGLE_TOPIC_WHITESPACE_DETECTION'
 const TOGGLE_SHOW_CONNECTION_LIST = 'TOGGLE_SHOW_CONNECTION_LIST'
 
-const getShowConnectionList = (): boolean => {
-  const _showConnectionList: string | null = localStorage.getItem('showConnectionList')
-  if (!_showConnectionList) {
-    return true
-  }
-  try {
-    const parsedShowConnectionList: unknown = JSON.parse(_showConnectionList)
-    return typeof parsedShowConnectionList === 'boolean' ? parsedShowConnectionList : true
-  } catch (error) {
-    return true
-  }
-}
-
 const stateRecord: App = loadSettings()
 
 const app = {
@@ -52,7 +39,7 @@ const app = {
     advancedVisible: true,
     willMessageVisible: true,
     allConnections: [],
-    showConnectionList: getShowConnectionList(),
+    showConnectionList: stateRecord.showConnectionList ?? true,
   },
   mutations: {
     [TOGGLE_THEME](state: App, currentTheme: Theme) {
@@ -132,7 +119,6 @@ const app = {
     },
     [TOGGLE_SHOW_CONNECTION_LIST](state: App, showConnectionList: boolean) {
       state.showConnectionList = showConnectionList
-      localStorage.setItem('showConnectionList', JSON.stringify(state.showConnectionList))
     },
   },
   actions: {
@@ -197,6 +183,7 @@ const app = {
       commit(CHANGE_ALL_CONNECTIONS, payload.allConnections)
     },
     TOGGLE_SHOW_CONNECTION_LIST({ commit }: any, payload: App) {
+      setSettings('settings.showConnectionList', payload.showConnectionList)
       commit(TOGGLE_SHOW_CONNECTION_LIST, payload.showConnectionList)
     },
   },

--- a/web/src/store/modules/app.ts
+++ b/web/src/store/modules/app.ts
@@ -25,7 +25,12 @@ const getShowConnectionList = (): boolean => {
   if (!_showConnectionList) {
     return true
   }
-  return JSON.parse(_showConnectionList)
+  try {
+    const parsedShowConnectionList: unknown = JSON.parse(_showConnectionList)
+    return typeof parsedShowConnectionList === 'boolean' ? parsedShowConnectionList : true
+  } catch (error) {
+    return true
+  }
 }
 
 const stateRecord: App = loadSettings()

--- a/web/src/types/global.d.ts
+++ b/web/src/types/global.d.ts
@@ -134,6 +134,7 @@ declare global {
     willMessageVisible: boolean
     advancedVisible: boolean
     allConnections: ConnectionModel[] | []
+    showConnectionList: boolean
   }
 
   interface State {

--- a/web/src/views/connections/ConnectionsDetail.vue
+++ b/web/src/views/connections/ConnectionsDetail.vue
@@ -261,6 +261,7 @@ export default class ConnectionsDetail extends Vue {
   @Getter('showClientInfo') private clientInfoVisibles!: {
     [id: string]: boolean
   }
+  @Getter('showConnectionList') private showConnectionList!: boolean
 
   /**
    * Notice: when we jump order by `other page` -> `creation page` -> `connection page`,
@@ -490,8 +491,17 @@ export default class ConnectionsDetail extends Vue {
   }
 
   get marginLeft(): string {
-    const left = this.showSubs ? (this.largeDesktop ? '916px' : '676px') : this.largeDesktop ? '517px' : '397px'
-    return left
+    if (!this.showConnectionList) {
+      // ConnectionsList hidden: subtract its width (320px / 400px) from the offsets.
+      return this.showSubs
+        ? this.largeDesktop
+          ? '516px'
+          : '356px'
+        : this.largeDesktop
+        ? '116px'
+        : '76px'
+    }
+    return this.showSubs ? (this.largeDesktop ? '916px' : '676px') : this.largeDesktop ? '517px' : '397px'
   }
 
   get subListRef(): SubscriptionsList {

--- a/web/src/views/connections/ConnectionsDetail.vue
+++ b/web/src/views/connections/ConnectionsDetail.vue
@@ -5,6 +5,21 @@
         <div class="topbar">
           <div class="connection-head">
             <el-tooltip
+              v-if="!showConnectionList"
+              placement="bottom"
+              :effect="theme !== 'light' ? 'light' : 'dark'"
+              :open-delay="500"
+              :content="$t('connections.showConnections')"
+            >
+              <a
+                href="javascript:;"
+                class="show-connections-button"
+                @click="toggleShowConnectionList({ showConnectionList: true })"
+              >
+                <i class="iconfont icon-show-connections"></i>
+              </a>
+            </el-tooltip>
+            <el-tooltip
               :disabled="!showTitleTooltip"
               :effect="theme !== 'light' ? 'light' : 'dark'"
               :content="titleName"
@@ -251,6 +266,9 @@ export default class ConnectionsDetail extends Vue {
   @Action('REMOVE_ACTIVE_CONNECTION') private removeActiveConnection!: (payload: { readonly id: string }) => void
   @Action('SHOW_CLIENT_INFO') private changeShowClientInfo!: (payload: ClientInfo) => void
   @Action('UNREAD_MESSAGE_COUNT_INCREMENT') private unreadMessageIncrement!: (payload: UnreadMessage) => void
+  @Action('TOGGLE_SHOW_CONNECTION_LIST') private toggleShowConnectionList!: (payload: {
+    showConnectionList: boolean
+  }) => void
 
   @Getter('currentLang') private getterLang!: Language
   @Getter('activeConnection') private activeConnection: $TSFixed
@@ -1148,6 +1166,13 @@ export default class ConnectionsDetail extends Vue {
           &.offline {
             color: var(--color-text-light);
           }
+        }
+        .icon-show-connections {
+          font-size: 20px;
+        }
+        a.show-connections-button {
+          color: var(--color-text-title);
+          margin-right: 12px;
         }
         a.collapse-btn {
           font-size: 18px;

--- a/web/src/views/connections/index.vue
+++ b/web/src/views/connections/index.vue
@@ -1,11 +1,32 @@
 <template>
   <div class="connections">
-    <div class="left-list">
-      <h1 class="titlebar">{{ $t('connections.connections') }}</h1>
-      <ConnectionsList :data="records" :connectionId="connectionId" @delete="onDelete" />
-    </div>
+    <transition name="slide">
+      <div v-show="showConnectionList" class="left-list">
+        <h1 class="titlebar">{{ $t('connections.connections') }}</h1>
+        <ConnectionsList :data="records" :connectionId="connectionId" @delete="onDelete" />
+      </div>
+    </transition>
 
-    <div class="connections-view">
+    <el-tooltip
+      placement="bottom"
+      :effect="theme !== 'light' ? 'light' : 'dark'"
+      :open-delay="500"
+      :content="showConnectionList ? $t('connections.hideConnections') : $t('connections.showConnections')"
+    >
+      <a
+        href="javascript:;"
+        :class="['toggle-list-btn', 'collapse-btn', showConnectionList ? 'top' : 'bottom']"
+        @click="
+          toggleShowConnectionList({
+            showConnectionList: !showConnectionList,
+          })
+        "
+      >
+        <i class="el-icon-d-arrow-left"></i>
+      </a>
+    </el-tooltip>
+
+    <div :class="['connections-view', { 'is-list-hidden': !showConnectionList }]">
       <EmptyPage
         v-if="isEmpty && !oper"
         name="connections"
@@ -28,7 +49,7 @@
 
 <script lang="ts">
 import { Component, Vue, Watch } from 'vue-property-decorator'
-import { Action } from 'vuex-class'
+import { Action, Getter } from 'vuex-class'
 import { loadConnections, loadConnection } from '@/utils/api/connection'
 import EmptyPage from '@/components/EmptyPage.vue'
 import ConnectionsList from './ConnectionsList.vue'
@@ -49,6 +70,12 @@ export default class Connections extends Vue {
   @Action('CHANGE_ALL_CONNECTIONS') private changeAllConnections!: (payload: {
     allConnections: ConnectionModel[] | []
   }) => void
+  @Action('TOGGLE_SHOW_CONNECTION_LIST') private toggleShowConnectionList!: (payload: {
+    showConnectionList: boolean
+  }) => void
+
+  @Getter('currentTheme') private theme!: Theme
+  @Getter('showConnectionList') private showConnectionList!: boolean
 
   private isEmpty: boolean = false
   private records: ConnectionModel[] | [] = []
@@ -122,9 +149,73 @@ export default class Connections extends Vue {
 </script>
 
 <style lang="scss">
+@import '~@/assets/scss/mixins.scss';
+
+$collapse-ease: cubic-bezier(0.4, 0, 0.2, 1);
+$collapse-duration: 0.3s;
+
 .connections {
   .titlebar {
     padding: 16px;
+  }
+  a.toggle-list-btn {
+    position: fixed;
+    top: 21px;
+    left: 369px;
+    z-index: 1001;
+    font-size: 18px;
+    line-height: 1;
+    transition: left $collapse-duration $collapse-ease, transform $collapse-duration $collapse-ease;
+    @media (min-width: 1920px) {
+      left: 489px;
+    }
+  }
+  @include collapse-btn-transform(0deg, 180deg);
+  .connections-view {
+    .right-topbar {
+      transition: left $collapse-duration $collapse-ease;
+    }
+    .connections-detail-main {
+      transition: margin-left $collapse-duration $collapse-ease, padding-top 0.3s;
+    }
+    .connections-detail-main .connections-body .filter-bar {
+      transition: left $collapse-duration $collapse-ease;
+    }
+    .connections-footer {
+      transition: margin-left $collapse-duration $collapse-ease;
+    }
+    .left-panel > div {
+      transition: left $collapse-duration $collapse-ease;
+    }
+  }
+  .connections-view.is-list-hidden {
+    .right-topbar,
+    .connections-detail-main .connections-body .filter-bar,
+    .left-panel > div {
+      left: 76px;
+    }
+    .right-content {
+      margin-left: 76px;
+    }
+    .right-topbar .topbar .connection-head {
+      padding-left: 32px;
+    }
+    @media (min-width: 1920px) {
+      .right-topbar,
+      .connections-detail-main .connections-body .filter-bar,
+      .left-panel > div {
+        left: 116px;
+      }
+      .right-content {
+        margin-left: 116px;
+      }
+    }
+  }
+}
+.connections a.toggle-list-btn.bottom {
+  left: 92px;
+  @media (min-width: 1920px) {
+    left: 132px;
   }
 }
 .left-list {
@@ -149,5 +240,14 @@ export default class Connections extends Vue {
     left: 40%;
     color: var(--color-text-light);
   }
+}
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform $collapse-duration $collapse-ease, opacity $collapse-duration $collapse-ease;
+}
+.slide-enter,
+.slide-leave-to {
+  transform: translateX(-100%);
+  opacity: 0;
 }
 </style>

--- a/web/src/views/connections/index.vue
+++ b/web/src/views/connections/index.vue
@@ -2,29 +2,28 @@
   <div class="connections">
     <transition name="slide">
       <div v-show="showConnectionList" class="left-list">
-        <h1 class="titlebar">{{ $t('connections.connections') }}</h1>
+        <div class="left-list-topbar">
+          <h1 class="titlebar">{{ $t('connections.connections') }}</h1>
+          <div class="left-list-tailbar">
+            <el-tooltip
+              placement="bottom"
+              :effect="theme !== 'light' ? 'light' : 'dark'"
+              :open-delay="500"
+              :content="$t('connections.hideConnections')"
+            >
+              <a
+                href="javascript:;"
+                class="hide-connections-button"
+                @click="toggleShowConnectionList({ showConnectionList: false })"
+              >
+                <i class="iconfont icon-hide-connections"></i>
+              </a>
+            </el-tooltip>
+          </div>
+        </div>
         <ConnectionsList :data="records" :connectionId="connectionId" @delete="onDelete" />
       </div>
     </transition>
-
-    <el-tooltip
-      placement="bottom"
-      :effect="theme !== 'light' ? 'light' : 'dark'"
-      :open-delay="500"
-      :content="showConnectionList ? $t('connections.hideConnections') : $t('connections.showConnections')"
-    >
-      <a
-        href="javascript:;"
-        :class="['toggle-list-btn', 'collapse-btn', showConnectionList ? 'top' : 'bottom']"
-        @click="
-          toggleShowConnectionList({
-            showConnectionList: !showConnectionList,
-          })
-        "
-      >
-        <i class="el-icon-d-arrow-left"></i>
-      </a>
-    </el-tooltip>
 
     <div :class="['connections-view', { 'is-list-hidden': !showConnectionList }]">
       <EmptyPage
@@ -155,22 +154,29 @@ $collapse-ease: cubic-bezier(0.4, 0, 0.2, 1);
 $collapse-duration: 0.3s;
 
 .connections {
+  .left-list-topbar {
+    @include flex-space-between;
+    min-height: 10px;
+    height: 59px;
+  }
   .titlebar {
     padding: 16px;
   }
-  a.toggle-list-btn {
-    position: fixed;
-    top: 21px;
-    left: 369px;
-    z-index: 1001;
-    font-size: 18px;
-    line-height: 1;
-    transition: left $collapse-duration $collapse-ease, transform $collapse-duration $collapse-ease;
-    @media (min-width: 1920px) {
-      left: 489px;
+  .left-list-tailbar {
+    display: flex;
+    align-items: center;
+    margin-right: 16px;
+    .hide-connections-button {
+      color: var(--color-text-title);
+      .icon-hide-connections {
+        font-size: 20px;
+        color: var(--color-text-title);
+        &:hover {
+          color: var(--color-text-title);
+        }
+      }
     }
   }
-  @include collapse-btn-transform(0deg, 180deg);
   .connections-view {
     .right-topbar {
       transition: left $collapse-duration $collapse-ease;
@@ -197,9 +203,6 @@ $collapse-duration: 0.3s;
     .right-content {
       margin-left: 76px;
     }
-    .right-topbar .topbar .connection-head {
-      padding-left: 32px;
-    }
     @media (min-width: 1920px) {
       .right-topbar,
       .connections-detail-main .connections-body .filter-bar,
@@ -210,12 +213,6 @@ $collapse-duration: 0.3s;
         margin-left: 116px;
       }
     }
-  }
-}
-.connections a.toggle-list-btn.bottom {
-  left: 92px;
-  @media (min-width: 1920px) {
-    left: 132px;
   }
 }
 .left-list {


### PR DESCRIPTION
> ⚠️ **Alternative to #2047** — same feature, different presentation.
>
> #2047 introduced the connections-list collapse with a single floating rotating chevron. This PR is the same feature implemented with the **desktop icon pattern** instead, per @ysfscream's review suggestion on #2047 ("could we align this with the existing desktop UI pattern? Desktop uses `icon-hide-connections` in the connections list header and `icon-show-connections` in the detail header when the list is hidden").
>

## Summary

Brings the desktop app's "show/hide connections list" feature to the web build. The connections list pane on the left can be collapsed to give more horizontal space to messages, subscriptions, and the publish editor — useful for long topic trees or wide payloads.

State is persisted into the existing `db` lowdb store under `settings.showConnectionList` — the same JSON blob in `localStorage` that already holds `currentTheme`, `currentLang`, `autoCheck`, etc. — so the layout sticks across reloads.

## Behavior

- **Desktop icon pattern**: `icon-hide-connections` lives in a flex topbar next to the list's `connections` titlebar; `icon-show-connections` renders inside the detail header (`.connection-head`, before the title) with `v-if="!showConnectionList"`. Mirrors `src/views/connections/ConnectionsList.vue:24-41` and `src/views/connections/ConnectionsDetail.vue:13-31` on desktop.
- From the form (`?oper=create` / edit) and empty-state views, the recovery path is the **Leftbar connections icon** — matches desktop, which also doesn't render a show-button on those views.
- The Leftbar's connections icon is route-aware: on `/recent_connections` or any of its subpages (`/recent_connections/:id`, including the `?oper=create` form), clicking it **toggles** the pane in-place; from settings/help/about it routes to `/recent_connections` as before without toggling. You can collapse/expand the list without leaving the connection you're viewing or editing.
- All affected layout offsets (`.right-topbar`, `.connections-detail-main` margin, `.filter-bar`, the subscriptions `LeftPanel`, plus the `marginLeft` getter that accounts for `showSubs` + `largeDesktop`) reflow with `0.3s cubic-bezier(0.4, 0, 0.2, 1)` transitions.

## Note on one small divergence from desktop

On the desktop app, the show-button only lives inside `ConnectionsDetail.vue` — there's no show-button on the empty-state view or the create/edit form. So on desktop, **if a user has zero registered connections and hides the list, they can't bring it back until they add at least one connection**. The pane stays hidden through the entire onboarding flow.

This PR matches desktop's icon placement exactly (no show-button on the empty-state or form views either — `src/components/EmptyPage.vue` and `src/views/connections/ConnectionForm.vue` are unchanged). What does differ: web's Leftbar connections icon is now route-aware (see `web/src/components/Leftbar.vue` change), so on `/recent_connections*` — including the empty-state view — clicking it **toggles** the pane. Net effect: visually aligned with desktop on the icons; slightly more forgiving on recovery from empty-state because the Leftbar gives users a way out. Keeping that small asymmetry — happy to remove it if reviewers prefer strict parity.

## Why this exists in desktop but not web

The desktop variant (`src/`) already has this feature (`showConnectionList` in `store/modules/app.ts`, `iconfont icon-hide-connections` / `icon-show-connections` in `ConnectionsList.vue` and `ConnectionsDetail.vue`). The web variant (`web/src/`) shipped without it — the `.left-list` div in `web/src/views/connections/index.vue` had no toggle, no Vuex state, and no buttons. This PR closes that parity gap, and unlike #2047 it also matches desktop on the presentation layer.

## Files

| File | Change |
| --- | --- |
| `web/src/store/modules/app.ts` | `showConnectionList` state, `TOGGLE_SHOW_CONNECTION_LIST` mutation + action; persists via `setSettings('settings.showConnectionList', …)` so it lives in the existing `db` lowdb store alongside theme/lang/etc. — no extra top-level `localStorage` key |
| `web/src/database/index.ts` | `showConnectionList: boolean` added to the `settings` schema, with a default of `true` on first run |
| `web/src/store/getter.ts` | new `showConnectionList` getter |
| `web/src/types/global.d.ts` | `App.showConnectionList: boolean` |
| `web/src/lang/connections.ts` | `hideConnections` / `showConnections` (zh, en, ja) |
| `web/src/views/connections/index.vue` | flex `.left-list-topbar` with hide-button, layout overrides, transitions |
| `web/src/views/connections/ConnectionsDetail.vue` | show-button in `.connection-head`, `TOGGLE_SHOW_CONNECTION_LIST` action wired, `marginLeft` getter accounts for hidden list |
| `web/src/components/Leftbar.vue` | route-aware toggle on the connections icon |

## Test plan

_Verified locally so far: light, dark, and night themes — both `icon-hide-connections` and `icon-show-connections` render correctly in all three (color follows `var(--color-text-title)`, hover state preserved). Also verified the lowdb migration: existing users without `settings.showConnectionList` get it seeded to `true` on first load._

- [ ] Hide-button in the list's titlebar — clicking slides the list out, detail/empty/form pane fills the freed space
- [ ] Show-button appears in the detail header (`.connection-head`, before the title) when the list is hidden — clicking restores the list
- [ ] On `/recent_connections` (list view), click the Leftbar connections icon → toggles in place
- [ ] On `/recent_connections/:id` (connection detail or `?oper=create` form), click the Leftbar connections icon → toggles in place without navigating away
- [ ] From the empty-state and form views with the list hidden, the Leftbar connections icon restores the list
- [ ] Reload the page — `showConnectionList` state restored from `db.settings.showConnectionList` (inspect the `db` entry in `localStorage` to confirm there's no separate `showConnectionList` key)
- [ ] With a connection open and subscriptions visible, toggle — filter bar, footer, message list, and subscriptions popup all reflow smoothly
- [ ] Switch to settings / help / about with list hidden — return via the Leftbar connections icon → routes there without changing the toggle state
- [ ] Try at <1920px and ≥1920px viewports — offsets adapt for both breakpoints
- [ ] Light / dark / night themes — both icons follow `var(--color-text-title)`

## Screenshots

<img width="575" height="319" alt="Screenshot 2026-05-21 at 15 59 12" src="https://github.com/user-attachments/assets/2bd4df8f-7e57-4ffa-99fb-229130c2f150" />
<img width="430" height="346" alt="Screenshot 2026-05-21 at 15 59 21" src="https://github.com/user-attachments/assets/734db915-0043-402d-a1ae-9ae8fed41d15" />

