### PR TITLE
feat(connections): move Clear History button from menu to hotbar

### DIFF
--- a/src/views/connections/ConnectionsDetail.vue
+++ b/src/views/connections/ConnectionsDetail.vue
@@ -147,6 +147,16 @@
                   <i class="iconfont icon-edit"></i>
                 </a>
               </el-tooltip>
+              <el-tooltip
+                placement="bottom"
+                :effect="theme !== 'light' ? 'light' : 'dark'"
+                :open-delay="500"
+                :content="$t('connections.clearHistory')"
+              >
+                <a class="clear-history-btn" href="javascript:;" @click="handleMsgClear">
+                  <i class="iconfont icon-clear-history"></i>
+                </a>
+              </el-tooltip>
               <el-dropdown class="connection-oper" trigger="click" @command="handleCommand">
                 <a href="javascript:;">
                   <i class="iconfont icon-more"></i>
@@ -154,9 +164,6 @@
                 <el-dropdown-menu class="connection-oper-item" slot="dropdown">
                   <el-dropdown-item command="searchContent">
                     <i class="iconfont icon-search"></i>{{ $t('connections.searchContent') }}
-                  </el-dropdown-item>
-                  <el-dropdown-item command="clearHistory">
-                    <i class="iconfont icon-clear-history"></i>{{ $t('connections.clearHistory') }}
                   </el-dropdown-item>
                   <el-dropdown-item command="useScript" :disabled="!client.connected">
                     <i class="iconfont icon-use-script"></i>{{ $t('script.useScript') }}
@@ -2294,7 +2301,8 @@ export default class ConnectionsDetail extends Vue {
         .edit-btn,
         .connect-btn,
         .copilot-btn,
-        .new-window-btn {
+        .new-window-btn,
+        .clear-history-btn {
           margin-right: 16px;
         }
         .edit-btn {

--- a/web/src/views/connections/ConnectionsDetail.vue
+++ b/web/src/views/connections/ConnectionsDetail.vue
@@ -79,6 +79,16 @@
                 <i class="iconfont icon-edit"></i>
               </a>
             </el-tooltip>
+            <el-tooltip
+              placement="bottom"
+              :effect="theme !== 'light' ? 'light' : 'dark'"
+              :open-delay="1000"
+              :content="$t('connections.clearHistory')"
+            >
+              <a class="clear-history-btn" href="javascript:;" @click="handleMsgClear">
+                <i class="iconfont icon-clear-history"></i>
+              </a>
+            </el-tooltip>
             <el-dropdown class="connection-oper" trigger="click" @command="handleCommand">
               <a href="javascript:;">
                 <i class="iconfont icon-more"></i>
@@ -86,9 +96,6 @@
               <el-dropdown-menu class="connection-oper-item" slot="dropdown">
                 <el-dropdown-item command="searchByTopic">
                   <i class="iconfont icon-search"></i>{{ $t('connections.searchByTopic') }}
-                </el-dropdown-item>
-                <el-dropdown-item command="clearHistory">
-                  <i class="iconfont icon-clear-history"></i>{{ $t('connections.clearHistory') }}
                 </el-dropdown-item>
                 <el-dropdown-item command="disconnect" :disabled="!client.connected">
                   <i class="el-icon-switch-button"></i>{{ $t('connections.disconnect') }}
@@ -511,13 +518,7 @@ export default class ConnectionsDetail extends Vue {
   get marginLeft(): string {
     if (!this.showConnectionList) {
       // ConnectionsList hidden: subtract its width (320px / 400px) from the offsets.
-      return this.showSubs
-        ? this.largeDesktop
-          ? '516px'
-          : '356px'
-        : this.largeDesktop
-        ? '116px'
-        : '76px'
+      return this.showSubs ? (this.largeDesktop ? '516px' : '356px') : this.largeDesktop ? '116px' : '76px'
     }
     return this.showSubs ? (this.largeDesktop ? '916px' : '676px') : this.largeDesktop ? '517px' : '397px'
   }
@@ -1197,7 +1198,8 @@ export default class ConnectionsDetail extends Vue {
         .connect-loading,
         .edit-btn,
         .connect-btn,
-        .new-window-btn {
+        .new-window-btn,
+        .clear-history-btn {
           margin-right: 12px;
         }
         .edit-btn {


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

Right now to clear history user should open dropdown menu in top right and then click "Clear History" button.

#### What is the new behavior?

"Clear History" button is accessible from main screen. 
<img width="214" height="110" alt="image" src="https://github.com/user-attachments/assets/bb0190c8-9bd7-46de-9428-c306789e98a6" />


#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Other information

Action of clearing history is used very often, but hidden into collapsable menu. There are plenty of room in hotbar to include this button. 