### PR TITLE
feat(cli): Add recevied_at timestamp for received messages

### DIFF
--- a/cli/src/lib/sub.ts
+++ b/cli/src/lib/sub.ts
@@ -176,6 +176,7 @@ const sub = (options: SubscribeOptions) => {
 
     options.verbose && msgData.push({ label: 'mqtt-packet', value: packet })
 
+    msgData.push({ label: 'received_at', value: new Date().toISOString() })
     msgData.push({ label: 'topic', value: topic })
     msgData.push({ label: 'qos', value: packet.qos })
     msgData.push({ label: 'size', value: `${formatBytes(payload.length)}` })


### PR DESCRIPTION
When subscribing to topics to receive messages, several message details are shown (like topic, qos, size), in addition to the message payload.

But the date and time at which the message was received is not shown. Which makes mqttx CLI less useful as an unattended message recorder. Specially if the recorded messages are going to be used to diagnose unexpected or wrong communications, and correlate those communications with logs or other kind of diagnostics data from other sources.

Those correlations need, most of the time, a shared time line. The fact that mqttx CLI does not provide those timestamps makes those correlations impossible.

### PR Checklist

#### What is the current behavior?

The current version does not display the date and time at which each message, for the subscribed topic, was received.

#### What is the new behavior?

Now a `received_at` field is displayed, with the date and time (in ISO-8601 format, using the UTC timezone) at which a each message was received.

#### Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

#### Specific Instructions

No new instructions are needed. The only difference is that now `mqttx sub` also displays the `received_at` field.