### PR TITLE
feat(lang): add Korean (ko) language support

### DIFF
--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -52,6 +52,7 @@ import { changeDefaultLLMModel1727111519962 } from './migration/1727111519962-ch
 import { topicNodeTables1729246737362 } from './migration/1729246737362-topicNodeTables'
 import { reasonModelSupport1742835643809 } from './migration/1742835643809-reasonModelSupport'
 import { dashboardAndWidgetModels1759069904761 } from './migration/1759069904761-dashboardAndWidgetModels'
+import { koLang1783562195464 } from './migration/1783562195464-koLang'
 
 // Get store path; fall back when running in CLI (no Electron app)
 let STORE_PATH: string
@@ -114,6 +115,7 @@ const ORMConfig = {
     topicNodeTables1729246737362,
     reasonModelSupport1742835643809,
     dashboardAndWidgetModels1759069904761,
+    koLang1783562195464,
   ],
   migrationsTableName: 'temp_migration_table',
   entities: [

--- a/src/database/migration/1783562195464-koLang.ts
+++ b/src/database/migration/1783562195464-koLang.ts
@@ -1,0 +1,145 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class koLang1783562195464 implements MigrationInterface {
+  name = 'koLang1783562195464'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            CREATE TABLE "temporary_SettingEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "width" integer NOT NULL DEFAULT (1025),
+                "height" integer NOT NULL DEFAULT (749),
+                "autoCheck" boolean NOT NULL DEFAULT (1),
+                "currentLang" varchar CHECK(currentLang IN ('zh', 'en', 'ja', 'tr', 'hu', 'ko')) NOT NULL DEFAULT ('en'),
+                "currentTheme" varchar CHECK(currentTheme IN ('light', 'dark', 'night')) NOT NULL DEFAULT ('light'),
+                "maxReconnectTimes" integer NOT NULL DEFAULT (10),
+                "autoResub" boolean NOT NULL DEFAULT (1),
+                "syncOsTheme" boolean NOT NULL DEFAULT (0),
+                "multiTopics" boolean NOT NULL DEFAULT (1),
+                "jsonHighlight" boolean NOT NULL DEFAULT (1),
+                "openAIAPIKey" varchar NOT NULL DEFAULT (''),
+                "model" varchar NOT NULL DEFAULT ('gpt-4o'),
+                "enableCopilot" boolean NOT NULL DEFAULT (1),
+                "logLevel" varchar CHECK(logLevel IN ('debug', 'info', 'warn', 'error')) NOT NULL DEFAULT ('info'),
+                "openAIAPIHost" varchar NOT NULL DEFAULT ('https://api.openai.com/v1'),
+                "ignoreQoS0Message" boolean NOT NULL DEFAULT (0)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "temporary_SettingEntity"(
+                    "id",
+                    "width",
+                    "height",
+                    "autoCheck",
+                    "currentLang",
+                    "currentTheme",
+                    "maxReconnectTimes",
+                    "autoResub",
+                    "syncOsTheme",
+                    "multiTopics",
+                    "jsonHighlight",
+                    "openAIAPIKey",
+                    "model",
+                    "enableCopilot",
+                    "logLevel",
+                    "openAIAPIHost",
+                    "ignoreQoS0Message"
+                )
+            SELECT "id",
+                "width",
+                "height",
+                "autoCheck",
+                "currentLang",
+                "currentTheme",
+                "maxReconnectTimes",
+                "autoResub",
+                "syncOsTheme",
+                "multiTopics",
+                "jsonHighlight",
+                "openAIAPIKey",
+                "model",
+                "enableCopilot",
+                "logLevel",
+                "openAIAPIHost",
+                "ignoreQoS0Message"
+            FROM "SettingEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "SettingEntity"
+        `)
+    await queryRunner.query(`
+            ALTER TABLE "temporary_SettingEntity"
+                RENAME TO "SettingEntity"
+        `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+            ALTER TABLE "SettingEntity"
+                RENAME TO "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            CREATE TABLE "SettingEntity" (
+                "id" varchar PRIMARY KEY NOT NULL,
+                "width" integer NOT NULL DEFAULT (1025),
+                "height" integer NOT NULL DEFAULT (749),
+                "autoCheck" boolean NOT NULL DEFAULT (1),
+                "currentLang" varchar CHECK(currentLang IN ('zh', 'en', 'ja', 'tr', 'hu')) NOT NULL DEFAULT ('en'),
+                "currentTheme" varchar CHECK(currentTheme IN ('light', 'dark', 'night')) NOT NULL DEFAULT ('light'),
+                "maxReconnectTimes" integer NOT NULL DEFAULT (10),
+                "autoResub" boolean NOT NULL DEFAULT (1),
+                "syncOsTheme" boolean NOT NULL DEFAULT (0),
+                "multiTopics" boolean NOT NULL DEFAULT (1),
+                "jsonHighlight" boolean NOT NULL DEFAULT (1),
+                "openAIAPIKey" varchar NOT NULL DEFAULT (''),
+                "model" varchar NOT NULL DEFAULT ('gpt-4o'),
+                "enableCopilot" boolean NOT NULL DEFAULT (1),
+                "logLevel" varchar CHECK(logLevel IN ('debug', 'info', 'warn', 'error')) NOT NULL DEFAULT ('info'),
+                "openAIAPIHost" varchar NOT NULL DEFAULT ('https://api.openai.com/v1'),
+                "ignoreQoS0Message" boolean NOT NULL DEFAULT (0)
+            )
+        `)
+    await queryRunner.query(`
+            INSERT INTO "SettingEntity"(
+                    "id",
+                    "width",
+                    "height",
+                    "autoCheck",
+                    "currentLang",
+                    "currentTheme",
+                    "maxReconnectTimes",
+                    "autoResub",
+                    "syncOsTheme",
+                    "multiTopics",
+                    "jsonHighlight",
+                    "openAIAPIKey",
+                    "model",
+                    "enableCopilot",
+                    "logLevel",
+                    "openAIAPIHost",
+                    "ignoreQoS0Message"
+                )
+            SELECT "id",
+                "width",
+                "height",
+                "autoCheck",
+                CASE WHEN "currentLang" = 'ko' THEN 'en' ELSE "currentLang" END,
+                "currentTheme",
+                "maxReconnectTimes",
+                "autoResub",
+                "syncOsTheme",
+                "multiTopics",
+                "jsonHighlight",
+                "openAIAPIKey",
+                "model",
+                "enableCopilot",
+                "logLevel",
+                "openAIAPIHost",
+                "ignoreQoS0Message"
+            FROM "temporary_SettingEntity"
+        `)
+    await queryRunner.query(`
+            DROP TABLE "temporary_SettingEntity"
+        `)
+  }
+}

--- a/src/database/models/SettingEntity.ts
+++ b/src/database/models/SettingEntity.ts
@@ -14,8 +14,8 @@ export default class SettingEntity {
   @Column({ type: 'boolean', default: true })
   autoCheck!: boolean
 
-  @Column({ type: 'simple-enum', enum: ['zh', 'en', 'ja', 'tr', 'hu'], default: 'en' })
-  currentLang!: 'zh' | 'en' | 'ja' | 'tr' | 'hu'
+  @Column({ type: 'simple-enum', enum: ['zh', 'en', 'ja', 'tr', 'hu', 'ko'], default: 'en' })
+  currentLang!: 'zh' | 'en' | 'ja' | 'tr' | 'hu' | 'ko'
 
   @Column({ type: 'simple-enum', enum: ['light', 'dark', 'night'], default: 'light' })
   currentTheme!: 'light' | 'dark' | 'night'

--- a/src/lang/about.ts
+++ b/src/lang/about.ts
@@ -5,6 +5,7 @@ export default {
     ja: 'MQTTXについて',
     tr: 'Hakkında',
     hu: 'Rólunk',
+    ko: '정보',
   },
   update: {
     zh: '检查更新',
@@ -12,6 +13,7 @@ export default {
     tr: 'Güncellemeleri kontrol et',
     ja: 'バージョンチェック',
     hu: 'Frissítések keresése',
+    ko: '업데이트 확인',
   },
   web: {
     zh: '官方网站',
@@ -19,6 +21,7 @@ export default {
     tr: 'Website',
     ja: '公式サイト',
     hu: 'Weboldal',
+    ko: '웹사이트',
   },
   support: {
     zh: '支持',
@@ -26,6 +29,7 @@ export default {
     tr: 'Destek',
     ja: 'サポート',
     hu: 'Támogatás',
+    ko: '지원',
   },
   releases: {
     zh: '更新日志',
@@ -33,6 +37,7 @@ export default {
     tr: 'Sürümler',
     ja: 'リリース履歴',
     hu: 'Kiadások',
+    ko: '릴리스',
   },
   mqttxDesc: {
     zh: 'MQTTX 是一款由 EMQ 开源的 MQTT 5.0 跨平台桌面客户端，旨在帮助开发者更快的开发、调试 MQTT 服务和应用。',
@@ -40,6 +45,7 @@ export default {
     tr: 'MQTTX, geliştiricilerin MQTT hizmetlerini ve uygulamalarını daha hızlı geliştirmelerine ve hata ayıklamalarına yardımcı olmak için tasarlanmış, EMQ tarafından sağlanan açık kaynaklı bir MQTT 5.0 platformlar arası masaüstü istemcisidir.',
     ja: 'MQTTXは、EMQによるオープンソースのMQTT 5.0クロスプラットフォーム・デスクスクライアントで、開発者がMQTTサービスおよびアプリケーションをより速く開発およびデバッグできるよう設計されています。',
     hu: 'Az MQTTX egy nyílt forráskódú MQTT 5.0 cross-platform asztali kliens az EMQ-tól, amelynek célja, hogy segítse a fejlesztőket az MQTT szolgáltatások és alkalmazások gyorsabb fejlesztésében és hibakeresésében.',
+    ko: 'MQTTX는 EMQ가 오픈소스로 제공하는 크로스 플랫폼 MQTT 5.0 클라이언트 도구로, 개발자가 MQTT 서비스와 애플리케이션을 더 빠르게 개발하고 디버깅할 수 있도록 돕기 위해 설계되었습니다.',
   },
   cloudTitle: {
     zh: '立即获取一个您专属的 MQTT 服务！',
@@ -47,6 +53,7 @@ export default {
     tr: 'Hemen özel bir MQTT sunucusuna sahip olun!',
     ja: '専用のMQTTサーバーを今すぐご利用いただけます！',
     hu: 'Saját, testreszabott MQTT szerverhez juthat most!',
+    ko: '지금 바로 전용 MQTT 서버를 만나보세요!',
   },
   cloudSummary: {
     zh: '发掘物联网的强大能量，尝试使用 EMQX Cloud - 一款全托管的 MQTT 云服务平台，支持连接海量设备，使用灵活按量计费的方式实时处理数据，将物联网连接和数据处理变得更高效便捷。',
@@ -54,6 +61,7 @@ export default {
     tr: `EMQX Cloud ile IoT'un gücünü keşfedin - tamamen yönetilen MQTT bulut hizmet platformu, milyonlarca cihazı bağlar ve gerçek zamanlı verileri esnek kullanım ücreti ödeme ile işler.`,
     ja: 'EMQX Cloudを使用してIoTの強力な機能を発見しましょう。EMQX Cloudは、大規模なデバイスを接続し、リアルタイムデータを柔軟な使用料金で処理することができる完全に管理されたMQTTクラウドサービスプラットフォームです。',
     hu: 'Fedezze fel az IoT erőteljes lehetőségeit az EMQX Cloud használatával - a teljesen kezelt MQTT felhőszolgáltatási platform, amely csatlakoztatja a tömeges mennyiségű eszközöket és folyamatos adatfeldolgozást végez a rugalmas használati díj fizetési móddal.',
+    ko: 'EMQX Cloud로 IoT의 강력한 힘을 활용해보세요 - 대량의 디바이스를 연결하고 유연한 종량제 요금으로 실시간 데이터를 처리하는 완전 관리형 MQTT 클라우드 서비스 플랫폼입니다.',
   },
   tryCloud: {
     zh: '免费试用 EMQX Cloud',
@@ -61,6 +69,7 @@ export default {
     tr: "EMQX Cloud'u ücretsiz deneyin",
     ja: 'EMQX Cloudの無料体験',
     hu: 'Az EMQX Cloud ingyenes próbaverziója',
+    ko: 'EMQX Cloud 무료로 체험하기',
   },
   platformTitle: {
     zh: '统一的物联网 MQTT 平台',
@@ -68,6 +77,7 @@ export default {
     tr: 'IoT için Birleşik MQTT Platformu',
     ja: 'IoT向け統合MQTTプラットフォーム',
     hu: 'Az egységes MQTT platform az IoT számára',
+    ko: 'IoT를 위한 통합 MQTT 플랫폼',
   },
   platformDesc: {
     zh: '完整的生产级 MQTT 平台，无缝连接工业设备、边缘网关和云服务。从边缘协议桥接到超大规模云消息传递，统一在一个平台下管理您的整个物联网数据基础设施。',
@@ -75,6 +85,7 @@ export default {
     tr: 'Endüstriyel cihazları, kenar ağ geçitlerini ve bulut hizmetlerini sorunsuz bir şekilde bağlayan eksiksiz, üretim düzeyinde bir MQTT platformu.',
     ja: '産業用デバイス、エッジゲートウェイ、クラウドサービスをシームレスに接続する、完全な本番環境対応MQTTプラットフォーム。',
     hu: 'Teljes körű, éles üzemre kész MQTT platform, amely zökkenőmentesen összeköti az ipari eszközöket, peremhálózati átjárókat és felhőszolgáltatásokat.',
+    ko: '모든 것을 연결하고, 무한히 확장하세요. 산업용 디바이스, 엣지 게이트웨이, 클라우드 서비스를 위한 하나의 플랫폼으로 전체 IoT 인프라를 구동합니다.',
   },
   statDownloads: {
     zh: '产品下载量',
@@ -82,6 +93,7 @@ export default {
     tr: 'Ürün İndirmeleri',
     ja: '製品ダウンロード数',
     hu: 'Termékletöltések',
+    ko: '제품 다운로드',
   },
   statClusters: {
     zh: '全球部署集群',
@@ -89,6 +101,7 @@ export default {
     tr: 'Küresel Kümeler',
     ja: 'グローバルクラスター',
     hu: 'Globális klaszterek',
+    ko: '글로벌 클러스터',
   },
   statProtocols: {
     zh: '工业协议支持',
@@ -96,6 +109,7 @@ export default {
     tr: 'Endüstriyel Protokoller',
     ja: '産業用プロトコル',
     hu: 'Ipari protokollok',
+    ko: '산업용 프로토콜',
   },
   statLatency: {
     zh: '超低延迟',
@@ -103,6 +117,7 @@ export default {
     tr: 'Çok Düşük Gecikme',
     ja: '超低遅延',
     hu: 'Ultrarövid késleltetés',
+    ko: '초저지연',
   },
   statConnections: {
     zh: '单集群并发连接',
@@ -110,6 +125,7 @@ export default {
     tr: 'Bağlantı/Küme',
     ja: '接続数/クラスター',
     hu: 'Kapcsolat/klaszter',
+    ko: '연결 수/클러스터',
   },
   tryPlatform: {
     zh: '立即免费试用',
@@ -117,6 +133,7 @@ export default {
     tr: 'Ücretsiz Denemeyi Başlat',
     ja: '無料トライアルを開始',
     hu: 'Ingyenes próba indítása',
+    ko: '무료 체험 시작',
   },
   signIn: {
     zh: '登录',
@@ -124,5 +141,6 @@ export default {
     tr: 'Giriş Yap',
     ja: 'サインイン',
     hu: 'Bejelentkezés',
+    ko: '로그인',
   },
 }

--- a/src/lang/common.ts
+++ b/src/lang/common.ts
@@ -5,6 +5,7 @@ export default {
     tr: 'İptal',
     ja: 'キャンセル',
     hu: 'Mégsem',
+    ko: '취소',
   },
   confirm: {
     zh: '确定',
@@ -12,6 +13,7 @@ export default {
     tr: 'Onayla',
     ja: '確認',
     hu: 'Megerősít',
+    ko: '확인',
   },
   inputRequired: {
     zh: '请输入',
@@ -19,6 +21,7 @@ export default {
     tr: 'Lütfen girin',
     ja: '入力してください',
     hu: 'Kérjük adja meg',
+    ko: '입력해 주세요',
   },
   selectRequired: {
     zh: '请选择',
@@ -26,6 +29,7 @@ export default {
     tr: 'Lütfen seçin',
     ja: '選択してください',
     hu: 'Kérjük válassza ki',
+    ko: '선택해 주세요',
   },
   back: {
     zh: '返回',
@@ -33,6 +37,7 @@ export default {
     tr: 'Geri',
     ja: '戻る',
     hu: 'Vissza',
+    ko: '뒤로',
   },
   save: {
     zh: '保 存',
@@ -40,6 +45,7 @@ export default {
     tr: 'Kaydet',
     ja: '保存',
     hu: 'Mentés',
+    ko: '저장',
   },
   saveOnly: {
     zh: '仅保存',
@@ -47,6 +53,7 @@ export default {
     tr: 'Sadece Kaydet',
     ja: '保存のみ',
     hu: 'Csak Mentés',
+    ko: '저장만',
   },
   reset: {
     zh: '重置',
@@ -54,6 +61,7 @@ export default {
     tr: 'sıfırlama',
     ja: 'リセット',
     hu: 'átszed',
+    ko: '초기화',
   },
   disable: {
     zh: '禁用',
@@ -61,6 +69,7 @@ export default {
     tr: 'Devre dışı bırakmak',
     ja: '無効にする',
     hu: 'Letiltás',
+    ko: '사용 안 함',
   },
   enable: {
     zh: '启用',
@@ -68,6 +77,7 @@ export default {
     tr: 'Etkinleştirme',
     ja: '有効',
     hu: 'Engedélyezze',
+    ko: '사용',
   },
   noData: {
     zh: '暂无数据',
@@ -75,6 +85,7 @@ export default {
     tr: 'Veri yok',
     ja: 'データなし',
     hu: 'Nincs adat',
+    ko: '데이터 없음',
   },
   createSuccess: {
     zh: '创建成功',
@@ -82,6 +93,7 @@ export default {
     tr: 'Kayıt Edildi',
     ja: '新規に成功しました',
     hu: 'Sikeresen létrehozva',
+    ko: '생성 성공',
   },
   createfailed: {
     zh: '创建失败',
@@ -89,6 +101,7 @@ export default {
     tr: 'Kayıt Edilemedi',
     ja: '新規に失敗しました',
     hu: 'Sikertelen létrehozás',
+    ko: '생성 실패',
   },
   editSuccess: {
     zh: '编辑成功',
@@ -96,6 +109,7 @@ export default {
     tr: 'Düzenlendi',
     ja: '更新に成功しました',
     hu: 'Sikeres szerkeztés',
+    ko: '편집 성공',
   },
   editfailed: {
     zh: '编辑失败',
@@ -103,6 +117,7 @@ export default {
     tr: 'Düzenlenemedi',
     ja: '更新に失敗しました',
     hu: 'Sikertelen szerkeztés',
+    ko: '편집 실패',
   },
   deleteSuccess: {
     zh: '删除成功',
@@ -110,6 +125,7 @@ export default {
     tr: 'Silindi',
     ja: '削除に成功しました',
     hu: 'Sikeres törlés',
+    ko: '삭제 성공',
   },
   deletefailed: {
     zh: '删除失败',
@@ -117,6 +133,7 @@ export default {
     tr: 'Silinemedi',
     ja: '削除に失敗しました',
     hu: 'Sikertelen törlés',
+    ko: '삭제 실패',
   },
   saveSuccess: {
     zh: '保存成功',
@@ -124,6 +141,7 @@ export default {
     tr: 'Kaydetme Başarılı',
     ja: '保存に成功しました',
     hu: 'Sikeres mentés',
+    ko: '저장 성공',
   },
   warning: {
     zh: '提示',
@@ -131,6 +149,7 @@ export default {
     tr: 'Uyarı',
     ja: 'ワーニング',
     hu: 'Figyelem',
+    ko: '경고',
   },
   confirmDelete: {
     zh: '此操作将删除 {name}，是否继续？',
@@ -138,6 +157,7 @@ export default {
     tr: '{name} silinecek, devam edilsin mi?',
     ja: '該当操作は{name}を削除してもよろしいですか？',
     hu: '{name} törlésre fog kerülni, folytatja?',
+    ko: '{name}을(를) 삭제합니다. 계속하시겠습니까?',
   },
   confirmReset: {
     zh: '此操作将重置发送时的属性配置，是否继续？',
@@ -145,6 +165,7 @@ export default {
     tr: 'Bu, özellikleri sıfırlayacak, devam edilsin mi?',
     ja: '該当操作はpropertiesを削除してもよろしいですか？',
     hu: 'Ez visszaállítja a tulajdonságokat, folytatja?',
+    ko: '속성을 초기화합니다. 계속하시겠습니까?',
   },
   new: {
     zh: '新 建',
@@ -152,6 +173,7 @@ export default {
     tr: 'Yeni',
     ja: '新 規',
     hu: 'Új',
+    ko: '신규',
   },
   delete: {
     zh: '删 除',
@@ -159,6 +181,7 @@ export default {
     tr: 'Sil',
     ja: '削 除',
     hu: 'Törlés',
+    ko: '삭제',
   },
   edit: {
     zh: '编 辑',
@@ -166,6 +189,7 @@ export default {
     tr: 'Düzenle',
     ja: '編 集',
     hu: 'Szerkesztés',
+    ko: '편집',
   },
   unitS: {
     zh: '秒',
@@ -173,6 +197,7 @@ export default {
     tr: 's',
     ja: '秒',
     hu: 's',
+    ko: '초',
   },
   unitMS: {
     zh: '毫秒',
@@ -180,6 +205,7 @@ export default {
     tr: 'ms',
     ja: 'ミリ秒',
     hu: 'ms',
+    ko: '밀리초',
   },
   config: {
     zh: '编辑连接',
@@ -187,6 +213,7 @@ export default {
     tr: 'Bağlantıyı Düzenle',
     ja: '接続の編集',
     hu: 'Kapcsolat szerkesztése',
+    ko: '연결 편집',
   },
   copy: {
     zh: '复 制',
@@ -194,6 +221,7 @@ export default {
     tr: 'Kopyala',
     ja: 'コピー',
     hu: 'Másolás',
+    ko: '복사',
   },
 
   copyTarget: {
@@ -202,6 +230,7 @@ export default {
     tr: '{target} Kopyala',
     ja: '{target} をコピー',
     hu: '{target} másolása',
+    ko: '{target} 복사',
   },
   copyTargetSuccess: {
     zh: '{target} 复制成功',
@@ -209,6 +238,7 @@ export default {
     tr: '{target} kopyalandı',
     ja: '{target} をコピーしました',
     hu: '{target} másolva',
+    ko: '{target} 복사됨',
   },
   copyTargetFailed: {
     zh: '{target} 复制失败',
@@ -216,6 +246,7 @@ export default {
     tr: '{target} kopyalanamadı',
     ja: '{target} のコピーに失敗しました',
     hu: '{target} másolása sikertelen',
+    ko: '{target} 복사 실패',
   },
   copySuccess: {
     zh: '复制成功',
@@ -223,6 +254,7 @@ export default {
     tr: 'Kopyalandı',
     ja: 'コピーが成功しました',
     hu: 'Sikeres másolás',
+    ko: '복사 성공',
   },
   copied: {
     zh: '已复制',
@@ -230,6 +262,7 @@ export default {
     tr: 'Kopyalandı',
     ja: 'コピー済み',
     hu: 'Másolva',
+    ko: '복사됨',
   },
   copyFailed: {
     zh: '复制失败',
@@ -237,6 +270,7 @@ export default {
     tr: 'Kopyalanamadı',
     ja: 'コピーが失敗しました',
     hu: 'Sikertelen másolás',
+    ko: '복사 실패',
   },
   exportSuccess: {
     zh: '导出成功',
@@ -244,6 +278,7 @@ export default {
     tr: 'başarıyla dışa aktarıldı',
     ja: 'のエクスポートが成功しました',
     hu: 'Sikeres exportálás',
+    ko: '내보내기 성공',
   },
   importSuccess: {
     zh: '导入成功',
@@ -251,6 +286,7 @@ export default {
     tr: 'Başarıyla içe aktarıldı',
     ja: 'インポートが成功しました',
     hu: 'Sikeres importálás',
+    ko: '가져오기 성공',
   },
   newWindow: {
     zh: '新建窗口',
@@ -258,6 +294,7 @@ export default {
     tr: 'Yeni pencere',
     ja: '新しいウィンドウ',
     hu: 'Új ablak',
+    ko: '새 창',
   },
   version: {
     zh: '版本：',
@@ -265,6 +302,7 @@ export default {
     tr: 'Versiyon: ',
     ja: 'システムバージョン：',
     hu: 'Verzió: ',
+    ko: '버전: ',
   },
   uptime: {
     zh: '运行时间：',
@@ -272,6 +310,7 @@ export default {
     tr: 'Çalışma süresi: ',
     ja: '稼働時間：',
     hu: 'Futásidő: ',
+    ko: '가동 시간: ',
   },
   emqx: {
     zh: '想要部署一个自托管的 MQTT 服务，试试 {emqx} 吧。',
@@ -279,6 +318,7 @@ export default {
     tr: "Kendi yönettiğiniz bir MQTT Broker'a sahip olmak için {emqx}'i deneyin.",
     ja: '自己管理型のMQTT Brokerをデプロイするには、{emqx}を試してください。',
     hu: 'Próbálja ki a saját maga kezelésében lévő MQTT Broker telepítését a {emqx} segítségével.',
+    ko: '자체 관리형 MQTT 브로커를 배포하려면 {emqx}를 사용해 보세요.',
   },
   cloud: {
     zh: '需要一个云原生的全托管 MQTT 服务？一键部署 {cloud}！',
@@ -286,6 +326,7 @@ export default {
     tr: "Tamamen yönetilen bir MQTT bulut hizmetine mi ihtiyacınız var? {cloud}'i şimdi deneyin!",
     ja: '完全に管理されたMQTTクラウドサービスが必要ですか？今すぐ{cloud}を試してください！',
     hu: 'Szüksége van egy teljesen kezelt MQTT felhőszolgáltatásra? Próbálja ki most a {cloud}!',
+    ko: '완전 관리형 MQTT 클라우드 서비스가 필요하신가요? 지금 {cloud}를 사용해 보세요!',
   },
   duplicate: {
     zh: '复制连接',
@@ -293,6 +334,7 @@ export default {
     tr: 'Kopyala',
     ja: '複製',
     hu: 'Másol',
+    ko: '복제',
   },
   neverExpire: {
     zh: '永不过期',
@@ -300,6 +342,7 @@ export default {
     tr: 'Süresiz',
     ja: '期限なし',
     hu: 'Soha ne járjon le',
+    ko: '만료 없음',
   },
   newMsg: {
     zh: '{count} 条新消息 | {count} 条新消息',
@@ -307,6 +350,7 @@ export default {
     tr: '{count} yeni mesaj | {count} yeni mesaj',
     ja: '{count}件の新しいメッセージ | {count}件の新しいメッセージ',
     hu: '{count} új üzenet | {count} új üzenet',
+    ko: '새 메시지 {count}개 | 새 메시지 {count}개',
   },
   seeMore: {
     zh: '查看更多',
@@ -314,6 +358,7 @@ export default {
     tr: 'Daha Fazla',
     ja: 'もっと見る',
     hu: 'Továbbiak',
+    ko: '더 보기',
   },
   viewData: {
     zh: '查看数据',
@@ -321,6 +366,7 @@ export default {
     tr: 'Veriyi Görüntüle',
     ja: 'データを表示',
     hu: 'Adatok meg',
+    ko: '데이터 보기',
   },
   saveToLocal: {
     zh: '保存到本地',
@@ -328,6 +374,7 @@ export default {
     tr: 'Yerel olarak kaydet',
     ja: 'ローカルに保存',
     hu: 'Mentés helyileg',
+    ko: '로컬에 저장',
   },
   msgType: {
     zh: '消息类型',
@@ -335,6 +382,7 @@ export default {
     tr: 'Mesaj Türü',
     ja: 'メッセージタイプ',
     hu: 'Üzenet típus',
+    ko: '메시지 유형',
   },
   last5Minutes: {
     zh: '最近 5 分钟',
@@ -342,6 +390,7 @@ export default {
     tr: 'Son 5 Dakika',
     ja: '最近 5分間',
     hu: 'Utoljára 5 perc',
+    ko: '최근 5분',
   },
   last30Minutes: {
     zh: '最近 30 分钟',
@@ -349,6 +398,7 @@ export default {
     tr: 'Son 30 Dakika',
     ja: '最近 30 分間',
     hu: 'Utoljára 30 perc',
+    ko: '최근 30분',
   },
   lastHour: {
     zh: '最近 1 小时',
@@ -356,6 +406,7 @@ export default {
     tr: 'Son 1 Saat',
     ja: '最近 1 時間',
     hu: 'Utoljára 1 óra',
+    ko: '최근 1시간',
   },
   lastDay: {
     zh: '最近 1 天',
@@ -363,6 +414,7 @@ export default {
     tr: 'Son 1 Gün',
     ja: '最近 1 日',
     hu: 'Utoljára 1 nap',
+    ko: '최근 1일',
   },
   lastWeek: {
     zh: '最近 1 周',
@@ -370,6 +422,7 @@ export default {
     tr: 'Son 1 Hafta',
     ja: '最近 1 週間',
     hu: 'Utoljára 1 hét',
+    ko: '최근 1주',
   },
   startTime: {
     zh: '开始时间',
@@ -377,6 +430,7 @@ export default {
     tr: 'Başlangıç Zamanı',
     ja: '開始時間',
     hu: 'Kezdés időpontja',
+    ko: '시작 시간',
   },
   endTime: {
     zh: '结束时间',
@@ -384,5 +438,6 @@ export default {
     tr: 'Bitiş Zamanı',
     ja: '終了時間',
     hu: 'Befejezés időpontja',
+    ko: '종료 시간',
   },
 }

--- a/src/lang/connections.ts
+++ b/src/lang/connections.ts
@@ -5,6 +5,7 @@ export default {
     tr: 'Bağlantılar',
     ja: '接続',
     hu: 'Kapcsolatok',
+    ko: '연결',
   },
   newConnections: {
     zh: '新建连接',
@@ -12,6 +13,7 @@ export default {
     tr: 'Yeni bağlantı',
     ja: '新しい接続',
     hu: 'Új kapcsolat',
+    ko: '새 연결',
   },
   search: {
     zh: '搜索',
@@ -19,6 +21,7 @@ export default {
     tr: 'Ara',
     ja: '検索',
     hu: 'Keresés',
+    ko: '검색',
   },
   topicCopied: {
     zh: '复制成功!',
@@ -26,6 +29,7 @@ export default {
     tr: 'Konu kopyalandı!',
     ja: 'コピーが成功しました',
     hu: 'Téma másolva!',
+    ko: '토픽이 복사되었습니다!',
   },
   clearHistory: {
     zh: '清除历史记录',
@@ -33,6 +37,7 @@ export default {
     tr: 'Geçmişi Temizle',
     ja: '履歴データの削除',
     hu: 'Előzmények törlése',
+    ko: '기록 삭제',
   },
   notConnect: {
     zh: '客户端未连接',
@@ -40,6 +45,7 @@ export default {
     tr: 'İstemci bağlı değil',
     ja: 'クライアントが接続されていません',
     hu: 'Kliens nincs csatlakozva',
+    ko: '클라이언트가 연결되어 있지 않습니다',
   },
   disconnect: {
     zh: '断开连接',
@@ -47,6 +53,7 @@ export default {
     tr: 'Bağlantıyı kes',
     ja: '切 断',
     hu: 'Kapcsolat bontása',
+    ko: '연결 해제',
   },
   disconnected: {
     zh: '已断开连接',
@@ -54,6 +61,7 @@ export default {
     tr: 'Bağlantı kesildi',
     ja: '接続を切断しました',
     hu: 'A kapcsolat bontva',
+    ko: '연결 해제됨',
   },
   deleteConnect: {
     zh: '删除连接',
@@ -61,6 +69,7 @@ export default {
     tr: 'Bağlantıyı Sil',
     ja: '削除',
     hu: 'Kapcsolat törlése',
+    ko: '연결 삭제',
   },
   all: {
     zh: '全部',
@@ -68,6 +77,7 @@ export default {
     tr: 'Hepsi',
     ja: '全て',
     hu: 'Mind',
+    ko: '전체',
   },
   received: {
     zh: '已接收',
@@ -75,6 +85,7 @@ export default {
     tr: 'Alınan',
     ja: '受信済み',
     hu: 'Fogadott',
+    ko: '수신됨',
   },
   published: {
     zh: '已发送',
@@ -82,6 +93,7 @@ export default {
     tr: 'Yayınlanan',
     ja: '送信済み',
     hu: 'Küldött',
+    ko: '발행됨',
   },
   writeMsg: {
     zh: '请输入消息',
@@ -89,6 +101,7 @@ export default {
     tr: 'Bir mesaj yaz',
     ja: 'メッセージを入力してください',
     hu: 'Írjon egy üzenetet',
+    ko: '메시지를 입력하세요',
   },
   subscriptions: {
     zh: '订阅列表',
@@ -96,6 +109,7 @@ export default {
     tr: 'Abonelikler',
     ja: 'サブスクリプションリスト',
     hu: 'Feliratkozások',
+    ko: '구독 목록',
   },
   subscription: {
     zh: '订阅',
@@ -103,6 +117,7 @@ export default {
     tr: 'abonelik',
     ja: 'サブスクリプション',
     hu: 'feliratkozás',
+    ko: '구독',
   },
   newSubscription: {
     zh: '添加订阅',
@@ -110,6 +125,7 @@ export default {
     tr: 'Yeni abonelik',
     ja: 'サブスクリプション追加',
     hu: 'Új feliratkozás',
+    ko: '새 구독',
   },
   editSubscription: {
     zh: '编辑订阅',
@@ -117,6 +133,7 @@ export default {
     tr: 'Aboneliği abonelik',
     ja: 'サブスクリプションの編集',
     hu: 'Előfizetés feliratkozás',
+    ko: '구독 편집',
   },
   subFailed: {
     zh: '无法订阅 {0}, Error: {1} (Code: {2})',
@@ -124,6 +141,7 @@ export default {
     tr: '{0} abone ollamadı, Hata: {1}(Kod: {2})',
     ja: 'サブスクリプション失敗：{0}, エラー：{1} (コード：{2})',
     hu: 'Előfizetés sikertelen: {0}, Hiba: {1} (Kód: {2})',
+    ko: '{0} 구독 실패, 오류: {1}(코드: {2})',
   },
   aclSubFailed: {
     zh: '请确保权限正确，并检查 MQTT Broker 的 ACL 配置',
@@ -131,6 +149,7 @@ export default {
     tr: 'İzinleri doğru olduğundan emin olun ve MQTT aracının ACL yapılandırmasını kontrol edin',
     ja: '権限が正しいことを確認し、MQTTブローカーのACL設定を確認してください',
     hu: 'Bizonyosodjon meg a jogosultságok helyességéről, és ellenőrizze az MQTT broker ACL konfigurációját',
+    ko: '권한이 올바른지 확인하고 MQTT 브로커의 ACL 설정을 확인하세요',
   },
   connected: {
     zh: '已连接',
@@ -138,6 +157,7 @@ export default {
     tr: 'Bağlı',
     ja: '接続に成功しました',
     hu: 'Csatlakozva',
+    ko: '연결됨',
   },
   noConnection: {
     zh: '未连接',
@@ -145,6 +165,7 @@ export default {
     tr: 'Bağlantı yok',
     ja: '未接続',
     hu: 'Nincs kapcsolat',
+    ko: '연결 해제됨',
   },
   connectFailed: {
     zh: '连接失败',
@@ -152,6 +173,7 @@ export default {
     tr: 'Bağlantı sağlanamadı',
     ja: '接続に失敗しました',
     hu: 'A Csatlakozás sikertelen',
+    ko: '연결 실패',
   },
   reconnect: {
     zh: '正在重连',
@@ -159,6 +181,7 @@ export default {
     tr: 'Yeniden bağlanılıyor',
     ja: '再接続中',
     hu: 'Újracsatlakozás',
+    ko: '재연결 중',
   },
   connectBtn: {
     zh: '连 接',
@@ -166,6 +189,7 @@ export default {
     tr: 'Bağlan',
     ja: '接 続',
     hu: 'Csatlakozás',
+    ko: '연결',
   },
   disconnectedBtn: {
     zh: '断开连接',
@@ -173,6 +197,7 @@ export default {
     tr: 'Bağlantıyı kes',
     ja: '切 断',
     hu: 'Kapcsolat bontása',
+    ko: '연결 해제',
   },
   connectionExists: {
     zh: '连接数据已存在',
@@ -180,6 +205,7 @@ export default {
     tr: 'Bağlantı zaten var',
     ja: '接続がすでに存在しました',
     hu: 'A kapcslat már létezik',
+    ko: '연결이 이미 존재합니다',
   },
   brokerIP: {
     zh: '服务器地址',
@@ -187,6 +213,7 @@ export default {
     tr: 'Sunucu',
     ja: 'ホスト',
     hu: 'Kiszolgáló',
+    ko: '호스트',
   },
   brokerPort: {
     zh: '端口',
@@ -194,6 +221,7 @@ export default {
     tr: 'Port',
     ja: 'ポート',
     hu: 'Port',
+    ko: '포트',
   },
   certType: {
     zh: '证书类型',
@@ -201,6 +229,7 @@ export default {
     tr: 'Sertifika',
     ja: '証明書種類',
     hu: 'Tanusítvány',
+    ko: '인증서',
   },
   name: {
     zh: '名称',
@@ -208,6 +237,7 @@ export default {
     tr: 'İsim',
     ja: '名前',
     hu: 'Név',
+    ko: '이름',
   },
   username: {
     zh: '用户名',
@@ -215,6 +245,7 @@ export default {
     tr: 'Kullanıcı Adı',
     ja: 'ユーザー名',
     hu: 'Felhasználónév',
+    ko: '사용자 이름',
   },
   password: {
     zh: '密码',
@@ -222,6 +253,7 @@ export default {
     tr: 'Parola',
     ja: 'パスワード',
     hu: 'Jelszó',
+    ko: '비밀번호',
   },
   ca: {
     zh: 'CA 文件',
@@ -229,6 +261,7 @@ export default {
     tr: 'CA Dosyası',
     ja: 'CA ファイル',
     hu: 'CA fájl',
+    ko: 'CA 파일',
   },
   cert: {
     zh: '客户端证书',
@@ -236,6 +269,7 @@ export default {
     tr: 'İstemci Sertifika Dosyası',
     ja: 'クライアント証明書',
     hu: 'Kliens tanusítvány fájl',
+    ko: '클라이언트 인증서 파일',
   },
   key: {
     zh: '客户端 key 文件',
@@ -243,6 +277,7 @@ export default {
     tr: 'İstemci anahtar dosyası',
     ja: 'クライアントキー',
     hu: 'Kliens kulcs fájl',
+    ko: '클라이언트 키 파일',
   },
   connectionTimeout: {
     zh: '连接超时时长',
@@ -250,6 +285,7 @@ export default {
     tr: 'Bağlantı zaman aşımı',
     ja: '接続タイムアウト',
     hu: 'Kapcsolat időtúlléps',
+    ko: '연결 타임아웃',
   },
   autoReconnect: {
     zh: '自动重连',
@@ -257,6 +293,7 @@ export default {
     tr: 'Otomatik Yeniden Bağlanma',
     ja: '自動再接続',
     hu: 'Automatikus újracsatlakozás',
+    ko: '자동 재연결',
   },
   reconnectPeriod: {
     zh: '重连周期',
@@ -264,6 +301,7 @@ export default {
     tr: 'Yeniden Bağlantı Süresi',
     ja: '再接続期間',
     hu: 'Újracsatlakozási időszak',
+    ko: '재연결 주기',
   },
   mqttVersion: {
     zh: 'MQTT 版本',
@@ -271,6 +309,7 @@ export default {
     tr: 'MQTT Sürümü',
     ja: 'MQTT バージョン',
     hu: 'MQTT verzió',
+    ko: 'MQTT 버전',
   },
   sessionExpiryInterval: {
     zh: '会话过期时间',
@@ -278,6 +317,7 @@ export default {
     tr: 'Oturum Bitiş Aralığı',
     ja: 'セッション有効期限',
     hu: 'Munkamenet lejárati intervallum',
+    ko: '세션 만료 간격',
   },
   receiveMaximum: {
     zh: '接收最大数值',
@@ -285,6 +325,7 @@ export default {
     tr: 'Maksimum Alma',
     ja: '最大受信数',
     hu: 'Maximális fogadás ',
+    ko: '수신 최대값',
   },
   topicAliasMaximum: {
     zh: '主题别名最大值',
@@ -292,6 +333,7 @@ export default {
     tr: 'Konu Takma Adı Maksimum',
     ja: 'Topic Aliasの最大値',
     hu: 'Macimális téma becenév',
+    ko: '토픽 별칭 최대값',
   },
   topicAlias: {
     zh: '主题别名',
@@ -299,6 +341,7 @@ export default {
     tr: 'Konu Takma Adı',
     ja: 'トピックエイリアス',
     hu: 'Téma Alias',
+    ko: '토픽 별칭',
   },
   maximumPacketSize: {
     zh: '最大数据包大小',
@@ -306,6 +349,7 @@ export default {
     tr: 'En Büyük Paket Boyutu',
     ja: '最大パケット サイズ',
     hu: 'Maximális csomagméret',
+    ko: '최대 패킷 크기',
   },
   requestResponseInformation: {
     zh: '请求响应信息',
@@ -313,6 +357,7 @@ export default {
     tr: 'Yanıt Bilgisi İste',
     ja: 'レスポンス情報をリクエストする',
     hu: 'Válasz információ kérése',
+    ko: '응답 정보 요청',
   },
   requestProblemInformation: {
     zh: '请求失败信息',
@@ -320,6 +365,7 @@ export default {
     tr: 'Sorun Bilgisi İste',
     ja: '失敗情報をリクエストする',
     hu: 'Probléma információ kérése',
+    ko: '문제 정보 요청',
   },
   userProperties: {
     zh: '用户属性',
@@ -327,6 +373,7 @@ export default {
     tr: 'Kullanıcı Özellikleri',
     ja: 'ユーザー プロパティ',
     hu: 'Felhasználói tulajdonságok',
+    ko: '사용자 속성',
   },
   topicRequired: {
     zh: '请输入主题，并注意下方提示',
@@ -334,6 +381,7 @@ export default {
     tr: 'Konu gerekli, lütfen aşağıdaki ipucunu kontrol edin',
     ja: 'トピックを入力してください。下のヒントを確認してください',
     hu: 'Téma szükséges, kérjük ellenőrizze az alábbi tippet',
+    ko: '토픽은 필수입니다. 아래 힌트를 확인해 주세요',
   },
   topicCannotContain: {
     zh: '不能向包含通配符 #、+ 的主题发布消息',
@@ -341,6 +389,7 @@ export default {
     tr: '#, + joker karakterler içeren konulara mesaj gönderilemez',
     ja: 'ワイルドカード文字 #、+ を含むトピックにメッセージを送信できません',
     hu: 'Nem lehet üzenetet küldeni az #, + karaktereket tartalmazó témákhoz',
+    ko: '와일드카드 문자(#, +)가 포함된 토픽에는 메시지를 발행할 수 없습니다',
   },
   topicWhitespaceHint: {
     zh: '空格检测提示',
@@ -348,6 +397,7 @@ export default {
     tr: 'Whitespace check',
     ja: '空白検出',
     hu: 'Whitespace check',
+    ko: '공백 확인',
   },
   topicTips: {
     zh: '可订阅一个或多个主题。订阅多个主题时，请用逗号（,）分隔每个主题。例如：test1,test2',
@@ -355,6 +405,7 @@ export default {
     tr: 'Bir veya birden fazla konuya abone olabilirsiniz. Birden fazla konuya abone olurken her konuyu virgülle (,) ayırın. Örneğin: test1,test2',
     Ja: '1つまたは複数のトピックを購読できます。複数のトピックを購読する場合は、各トピックをカンマ（,）で区切ってください。例えば：test1,test2',
     hu: 'Iratkozz fel egy vagy több témára. Több téma elválasztásához használj vesszőt (,). Például: test1,test2',
+    ko: '하나 이상의 토픽을 구독할 수 있습니다. 여러 토픽을 구독할 때는 쉼표(,)로 각 토픽을 구분하세요. 예: test1,test2',
   },
   enabledAutoResub: {
     zh: '已开启自动重新订阅',
@@ -362,6 +413,7 @@ export default {
     tr: 'Otomatik yeniden abonelik etkin',
     Ja: '自動再購読が有効',
     hu: 'Az automatikus újra feliratkozás engedélyezve',
+    ko: '자동 재구독이 활성화되었습니다',
   },
   disabledAutoResub: {
     zh: '已关闭自动重新订阅',
@@ -369,6 +421,7 @@ export default {
     tr: 'Otomatik yeniden abonelik devre dışı',
     Ja: '自動再購読が無効',
     hu: 'Az automatikus újra feliratkozás le van tiltva',
+    ko: '자동 재구독이 비활성화되었습니다',
   },
   enabledAutoResubDesc: {
     zh: '开启后，MQTTX 连接后会自动重新订阅本地保存的主题，无论主题是否在 MQTT Broker 持久化。',
@@ -376,6 +429,7 @@ export default {
     tr: "Etkinleştirildiğinde, MQTTX bağlantı kurduğunda yerel olarak kaydedilen konulara otomatik olarak yeniden abone olur, konuların MQTT Broker'da kalıcı olup olmadığını dikkate almaz.",
     Ja: '有効にすると、MQTTX は接続時にローカルに保存されたトピックを自動的に再購読します。トピックが MQTT Broker に永続化されているかどうかは関係ありません。',
     hu: 'Bekapcsoláskor az MQTTX automatikusan újra feliratkozik a helyben mentett témákra a csatlakozás után, függetlenül attól, hogy ezek a témák tartósak-e az MQTT Broker-ben.',
+    ko: '활성화하면 MQTTX는 연결 시 MQTT 브로커에서의 지속성 여부와 관계없이 로컬에 저장된 토픽에 자동으로 재구독합니다.',
   },
   disabledAutoResubDesc: {
     zh: '关闭后，本地保存的主题是否可用取决于 MQTT Broker 是否保存了 Session。如果 Clean Session 为 true，重新连接后需手动重新订阅。',
@@ -383,6 +437,7 @@ export default {
     tr: "Devre dışı bırakıldığında, yerel olarak kaydedilen konuların kullanılabilirliği, MQTT Broker'ın oturumu saklayıp saklamadığına bağlıdır. Clean Session doğru ise, yeniden bağlandıktan sonra elle yeniden abone olunması gerekir.",
     Ja: '無効にすると、ローカルに保存されたトピックは、MQTT Broker のセッション保持に依存します。Clean Session が true の場合、再接続後に手動で再購読する必要があります。',
     hu: 'Kikapcsoláskor a helyben mentett témák elérhetősége az MQTT Broker munkamenetének megőrzésétől függ. Ha a Clean Session igaz, újracsatlakozás után kézzel kell újra feliratkozni.',
+    ko: '비활성화하면 로컬에 저장된 토픽의 사용 가능 여부는 MQTT 브로커의 세션 유지 여부에 따라 달라집니다. Clean Session이 true인 경우 재연결 후 수동으로 재구독해야 합니다.',
   },
   payloadReuired: {
     zh: '请输入 Payload',
@@ -390,6 +445,7 @@ export default {
     tr: 'Yük gerekli',
     ja: 'Payloadを入力してください',
     hu: 'Üzenet szükséges',
+    ko: '페이로드는 필수입니다',
   },
   color: {
     zh: '标记',
@@ -397,6 +453,7 @@ export default {
     tr: 'Renk',
     ja: 'マーク',
     hu: 'Szín',
+    ko: '색상',
   },
   willMessage: {
     zh: '遗嘱消息',
@@ -404,6 +461,7 @@ export default {
     tr: 'Son arzu ve vasiyetname',
     ja: '遺言',
     hu: 'Last-Will és Testament',
+    ko: '유언(Will) 메시지',
   },
   strictValidateCertificate: {
     zh: 'SSL 安全',
@@ -411,6 +469,7 @@ export default {
     tr: 'SSL Güvenli',
     ja: 'SSL証明書',
     hu: 'SSL Titkosítás',
+    ko: 'SSL 보안',
   },
   willTopic: {
     zh: '遗嘱消息主题',
@@ -418,6 +477,7 @@ export default {
     tr: 'Son Vasiyet Konusu',
     ja: '遺言トピック',
     hu: 'Last-Will téma',
+    ko: '유언(Will) 토픽',
   },
   willPayload: {
     zh: '遗嘱消息',
@@ -425,6 +485,7 @@ export default {
     tr: 'Son İrade Yükü',
     ja: '遺言 Payload',
     hu: 'Last-Will üzenet',
+    ko: '유언(Will) 페이로드',
   },
   willQos: {
     zh: '遗嘱消息 QoS',
@@ -432,6 +493,7 @@ export default {
     tr: 'Son İstek QoS',
     ja: '遺言 QoS',
     hu: 'Last-Will QoS',
+    ko: '유언(Will) QoS',
   },
   willRetain: {
     zh: '遗嘱消息保留标志',
@@ -439,6 +501,7 @@ export default {
     tr: 'Son Tutulacak',
     ja: '遺言 Retain',
     hu: 'Last-Will Megőriz',
+    ko: '유언(Will) 유지',
   },
   willDelayInterval: {
     zh: '遗嘱消息延迟时间',
@@ -446,6 +509,7 @@ export default {
     tr: 'Gecikme Aralığı',
     ja: '遺言ディレイ間隔',
     hu: 'Will késleltetési intervallum',
+    ko: '유언(Will) 지연 간격',
   },
   messageExpiryInterval: {
     zh: '消息过期时间',
@@ -453,6 +517,7 @@ export default {
     tr: 'Mesaj Bitiş Aralığı',
     ja: 'メッセージの有効期限間隔',
     hu: 'Üzenet lejárati időköz',
+    ko: '메시지 만료 간격',
   },
   contentType: {
     zh: '内容类型',
@@ -460,6 +525,7 @@ export default {
     tr: 'İçerik türü',
     ja: 'コンテンツタイプ',
     hu: 'Tartalom típus',
+    ko: '콘텐츠 유형',
   },
   payloadFormatIndicator: {
     zh: '有效载荷指示器',
@@ -467,6 +533,7 @@ export default {
     tr: 'Yük Biçimi Göstergesi',
     ja: 'ペイロードフォーマットインジケーター',
     hu: 'A hasznos teher formátumának jelzője',
+    ko: '페이로드 형식 지시자',
   },
   responseTopic: {
     zh: '响应主题',
@@ -474,6 +541,7 @@ export default {
     tr: 'Yanıt Konusu',
     ja: '応答トピック',
     hu: 'Válasz téma',
+    ko: '응답 토픽',
   },
   correlationData: {
     zh: '对比数据',
@@ -481,6 +549,7 @@ export default {
     tr: 'Korelasyon Verileri',
     ja: '相関データ',
     hu: 'Korrelációs adatok',
+    ko: '상관 데이터',
   },
   duplicateName: {
     zh: '该名称已存在，请重新命名！',
@@ -488,6 +557,7 @@ export default {
     tr: 'Yinelenen ad. Lütfen yeniden adlandırın!',
     ja: '名称が既に存在したので、リネームをお願いします！',
     hu: 'Duplikált név, kérlek nevezd át!',
+    ko: '중복된 이름입니다. 다시 이름을 지정해 주세요!',
   },
   nameTip: {
     zh: '可快速选择已创建过的连接配置',
@@ -495,6 +565,7 @@ export default {
     tr: 'Oluşturulan bağlantı konfigürasyonlarının hızlı seçimi',
     ja: '作成された接続構成を早めに選択することができます',
     hu: 'Kapcsolati beállítások gyors kiválasztása',
+    ko: '생성된 연결 설정을 빠르게 선택',
   },
   clientIdWithTimeTip: {
     zh: '在连接时附加时间戳到 ClientID，以防止重复的连接',
@@ -502,6 +573,7 @@ export default {
     tr: "Yinelenen bağlantıları önlemek için ClientID'ye bir zaman damgası ekleyin",
     ja: '重複接続を防ぐために、ClientIDにタイムスタンプを追加します',
     hu: 'Adjon hozzá egy időbélyeget a ClientID-hoz, hogy elkerülje a duplikációt.',
+    ko: '연결 시 클라이언트 ID에 타임스탬프를 추가하여 중복 연결을 방지합니다',
   },
   publishMsg: {
     zh: '发送消息',
@@ -509,6 +581,7 @@ export default {
     tr: 'Mesaj yayınla',
     ja: '送信エラー：',
     hu: 'Üzenet küldése',
+    ko: '메시지 발행',
   },
   receivedMsg: {
     zh: '接收消息',
@@ -516,6 +589,7 @@ export default {
     tr: 'Mesaj alındı',
     ja: '受信エラー：',
     hu: 'Fogadott üzenet',
+    ko: '메시지 수신',
   },
   receivedPayloadDecodedBy: {
     zh: '使用以下格式编码接收到的 Payload',
@@ -523,6 +597,7 @@ export default {
     tr: 'Alınan Payload’ı şununla biçimlendir: ',
     ja: '以下の方式で受信 Payload をフォーマット: ',
     hu: 'Fogadott Payload formázása e szerint: ',
+    ko: '수신 페이로드 형식 지정 기준: ',
   },
   publishPayloadEncodedBy: {
     zh: '使用以下格式编码要发布的 Payload',
@@ -530,6 +605,7 @@ export default {
     tr: 'Yayınlamak için Payload’ı şununla biçimlendir: ',
     ja: '以下の方式で公開用 Payload をフォーマット: ',
     hu: 'A közzétételre szánt Payload formázása e szerint: ',
+    ko: '발행할 페이로드 형식 지정 기준: ',
   },
   alias: {
     zh: '别名',
@@ -537,6 +613,7 @@ export default {
     tr: 'Takma Ad',
     ja: 'エイリアス',
     hu: 'Becenév',
+    ko: '별칭',
   },
   aliasTip: {
     zh: '为多主题设置别名时，也使用逗号分隔符（,）',
@@ -544,6 +621,7 @@ export default {
     tr: 'Birden çok konu için takma ad ayarlarken ayrıca virgül ayırıcılar (,) kullanın',
     ja: '複数のトピックにエイリアスを設定する場合は、カンマ区切り（,）も使用されます。',
     hu: 'Ha több téma álnevét állít be, használjon vesszőt (,) is',
+    ko: '여러 토픽에 별칭을 설정할 때도 쉼표(,) 구분자를 사용합니다',
   },
   exportData: {
     zh: '导出数据',
@@ -551,6 +629,7 @@ export default {
     tr: 'Verileri Dışa Aktar',
     ja: 'エクスポート',
     hu: 'Adat export',
+    ko: '데이터 내보내기',
   },
   exportFormat: {
     zh: '导出数据格式',
@@ -558,6 +637,7 @@ export default {
     tr: 'Dışa aktarma biçimi',
     ja: 'エクスポートフォーマット',
     hu: 'Export formátum',
+    ko: '내보내기 형식',
   },
   cleanHistoryData: {
     zh: '清除历史数据',
@@ -565,6 +645,7 @@ export default {
     tr: 'Geçmiş verileri temizle',
     ja: 'クリーンな履歴データ',
     hu: 'Előzmények törlése',
+    ko: '기록 데이터 삭제',
   },
   cleanHistorySuccess: {
     zh: '清除历史数据成功',
@@ -572,6 +653,7 @@ export default {
     tr: 'Geçmişi başarıyla temizle',
     ja: '履歴を正常にクリアする',
     hu: 'Előzmények törlése sikeres',
+    ko: '기록이 성공적으로 삭제되었습니다',
   },
   allConnections: {
     zh: '全部数据',
@@ -579,6 +661,7 @@ export default {
     tr: 'Tüm bağlantılar',
     ja: '全ての接続',
     hu: 'Minden kapcsolat',
+    ko: '모든 연결',
   },
   allConnectionsTips: {
     zh: '当打开此开关后，可以导出全部数据',
@@ -586,6 +669,7 @@ export default {
     tr: 'Bu anahtar açıldığında, tüm Bağlantı verileri dışa aktarılabilir',
     ja: 'このスイッチをオンにすると、全ての接続のデータをエクスポートすることができます',
     hu: 'Ha ez a kapcsoló aktív, minden kapcsolat adata exportálható',
+    ko: '이 스위치를 켜면 모든 연결 데이터를 내보낼 수 있습니다',
   },
   importData: {
     zh: '导入数据',
@@ -593,6 +677,7 @@ export default {
     tr: 'Verileri İçe Aktar',
     ja: 'インポート',
     hu: 'Adatok importálása',
+    ko: '데이터 가져오기',
   },
   importDataTip: {
     zh: '导入完成后会断开所有连接，请手动点击连接进行恢复。',
@@ -600,6 +685,7 @@ export default {
     tr: 'İçe aktarmadan sonra tüm bağlantılar kesilecektir, lütfen geri yüklemek için bağlantı düğmesine manuel olarak tıklayın.',
     ja: 'インポート後、すべての接続が切断されます。復元するには、接続ボタンを手動でクリックしてください。',
     hu: 'Az importálás után az összes kapcsolat megszakad, kérjük, a visszaállításhoz kattintson a kapcsolódás gombra manuálisan.',
+    ko: '가져오기가 완료되면 모든 연결이 해제됩니다. 복원하려면 연결 버튼을 수동으로 클릭해 주세요.',
   },
   importFormat: {
     zh: '导入数据格式',
@@ -607,6 +693,7 @@ export default {
     tr: 'İçe aktarma biçimi',
     ja: 'フォーマット',
     hu: 'Import formátum',
+    ko: '가져오기 형식',
   },
   importConnectionsTip: {
     zh: '导入文件内容请参考导出数据生成的文件内容。<br>若 id 重复原数据将会被覆盖。',
@@ -619,6 +706,9 @@ export default {
     ja: `インポートしたファイルの内容については、エクスポートされたデータで生成されたファイルの内容を参照してください。<br>
     idが重複している場合は、元のデータが上書きされます。`,
     hu: 'Az importált adatok tartalmáért, kérjük ellenőrizza <br>a az exportált adatokat tartalmazó filet<br>Duplikciók esetén az eredeti adatok felülírásra kerülnek.',
+    ko: `가져온 파일의 내용은 내보내기로 생성된 파일의 내용을<br>
+    참고하세요.<br>
+    id가 중복되면 원본 데이터가 덮어씌워집니다.`,
   },
   importFile: {
     zh: '导入文件',
@@ -626,6 +716,7 @@ export default {
     tr: 'Dosyayı İçe Aktar',
     ja: 'ファイル',
     hu: 'Fájl importálása',
+    ko: '파일 가져오기',
   },
   readFileErr: {
     zh: '文件读取失败：',
@@ -633,6 +724,7 @@ export default {
     tr: 'Dosya okunurken bir hata oluştu:',
     ja: '読み込み中にエラーが発生したファイル:',
     hu: 'Hiba a fájl olvasása során',
+    ko: '파일을 읽는 중 오류가 발생했습니다:',
   },
   fileContentRequired: {
     zh: '文件内容中必填项为空',
@@ -640,6 +732,7 @@ export default {
     tr: 'Dosya içeriğindeki gerekli alanlar boş',
     ja: '必須フィールドに値を入力してください',
     hu: 'A szükséges mezők hiányoznak a fájlban',
+    ko: '파일 내용의 필수 항목이 비어 있습니다',
   },
   searchContent: {
     zh: '内容搜索',
@@ -647,6 +740,7 @@ export default {
     tr: 'Ara',
     ja: '内容検索',
     hu: 'Keresés',
+    ko: '검색',
   },
   inputTopic: {
     zh: '请输入主题',
@@ -654,6 +748,7 @@ export default {
     tr: 'Lütfen Konu Girin',
     ja: 'トピックを入力してください',
     hu: 'Kérjük adjon meg egy témát',
+    ko: '토픽을 입력해 주세요',
   },
   selectTopic: {
     zh: '请选择主题',
@@ -661,6 +756,7 @@ export default {
     tr: 'Lütfen Konu Seçin',
     ja: 'トピックを選択してください',
     hu: 'Kérjük válasszon egy témát',
+    ko: '토픽을 선택해 주세요',
   },
   inputMsgContent: {
     zh: '请输入消息内容',
@@ -668,6 +764,7 @@ export default {
     tr: 'Lütfen Mesaj Giriniz',
     ja: 'メッセージ内容を入力してください',
     hu: 'Kérjük adjon meg egy üzenetet',
+    ko: '메시지를 입력해 주세요',
   },
   flieName: {
     zh: '文件名',
@@ -675,6 +772,7 @@ export default {
     tr: 'Dosya Adı',
     ja: 'ファイル名',
     hu: 'Fájl név',
+    ko: '파일 이름',
   },
   uploadFileTip: {
     zh: '文件内容格式错误或为空',
@@ -682,6 +780,7 @@ export default {
     tr: 'Dosya içeriği bozuk veya boş',
     ja: 'ファイルの内容が不正な形式または空です',
     hu: 'A fájl tartalma üres vagy rosszul formázott',
+    ko: '파일 내용의 형식이 잘못되었거나 비어 있습니다',
   },
   messageCount: {
     zh: '消息数',
@@ -689,6 +788,7 @@ export default {
     tr: 'Mesaj sayısı',
     ja: 'メッセージ数',
     hu: 'Üzenet szám',
+    ko: '메시지 수',
   },
   timedMessage: {
     zh: '定时消息',
@@ -696,6 +796,7 @@ export default {
     tr: 'Zamanlanmış mesaj',
     ja: '自動送信',
     hu: 'Időzített üzenet',
+    ko: '타이머 메시지',
   },
   msgFrequency: {
     zh: '消息频率（秒）',
@@ -703,6 +804,7 @@ export default {
     tr: 'Mesaj sıklık(lar)ı',
     ja: '送信間隔（秒）',
     hu: 'Üzenet gyakoriság',
+    ko: '메시지 전송 주기(초)',
   },
   clearIntervalBtn: {
     zh: '清理定时器',
@@ -710,6 +812,7 @@ export default {
     tr: 'Zamanlayıcıyı temizle',
     ja: '自動送信を解除する',
     hu: 'Időzítő törlése',
+    ko: '타이머 지우기',
   },
   setTimerSuccess: {
     zh: '成功设置定时器，发送一条消息将触发定时消息',
@@ -718,6 +821,7 @@ export default {
     ja: `自動送信を設定しました。
     これから一つのメッセージを送信すると、設定した時間間隔で自動的に該当メッセージを送信できます`,
     hu: 'Időzítő sikeresen beállítva, az üzenet küldés időzített üzeneteket fog indítani',
+    ko: '타이머가 성공적으로 설정되었습니다. 메시지를 전송하면 타이머 메시지가 시작됩니다',
   },
   startTimedMessage: {
     zh: '成功开启定时消息，消息频率（秒）：',
@@ -725,6 +829,7 @@ export default {
     tr: 'Zamanlanmış mesaj başarıyla açıldı, sıklık(lar):',
     ja: 'メッセージの自動送信が始まりました。送信間隔（秒）: ',
     hu: 'Időzített üzenenet sikeresen megnyitva, gyakoriság:',
+    ko: '타이머 메시지가 성공적으로 시작되었습니다, 주기(초): ',
   },
   stopTimedMessage: {
     zh: '已停止发送定时消息',
@@ -732,6 +837,7 @@ export default {
     tr: 'Zamanlanmış mesaj göndermeyi durdurdu',
     ja: '自動送信設定を解除しました',
     hu: 'Időzített üzenetek leállítva',
+    ko: '타이머 메시지 전송이 중지되었습니다',
   },
   systemTopic: {
     zh: '系统主题',
@@ -739,6 +845,7 @@ export default {
     tr: 'Sistem konusu',
     ja: 'システムトピック',
     hu: 'Rendszer téma',
+    ko: '시스템 토픽',
   },
   secureTip: {
     zh: '是否验证服务端证书链和地址名称',
@@ -746,6 +853,7 @@ export default {
     tr: 'İstemcinin sunucunun sertifika zincirini ve ana bilgisayar adını doğrulayıp doğrulamadığı',
     ja: "Whether a client verifies the server's certificate chain and host name",
     hu: 'Amennyiben a kliens visszaigazolja a szerver tanusítványt láncot és a kiszolgáló nevét',
+    ko: '클라이언트가 서버의 인증서 체인과 호스트 이름을 확인하는지 여부',
   },
   newCollection: {
     zh: '新建分组',
@@ -753,6 +861,7 @@ export default {
     tr: 'Yeni Grup',
     ja: '新しいグループ',
     hu: 'Új csoport',
+    ko: '새 그룹',
   },
   collectionPlaceholder: {
     zh: '分组名称',
@@ -760,6 +869,7 @@ export default {
     tr: 'Koleksiyon adı',
     ja: 'フォルダ名',
     hu: 'Gyüjtemény név',
+    ko: '그룹 이름',
   },
   deleteCollection: {
     zh: '删除分组',
@@ -767,6 +877,7 @@ export default {
     tr: 'Koleksiyonu Sil',
     ja: 'フォルダを削除する',
     hu: 'Gyüjtemény törlése',
+    ko: '그룹 삭제',
   },
   renameCollection: {
     zh: '重命名分组',
@@ -774,6 +885,7 @@ export default {
     tr: 'Koleksiyona Yeniden Ad Ver',
     ja: '名前を変更する',
     hu: 'Gyüjtemény átnevezése',
+    ko: '그룹 이름 변경',
   },
   metaTips: {
     zh: '仅在 MQTT 5.0 中启用',
@@ -781,6 +893,7 @@ export default {
     tr: 'Yalnızca MQTT 5.0 ile etkinleştirilir',
     ja: 'MQTT 5.0でのみ有効',
     hu: 'Csak MQTT 5.0 esetén engedélyezett',
+    ko: 'MQTT 5.0에서만 사용 가능',
   },
   subscriptionIdentifier: {
     zh: '订阅标识符',
@@ -788,6 +901,7 @@ export default {
     tr: 'Abonelik Tanımlayıcısı',
     ja: 'サブスクリプション識別子',
     hu: 'Előfizetési azonosító',
+    ko: '구독 식별자',
   },
   qos0: {
     zh: '最多一次',
@@ -795,6 +909,7 @@ export default {
     tr: 'en fazla bir kere',
     ja: 'せいぜい一度',
     hu: 'Legfeljebb egyszer',
+    ko: '최대 한 번',
   },
   qos1: {
     zh: '至少一次',
@@ -802,6 +917,7 @@ export default {
     tr: 'En azından bir kere',
     ja: '少なくとも一度は',
     hu: 'Legalább egyszer',
+    ko: '최소 한 번',
   },
   qos2: {
     zh: '仅一次',
@@ -809,6 +925,7 @@ export default {
     tr: 'tam olarak bir kez',
     ja: 'ちょうど一度',
     hu: 'Pontosan egyszer',
+    ko: '정확히 한 번',
   },
   duplicated: {
     zh: '{oldName} 已被复制为 {name}',
@@ -816,6 +933,7 @@ export default {
     tr: '{oldName}, {name} olarak kopyalandı',
     ja: '{oldName}は{name}として複製されました',
     hu: 'A(z) {oldName} a(z) {Name} néven másolva',
+    ko: '{oldName}이(가) {name}(으)로 복제되었습니다',
   },
   sslFileRequired: {
     zh: '请至少上传一种证书文件',
@@ -823,6 +941,7 @@ export default {
     tr: 'Lütfen en az bir sertifika dosyası yükleyin',
     ja: '少なくとも1つの証明書ファイルをアップロードしてください',
     hu: 'Legalább egy tanúsítványfájlt töltsön fel',
+    ko: '최소 하나의 인증서 파일을 업로드해 주세요',
   },
   usedScript: {
     zh: '已使用',
@@ -830,6 +949,7 @@ export default {
     tr: 'Kullanıldı',
     ja: '使用済み',
     hu: 'Használt',
+    ko: '사용됨',
   },
   usedScriptAnd: {
     zh: '和',
@@ -837,6 +957,7 @@ export default {
     tr: 'Ve',
     ja: 'そして',
     hu: 'És',
+    ko: '및',
   },
   clearRetainedMessage: {
     zh: '清除保留消息',
@@ -844,6 +965,7 @@ export default {
     tr: 'Saklı Mesajı Temizle',
     ja: '保持メッセージをクリア',
     hu: 'Megőrzött üzenet törlése',
+    ko: '유지된 메시지 지우기',
   },
   clearRetainedMessageConfirm: {
     zh: '确定清除该主题的保留消息吗？',
@@ -851,6 +973,7 @@ export default {
     tr: 'Bu konu için saklı mesajları temizlemek istiyor musunuz?',
     ja: 'このトピックの保持メッセージをクリアしますか？',
     hu: 'Törölni kívánja a témához kapcsolódó megőrzött üzeneteket?',
+    ko: '이 토픽의 유지된 메시지를 삭제하시겠습니까?',
   },
   noLocal: {
     zh: '禁止本地转发',
@@ -858,6 +981,7 @@ export default {
     tr: 'Yerel İletimi Engelle',
     ja: 'ローカル転送禁止',
     hu: 'Helyi továbbítás tiltása',
+    ko: '로컬 전달 금지 플래그',
   },
   retainAsPublished: {
     zh: '发布时状态保留',
@@ -865,6 +989,7 @@ export default {
     tr: 'Yayınlandığı Gibi Sakla',
     ja: '公開時の状態を維持',
     hu: 'Megőrzés közzétételként',
+    ko: '발행 시 상태 유지 플래그',
   },
   retainHandling: {
     zh: '保留消息处理',
@@ -872,6 +997,7 @@ export default {
     tr: 'Mesajı Saklama İşlemi',
     ja: '保持メッセージの取り扱い',
     hu: 'Üzenetmegőrzés kezelése',
+    ko: '유지 메시지 처리 방식',
   },
   onDisconnect: {
     zh: '服务器已主动断开连接, Reason: {reason} (Code: {reasonCode})',
@@ -879,6 +1005,7 @@ export default {
     tr: 'Sunucu aktif bir şekilde bağlantıyı kesmiştir, Reason: {reason} (Code: {reasonCode})',
     ja: 'サーバーから積極的に接続が切断されました, Reason: {reason} (Code: {reasonCode})',
     hu: 'A kiszolgáló aktívan bontotta a kapcsolatot, Reason: {reason} (Code: {reasonCode})',
+    ko: '브로커가 능동적으로 연결을 해제했습니다, Reason: {reason} (Code: {reasonCode})',
   },
   hideConnections: {
     zh: '隐藏连接列表',
@@ -886,6 +1013,7 @@ export default {
     tr: 'Bağlantıları Gizle',
     ja: '接続リストを非表示',
     hu: 'Kapcsolatok elrejtése',
+    ko: '연결 목록 숨기기',
   },
   showConnections: {
     zh: '显示连接列表',
@@ -893,6 +1021,7 @@ export default {
     tr: 'Bağlantıları Göster',
     ja: '接続リストを表示',
     hu: 'Kapcsolatok mutatása',
+    ko: '연결 목록 표시',
   },
   messageTooLargeToHide: {
     zh: '消息内容过大，已隐藏，点击查看完整内容',
@@ -900,6 +1029,7 @@ export default {
     tr: 'Mesaj içeriği çok büyük, gizlendi, tam içeriği görüntülemek için tıklayın',
     ja: 'メッセージ内容が大きすぎて非表示になりました。クリックして完全な内容を表示します',
     hu: 'Az üzenet tartalma túl nagy, elrejtve, kattintson a teljes tartalom megtekintéséhez',
+    ko: '메시지 내용이 너무 커서 숨겨졌습니다. 전체 내용을 보려면 클릭하세요',
   },
   payloadSize: {
     zh: '消息大小',
@@ -907,6 +1037,7 @@ export default {
     tr: 'Yük Boyutu',
     ja: 'ペイロードサイズ',
     hu: 'A hasznos teher mérete',
+    ko: '페이로드 크기',
   },
   subTopics: {
     zh: '子主题',
@@ -914,6 +1045,7 @@ export default {
     tr: 'Alt Konular',
     ja: 'サブトピック',
     hu: 'Al téma',
+    ko: '하위 토픽',
   },
   fullTopic: {
     zh: '完整主题',
@@ -921,6 +1053,7 @@ export default {
     tr: 'Tam Konu',
     ja: '完全なトピック',
     hu: 'Teljes téma',
+    ko: '전체 토픽',
   },
   receivedTime: {
     zh: '接收时间',
@@ -928,6 +1061,7 @@ export default {
     tr: 'Alındığı Zaman',
     ja: '受信時間',
     hu: 'Időbélyeg',
+    ko: '수신 시간',
   },
   syncToTopicTree: {
     zh: '同步到主题树',
@@ -935,6 +1069,7 @@ export default {
     tr: 'Konu Ağacına Senkronize Et',
     ja: 'トピックツリーに同期',
     hu: 'Témafa szinkronizálása',
+    ko: '토픽 트리 동기화',
   },
   previousPayload: {
     zh: '上一条消息',
@@ -942,6 +1077,7 @@ export default {
     tr: 'Önceki Yük',
     ja: '前のペイロード',
     hu: 'Előző terhelés',
+    ko: '이전 페이로드',
   },
   nextPayload: {
     zh: '下一条消息',
@@ -949,6 +1085,7 @@ export default {
     tr: 'Sonraki Yük',
     ja: '次のペイロード',
     hu: 'Következő terhelés',
+    ko: '다음 페이로드',
   },
   payloadHistory: {
     zh: '消息历史',
@@ -956,6 +1093,7 @@ export default {
     tr: 'Yük Geçmişi',
     ja: 'ペイロード履歴',
     hu: 'Terhelés előzmények',
+    ko: '페이로드 기록',
   },
   authenticationMethod: {
     zh: '认证方法',
@@ -963,5 +1101,6 @@ export default {
     tr: 'Kimlik Doğrulama Yöntemi',
     ja: '認証方法',
     hu: 'Hitelesítési módszer',
+    ko: '인증 방법',
   },
 }

--- a/src/lang/copilot.ts
+++ b/src/lang/copilot.ts
@@ -5,6 +5,7 @@ export default {
     tr: 'Düşünüyorum...',
     ja: '考え中...',
     hu: 'Gondolkodom...',
+    ko: '생각 중...',
   },
   welcomeToCopilot: {
     zh: 'MQTTX Copilot 可以帮您生成连接代码、解答 MQTT 问题、创建消息转换脚本和测试数据，成为您的 MQTT 开发助手。',
@@ -12,6 +13,7 @@ export default {
     tr: 'MQTTX Copilot, bağlantı kodu oluşturmanıza, MQTT sorularını yanıtlamanıza, mesaj dönüştürme komut dosyaları ve test verileri oluşturmanıza yardımcı olabilir ve MQTT geliştirme asistanınız olarak hizmet verir.',
     ja: 'MQTTX Copilotは、接続コードの生成、MQTTの質問への回答、メッセージ変換スクリプトとテストデータの作成をサポートし、MQTTの開発アシスタントとして機能します。',
     hu: 'Az MQTTX Copilot segíthet a kapcsolódási kód generálásában, MQTT kérdések megválaszolásában, üzenet-átalakító szkriptek és tesztadatok létrehozásában, MQTT fejlesztési asszisztensként szolgálva.',
+    ko: 'MQTTX Copilot은 연결 코드 생성, MQTT 관련 질문 답변, 메시지 변환 스크립트 및 테스트 데이터 생성을 도와드리는 MQTT 개발 도우미입니다.',
   },
   didYouKnow: {
     zh: '您知道吗？',
@@ -19,6 +21,7 @@ export default {
     tr: 'Biliyor muydunuz?',
     ja: 'ご存知でしたか？',
     hu: 'Tudta?',
+    ko: '알고 계셨나요?',
   },
   tipContent1: {
     zh: '遇到连接问题？快速点击错误框中的 "Ask Copilot" 按钮，将帮助您诊断和解决问题。',
@@ -26,6 +29,7 @@ export default {
     tr: 'Bağlantı sorunları mı yaşıyorsunuz? Hata kutusundaki "Ask Copilot" düğmesine hızlıca tıklayın, bu size sorunu teşhis etmenize ve çözmenize yardımcı olacaktır.',
     ja: '接続に問題がありますか？エラーボックスの「Ask Copilot」ボタンをクリックすると、問題の診断と解決をサポートします。',
     hu: 'Kapcsolódási problémák? Kattintson gyorsan a hiba ablakban található "Ask Copilot" gombra, amely segít diagnosztizálni és megoldani a problémát.',
+    ko: '연결 문제가 있나요? 오류 창의 "Ask Copilot" 버튼을 클릭하면 문제를 진단하고 해결하는 데 도움을 드립니다.',
   },
   tipContent2: {
     zh: '使用 "生成连接代码" 功能可以快速获取多种编程语言的 MQTT 客户端代码，直接复制到您的项目中使用。',
@@ -33,6 +37,7 @@ export default {
     tr: 'Çeşitli programlama dillerinde MQTT istemci kodunu hızlıca almak için "Bağlantı Kodu Oluştur" özelliğini kullanın, projenize kopyalamaya hazır.',
     ja: '「接続コード生成」機能を使用すると、さまざまなプログラミング言語でMQTTクライアントコードをすぐに取得でき、プロジェクトにコピーできます。',
     hu: 'Használja a "Kapcsolódási kód generálása" funkciót, hogy gyorsan kapjon MQTT kliens kódot különböző programozási nyelveken, készen a projektbe való másolásra.',
+    ko: '"연결 코드 생성" 기능을 사용하면 다양한 프로그래밍 언어의 MQTT 클라이언트 코드를 빠르게 얻어 프로젝트에 바로 복사해 사용할 수 있습니다.',
   },
   tipContent3: {
     zh: '试试生成测试数据功能！Copilot 可为您创建各种 IoT 场景的模拟数据，如智能家居、工业物联网、车联网等。',
@@ -40,6 +45,7 @@ export default {
     tr: 'Test verisi oluşturma özelliğini deneyin! Copilot, akıllı evler, endüstriyel IoT, bağlantılı araçlar ve daha fazlası gibi çeşitli IoT senaryoları için simüle edilmiş veriler oluşturabilir.',
     ja: 'テストデータ生成機能を試してみてください！Copilotは、スマートホーム、産業用IoT、コネクテッドカーなどのさまざまなIoTシナリオの模擬データを作成できます。',
     hu: 'Próbálja ki a tesztadat-generálási funkciót! A Copilot szimulált adatokat hozhat létre különböző IoT forgatókönyvekhez, például okosotthonokhoz, ipari IoT-hez, csatlakoztatott járművekhez és egyebekhez.',
+    ko: '테스트 데이터 생성 기능을 사용해 보세요! Copilot은 스마트홈, 산업용 IoT, 커넥티드 카 등 다양한 IoT 시나리오에 대한 시뮬레이션 데이터를 생성할 수 있습니다.',
   },
   tipContent4: {
     zh: '了解 MQTT QoS？询问 Copilot "MQTT 的 QoS 级别有什么区别"，获取详细解释和实际使用场景。',
@@ -47,6 +53,7 @@ export default {
     tr: 'MQTT QoS hakkında merak mı ediyorsunuz? Ayrıntılı açıklamalar ve pratik kullanım örnekleri için Copilot\'a "MQTT QoS seviyeleri arasındaki farklar nelerdir" diye sorun.',
     ja: 'MQTT QoSについて知りたいですか？Copilotに「MQTTのQoSレベルの違いは何ですか」と質問すると、詳細な説明と実際の使用例が得られます。',
     hu: 'Kíváncsi az MQTT QoS-re? Kérdezze meg a Copilot-tól: "Mik a különbségek az MQTT QoS szintek között", hogy részletes magyarázatokat és gyakorlati felhasználási eseteket kapjon.',
+    ko: 'MQTT QoS가 궁금하신가요? Copilot에게 "MQTT QoS 레벨 간의 차이는 무엇인가요"라고 물어보시면 자세한 설명과 실제 사용 사례를 알려드립니다.',
   },
   tipContent5: {
     zh: '需要处理消息转换？Copilot 可以帮您编写脚本，处理 JSON 转换、数据过滤、格式转换等任务。',
@@ -54,6 +61,7 @@ export default {
     tr: 'Mesaj dönüşümlerini ele almanız mı gerekiyor? Copilot, JSON dönüşümleri, veri filtreleme, format dönüşümleri ve daha fazlası için komut dosyaları yazmanıza yardımcı olabilir.',
     ja: 'メッセージ変換を処理する必要がありますか？Copilotは、JSON変換、データフィルタリング、フォーマット変換などのスクリプトを書くのを手伝います。',
     hu: 'Üzenet-átalakításokat kell kezelnie? A Copilot segíthet olyan szkripteket írni, amelyek JSON-átalakításokat, adatszűrést, formátum-átalakításokat és egyebeket végeznek.',
+    ko: '메시지 변환 작업이 필요하신가요? Copilot은 JSON 변환, 데이터 필터링, 형식 변환 등을 위한 스크립트 작성을 도와드립니다.',
   },
   tipContent6: {
     zh: '想了解 MQTT 5.0 的新特性？询问 Copilot 获取详细解释，包括共享订阅、消息过期、主题别名等功能。',
@@ -61,6 +69,7 @@ export default {
     tr: "MQTT 5.0 özelliklerini öğrenmek mi istiyorsunuz? Paylaşılan abonelikler, mesaj süresi, konu takma adları ve daha fazlası hakkında ayrıntılı açıklamalar için Copilot'a sorun.",
     ja: 'MQTT 5.0の機能について学びたいですか？共有サブスクリプション、メッセージ有効期限、トピックエイリアスなどの詳細な説明については、Copilotに質問してください。',
     hu: 'Szeretne többet megtudni az MQTT 5.0 funkcióiról? Kérdezze meg a Copilot-tól a megosztott előfizetésekről, üzenet lejáratról, téma álnevekről és egyebekről szóló részletes magyarázatokat.',
+    ko: 'MQTT 5.0의 새로운 기능이 궁금하신가요? Copilot에게 공유 구독, 메시지 만료, 토픽 별칭 등에 대한 자세한 설명을 요청해 보세요.',
   },
   tipContent7: {
     zh: '试试启用 MCP（模型上下文协议）功能！MCP 允许 Copilot 使用各类外部工具和服务，大幅扩展其功能，帮助您进行更高效的测试、自动化和开发工作。',
@@ -68,6 +77,7 @@ export default {
     tr: "MCP (Model Context Protocol) özelliğini etkinleştirmeyi deneyin! MCP, Copilot'ın çeşitli dış araçları ve hizmetleri kullanmasına izin vererek, daha verimli test, otomasyon ve geliştirme görevlerinde size yardımcı olmak için yeteneklerini önemli ölçüde genişletir.",
     ja: 'MCP（モデルコンテキストプロトコル）機能を有効にしてみてください！MCPはCopilotにさまざまな外部ツールやサービスを使用することを可能にし、より効率的なテスト、自動化、開発タスクをサポートするためにその機能を大幅に拡張します。',
     hu: 'Próbálja ki az MCP (Model Context Protocol) funkció engedélyezését! Az MCP lehetővé teszi a Copilot számára különféle külső eszközök és szolgáltatások használatát, jelentősen bővítve képességeit, hogy segítsen a hatékonyabb tesztelésben, automatizálásban és fejlesztési feladatokban.',
+    ko: 'MCP(Model Context Protocol) 기능을 활성화해 보세요! MCP를 사용하면 Copilot이 다양한 외부 도구와 서비스를 활용할 수 있어 기능이 크게 확장되며, 더욱 효율적인 테스트, 자동화, 개발 작업을 도와드립니다.',
   },
   showThinking: {
     zh: '查看思考过程',
@@ -75,6 +85,7 @@ export default {
     tr: 'Düşünme Sürecini Görüntüle',
     ja: '思考プロセスを表示',
     hu: 'Gondolkodási folyamat megtekintése',
+    ko: '생각 과정 보기',
   },
   copilotPubMsgPlaceholder: {
     en: 'Enter message, use / for preset prompts, ↩︎ to send',
@@ -82,6 +93,7 @@ export default {
     ja: 'メッセージを入力し、/ でプリセットプロンプトを開き、↩︎ で送信します',
     tr: 'Mesajı girin, hazır istemler için / kullanın, göndermek için ↩︎ kullanın',
     hu: 'Üzenet beírása, használja a / jelet az előre beállított promptokhoz, ↩︎ a küldéshez',
+    ko: '메시지를 입력하세요. 사전 설정 프롬프트는 /, 전송은 ↩︎ 키를 사용하세요',
   },
   copilotUser: {
     zh: '用户',
@@ -89,6 +101,7 @@ export default {
     tr: 'Sen',
     ja: 'あなた',
     hu: 'Te',
+    ko: '나',
   },
   copilotAPIKeyRequired: {
     zh: '请先在设置中配置 Copilot 的 API Key',
@@ -96,6 +109,7 @@ export default {
     tr: 'Lütfen önce ayarlarda Copilot API Anahtarını yapılandırın',
     ja: '最初に設定でCopilot APIキーを構成してください',
     hu: 'Kérjük, először állítsa be a Copilot API-kulcsot a beállításokban',
+    ko: '먼저 설정에서 Copilot API Key를 등록해 주세요',
   },
   goToSetting: {
     zh: '去设置',
@@ -103,6 +117,7 @@ export default {
     tr: 'Ayarlar',
     ja: '設定',
     hu: 'Beállítások',
+    ko: '설정으로 이동',
   },
   promptError: {
     zh: '请帮助解析并解决以下错误：',
@@ -110,6 +125,7 @@ export default {
     tr: 'Lütfen aşağıdaki hata mesajını analiz etmeye ve çözmeye yardımcı olun: ',
     ja: '以下のエラーメッセージを分析し、解決してください：',
     hu: 'Kérjük, segítsen elemezni és megoldani az alábbi hibaüzenetet: ',
+    ko: '다음 오류를 분석하고 해결하는 데 도움을 주세요: ',
   },
   myConnectionInfo: {
     zh: '有需要的话可以查看这个当前的连接信息：@connection',
@@ -117,6 +133,7 @@ export default {
     tr: 'Gerekirse, mevcut bağlantı bilgisini kontrol edebilirsiniz: @connection',
     ja: '必要な場合は、現在の接続情報を確認できます：@connection',
     hu: 'Szükség esetén ellenőrizheti a jelenlegi kapcsolati információkat: @connection',
+    ko: '필요하다면 현재 연결 정보를 확인할 수 있습니다: @connection',
   },
   promptCodegen: {
     zh: '客户端代码生成',
@@ -124,6 +141,7 @@ export default {
     tr: 'Kod Oluşturucu',
     ja: 'コード生成',
     hu: 'Kódgenerálás',
+    ko: '클라이언트 코드 생성',
   },
   promptProgrammingLanguage: {
     zh: '使用当前连接创建 {0} MQTT Client 代码 {1}',
@@ -131,6 +149,7 @@ export default {
     tr: 'Mevcut bağlantı ile {0} MQTT Client kodu oluştur {1}',
     ja: '現在の接続で {0} MQTTクライアントコードを作成する {1}',
     hu: 'Hozzon létre {0} MQTT ügyfélkódot az aktuális kapcsolattal {1}',
+    ko: '현재 연결로 {0} MQTT 클라이언트 코드 생성 {1}',
   },
   genSimpleIoTPayload: {
     zh: '生成简单测试数据',
@@ -138,6 +157,7 @@ export default {
     tr: 'Basit IoT Verisi Oluştur',
     ja: 'シンプルなIoTデータを生成する',
     hu: 'Egyszerű IoT Adatok Generálása',
+    ko: '간단한 테스트 데이터 생성',
   },
   promptGenSimpleIoTPayload: {
     zh: '生成简单结构的 MQTT IoT 测试数据，适合基础测试场景。',
@@ -145,6 +165,7 @@ export default {
     tr: 'Temel test senaryoları için basit yapıda MQTT IoT test verileri oluşturun.',
     ja: '基本的なテストシナリオに適した、単純な構造のMQTT IoTテストデータを生成します。',
     hu: 'Generáljon egyszerű szerkezetű MQTT IoT tesztadatokat, amelyek alapvető tesztelési forgatókönyvekhez alkalmasak.',
+    ko: '간단한 구조의 MQTT IoT 테스트 데이터를 생성합니다. 기본적인 테스트 시나리오에 적합합니다.',
   },
   genComplexIoTPayload: {
     zh: '生成复杂测试数据',
@@ -152,6 +173,7 @@ export default {
     tr: 'Karmaşık IoT Verisi Oluştur',
     ja: '複雑なIoTデータを生成する',
     hu: 'Bonyolult IoT Adatok Generálása',
+    ko: '복잡한 테스트 데이터 생성',
   },
   promptGenComplexIoTPayload: {
     zh: '生成具有复杂结构的 MQTT IoT 测试数据，适用于高级测试场景，包括多设备交互和数据分析。',
@@ -159,6 +181,7 @@ export default {
     tr: 'Gelişmiş test senaryoları için uygun, çoklu cihaz etkileşimlerini ve veri analizini içeren karmaşık yapıda IoT test verileri oluşturun.',
     ja: '複数デバイスの相互作用とデータ分析を含む、高度なテストシナリオに適した複雑な構造のIoTテストデータを生成します。',
     hu: 'Generáljon bonyolult szerkezetű IoT tesztadatokat, amelyek alkalmasak fejlett tesztelési forgatókönyvekre, beleértve a több eszköz közötti interakciókat és az adatelemzést.',
+    ko: '복잡한 구조의 MQTT IoT 테스트 데이터를 생성합니다. 다중 기기 상호작용과 데이터 분석을 포함한 고급 테스트 시나리오에 적합합니다.',
   },
   genConnectedCarPayload: {
     zh: '车联网测试数据',
@@ -166,6 +189,7 @@ export default {
     tr: 'Bağlantılı Araba Test Verisi Oluştur',
     ja: '車載テレメトリーデータ',
     hu: 'Csatlakoztatott Autó Tesztadatok Generálása',
+    ko: '커넥티드 카 테스트 데이터',
   },
   promptGenConnectedCarPayload: {
     zh: '生成车联网测试数据，模拟车辆通信、远程监控和数据分析。',
@@ -173,6 +197,7 @@ export default {
     tr: 'Araç iletişimi, uzaktan izleme ve veri analizini simüle eden bağlantılı araba test verileri oluşturun.',
     ja: '車両通信、リモートモニタリング、データ分析をシミュレートするコネクテッドカーのテストデータを生成します。',
     hu: 'Generáljon csatlakoztatott autó tesztadatokat, amelyek az autókommunikációt, a távoli monitorozást és az adatelemzést szimulálják.',
+    ko: '차량 통신, 원격 모니터링, 데이터 분석을 시뮬레이션하는 커넥티드 카 테스트 데이터를 생성합니다.',
   },
   genSmartHomePayload: {
     zh: '智能家居测试数据',
@@ -180,6 +205,7 @@ export default {
     tr: 'Akıllı Ev Test Verisi Oluştur',
     ja: 'スマートホームのテストデータを生成する',
     hu: 'Okosotthoni Tesztadatok Generálása',
+    ko: '스마트홈 테스트 데이터',
   },
   promptGenSmartHomePayload: {
     zh: '生成智能家居测试数据，包括设备自动化和用户行为模式。',
@@ -187,6 +213,7 @@ export default {
     tr: 'Cihaz otomasyonunu ve kullanıcı davranış modellerini içeren akıllı ev test verileri oluşturun.',
     ja: 'デバイスの自動化とユーザー行動パターンを含むスマートホームテストデータを生成します。',
     hu: 'Generáljon okosotthoni tesztadatokat, amelyek az eszközautomatizálást és a felhasználói viselkedésmintákat tartalmazzák.',
+    ko: '기기 자동화와 사용자 행동 패턴을 포함한 스마트홈 테스트 데이터를 생성합니다.',
   },
   genIndustrialIoTPayload: {
     zh: '工业物联网测试数据',
@@ -194,6 +221,7 @@ export default {
     tr: 'Endüstriyel IoT Test Verisi Oluştur',
     ja: '産業用IoTテストデータを生成する',
     hu: 'Ipari IoT Tesztadatok Generálása',
+    ko: '산업용 IoT 테스트 데이터',
   },
   promptGenIndustrialIoTPayload: {
     zh: '生成适用于工业物联网场景的 MQTT IoT 测试数据，包括机器性能、传感器读数和生产线状态。',
@@ -201,6 +229,7 @@ export default {
     tr: 'Makine performansını, sensör okumalarını ve üretim hattı durumlarını içeren, endüstriyel IoT senaryoları için uygun MQTT IoT test verileri oluşturun.',
     ja: '機械のパフォーマンス、センサーの読み取り、生産ラインの状態を含む、産業用IoTシナリオに適したMQTT IoTテストデータを生成します。',
     hu: 'Generáljon MQTT IoT tesztadatokat ipari IoT forgatókönyvekhez, beleértve a gépek teljesítményét, a szenzorok olvasásait és a termelési sor állapotait.',
+    ko: '기계 성능, 센서 값, 생산 라인 상태를 포함해 산업용 IoT 시나리오에 적합한 MQTT IoT 테스트 데이터를 생성합니다.',
   },
   mqttProtocol: {
     zh: 'MQTT 协议是什么',
@@ -208,6 +237,7 @@ export default {
     tr: 'MQTT Protokolü Nedir',
     ja: 'MQTTプロトコルとは何ですか',
     hu: 'Mi az MQTT protokoll',
+    ko: 'MQTT 프로토콜이란',
   },
   whatIsMQTT5: {
     zh: 'MQTT 5.0 是什么',
@@ -215,6 +245,7 @@ export default {
     tr: 'MQTT 5.0 nedir',
     ja: 'MQTT 5.0 とは何ですか',
     hu: 'Mi az MQTT 5.0',
+    ko: 'MQTT 5.0이란',
   },
   whatIsMQTT5Desc: {
     zh: 'MQTT 5.0 是什么？请提供详细的介绍，包含 MQTT 5.0 的新特性和更新。',
@@ -222,6 +253,7 @@ export default {
     tr: "MQTT 5.0 nedir? Lütfen MQTT 5.0'ın yeni özelliklerini ve güncellemelerini içeren ayrıntılı bir tanıtım sağlayın.",
     ja: 'MQTT 5.0とは何ですか？MQTT 5.0の新機能と更新を含む詳細な紹介を提供してください。',
     hu: 'Mi az MQTT 5.0? Kérjük, adjon meg egy részletes bevezetést, amely tartalmazza az MQTT 5.0 új funkcióit és frissítéseit.',
+    ko: 'MQTT 5.0이란 무엇인가요? MQTT 5.0의 새로운 기능과 업데이트를 포함해 자세히 소개해 주세요.',
   },
   mqttQoS: {
     zh: 'MQTT QoS 是什么',
@@ -229,6 +261,7 @@ export default {
     tr: 'MQTT QoS Nedir',
     ja: 'MQTT QoSとは何ですか',
     hu: 'Mi az MQTT QoS',
+    ko: 'MQTT QoS란',
   },
   mqttQoSDesc: {
     zh: 'MQTT QoS 是什么？我该如何选择，请提供一些真实场景案例区分',
@@ -236,6 +269,7 @@ export default {
     tr: 'MQTT QoS Nedir? Nasıl seçilir? Lütfen ayırt etmek için bazı gerçek dünya senaryo durumları sağlayın',
     ja: 'MQTT QoSとは何ですか？どうやって選びますか？区別するためにいくつかの実世界のシナリオケースを提供してください',
     hu: 'Mi az MQTT QoS? Hogyan válasszam ki? Kérjük, adjon meg néhány valós világ szcenárió esetet a megkülönböztetéshez',
+    ko: 'MQTT QoS란 무엇인가요? 어떻게 선택해야 하나요? 구분할 수 있도록 실제 사례를 몇 가지 제시해 주세요',
   },
   mqttRetain: {
     zh: 'MQTT 保留消息是什么',
@@ -243,6 +277,7 @@ export default {
     tr: 'Retain Mesajı Nedir',
     ja: 'レテインメッセージとは何ですか',
     hu: 'Mi a Retain Üzenet',
+    ko: 'Retain 메시지란',
   },
   mqttRetainDesc: {
     zh: 'MQTT 保留消息是什么？我该如何使用，请提供一些真实场景案例，并且告知如何使用 MQTTX 来清除保留消息呢？',
@@ -250,6 +285,7 @@ export default {
     tr: "MQTT Retain Mesajı Nedir? Nasıl kullanılır? Lütfen bazı gerçek dünya senaryo durumları sağlayın ve MQTTX'i kullanarak kalıcı mesajları nasıl temizleyeceğimi söyleyin?",
     ja: 'MQTT レテインメッセージとは何ですか？どうやって使うのですか？実際のシナリオケースをいくつか提供し、MQTTXを使用して保持されたメッセージをクリアする方法を教えてください。',
     hu: 'Mi az MQTT Retain Üzenet? Hogyan használjam? Kérjük, adjon meg néhány valós világ szcenárió esetet, és mondja el, hogyan használhatom az MQTTX-et a megőrzött üzenetek törléséhez?',
+    ko: 'MQTT Retain 메시지란 무엇인가요? 어떻게 사용하나요? 실제 사례를 몇 가지 제시하고, MQTTX로 Retain 메시지를 삭제하는 방법도 알려주세요?',
   },
   installEMQX: {
     zh: '如何安装 EMQX',
@@ -257,6 +293,7 @@ export default {
     tr: 'EMQX Nasıl Kurulur',
     ja: 'EMQXのインストール方法',
     hu: 'Hogyan telepíthető az EMQX',
+    ko: 'EMQX 설치 방법',
   },
   emqxRule: {
     zh: 'EMQX 规则引擎 SQL 示例',
@@ -264,6 +301,7 @@ export default {
     tr: 'EMQX Kural Motoru SQL Örneği',
     ja: 'EMQXルールエンジンSQLの例',
     hu: 'EMQX szabálymotor SQL példa',
+    ko: 'EMQX 규칙 엔진 SQL 예제',
   },
   promptEmqxRule: {
     zh: '请帮我编辑一段 EMQX 规则引擎的 SQL 示例，包含解释和简单教程',
@@ -271,6 +309,7 @@ export default {
     tr: 'Lütfen bana bir EMQX Kural Motoru SQL örneği düzenleme konusunda yardımcı olun, açıklama ve basit bir öğretici içerir',
     ja: 'EMQXルールエンジンSQLの例を編集してください。説明と簡単なチュートリアルが含まれています',
     hu: 'Segítsen szerkeszteni egy EMQX szabálymotor SQL példát, beleértve a magyarázatot és az egyszerű útmutatót',
+    ko: 'EMQX 규칙 엔진 SQL 예제 작성을 도와주세요. 설명과 간단한 튜토리얼도 포함해 주세요',
   },
   currentConnectionInfo: {
     zh: '当前连接信息',
@@ -278,6 +317,7 @@ export default {
     tr: 'Mevcut Bağlantı Bilgisi',
     ja: '現在の接続情報',
     hu: 'Jelenlegi kapcsolat információ',
+    ko: '현재 연결 정보',
   },
   promptCurrentConnectionInfo: {
     zh: '请帮我解释当前连接的信息，包含连接的基本信息 {0}',
@@ -285,6 +325,7 @@ export default {
     tr: 'Lütfen bana mevcut bağlantının bilgisini açıklama konusunda yardımcı olun, bağlantının temel bilgilerini içerir {0}',
     ja: '現在の接続の情報を説明してください。接続の基本情報を含みます {0}',
     hu: 'Segítsen elmagyarázni a jelenlegi kapcsolat adatait, beleértve a kapcsolat alapadatait {0}',
+    ko: '현재 연결 정보를 설명해 주세요. 연결의 기본 정보 {0}를 포함해 주세요',
   },
   explainer: {
     zh: '解释器',
@@ -292,6 +333,7 @@ export default {
     tr: 'Açıklayıcı',
     ja: '解説者',
     hu: 'Magyarázó',
+    ko: '설명',
   },
   insertCodeToEditor: {
     zh: '插入编辑器',
@@ -299,6 +341,7 @@ export default {
     tr: 'Ekle',
     ja: '挿入',
     hu: 'Beszúrás',
+    ko: '삽입',
   },
   insertCodeSuccess: {
     zh: '代码已插入编辑器中',
@@ -306,6 +349,7 @@ export default {
     tr: 'Kod editöre eklendi',
     ja: 'コードがエディタに挿入されました',
     hu: 'A kód be lett szúrva a szerkesztőbe',
+    ko: '코드가 에디터에 삽입되었습니다',
   },
   genTestDoc: {
     zh: '生成测试文档',
@@ -313,6 +357,7 @@ export default {
     tr: 'Test Belgesi Oluştur',
     ja: 'テストドキュメントを生成する',
     hu: 'Teszt dokumentum generálása',
+    ko: '테스트 문서 생성',
   },
   promptGenTestDoc: {
     zh: '请帮我生成一份 MQTT的测试文档，包含测试的基本信息 {0}，并总结一份完整的测试报告',
@@ -320,6 +365,7 @@ export default {
     tr: 'Lütfen bana MQTT bağlantı testi belgesi oluşturma konusunda yardımcı olun, testin temel bilgilerini içerir {0} ve tam bir test raporu özetleyin',
     ja: 'MQTT接続テストドキュメントを生成してください。テストの基本情報を含みます {0} そして完全なテストレポートをまとめる',
     hu: 'Segítsen létrehozni egy MQTT kapcsolat teszt dokumentumot, beleértve a teszt alapvető információit {0} és összefoglal egy teljes teszt jelentést',
+    ko: 'MQTT 연결 테스트 문서를 생성해 주세요. 테스트의 기본 정보 {0}를 포함하고, 완전한 테스트 보고서로 정리해 주세요',
   },
   emqxLogAnalysis: {
     zh: 'EMQX 日志分析',
@@ -327,13 +373,15 @@ export default {
     tr: 'EMQX Günlük Analizi',
     ja: 'EMQXログ分析',
     hu: 'EMQX naplóelemzés',
+    ko: 'EMQX 로그 분석',
   },
   promptEmqxLogAnalysis: {
     zh: '请帮我分析一份 EMQX 日志，包含解释告警和错误信息等，并提供解决方案，日志内容：',
     en: 'Please help me analyze an EMQX log, including explanations of alerts and error messages, and provide solutions, log content:',
     tr: 'Lütfen bana bir EMQX günlüğü analiz etme konusunda yardımcı olun, uyarıların ve hata mesajlarının açıklamalarını içerir ve çözümler sağlar, günlük içeriği:',
     ja: 'EMQXログを分析してください。アラートとエラーメッセージの説明を含み、解決策を提供します。ログの内容',
-    hu: 'Segítsen elemzeni egy EMQX naplót, beleértve az riasztások és hibaüzenetek magyarázatát, és megoldásokat nyújt, naplótartalom:',
+    hu: 'Segítsen elemezeni egy EMQX naplót, beleértve az riasztások és hibaüzenetek magyarázatát, és megoldásokat nyújt, naplótartalom:',
+    ko: 'EMQX 로그 분석을 도와주세요. 경고 및 오류 메시지에 대한 설명과 해결 방안을 포함해 주세요. 로그 내용:',
   },
   programmingLang: {
     zh: '编程语言',
@@ -341,6 +389,7 @@ export default {
     tr: 'Diller',
     ja: 'プログラミング言語',
     hu: 'Programozási',
+    ko: '프로그래밍 언어',
   },
   hardware: {
     zh: '硬件',
@@ -348,6 +397,7 @@ export default {
     tr: 'Donanım',
     ja: 'ハードウェア',
     hu: 'Hardver',
+    ko: '하드웨어',
   },
   mobileApps: {
     zh: '移动应用',
@@ -355,6 +405,7 @@ export default {
     tr: 'Mobil Uygulamalar',
     ja: 'モバイルアプリ',
     hu: 'Mobil alkalmazások',
+    ko: '모바일 앱',
   },
   webApps: {
     zh: 'Web 应用',
@@ -362,6 +413,7 @@ export default {
     tr: 'Web Uygulamalar',
     ja: 'Webアプリ',
     hu: 'Web alkalmazások',
+    ko: '웹 앱',
   },
   customFunction: {
     zh: '自定义函数',
@@ -369,6 +421,7 @@ export default {
     tr: 'Özel Fonksiyon',
     ja: 'カスタム関数',
     hu: 'Egyedi függvény',
+    ko: '사용자 정의 함수',
   },
   customRequirementGenerate: {
     zh: '自定义需求生成',
@@ -376,6 +429,7 @@ export default {
     tr: 'Özel İhtiyaç Oluşturma',
     ja: 'カスタム要求生成',
     hu: 'Egyedi igény generálás',
+    ko: '사용자 정의 요구사항 생성',
   },
   simulateWeatherData: {
     zh: '模拟天气数据',
@@ -383,6 +437,7 @@ export default {
     tr: 'Hava Verisi Simüle Et',
     ja: '天気データをシミュレート',
     hu: 'Időjárás adatok szimulálása',
+    ko: '날씨 데이터 시뮬레이션',
   },
   dynamicCommandSwitch: {
     zh: '动态指令切换',
@@ -390,6 +445,7 @@ export default {
     tr: 'Dinamik Komut Anahtarı',
     ja: 'ダイナミックコマンドスイッチ',
     hu: 'Dinamik parancs kapcsoló',
+    ko: '동적 명령 전환',
   },
   timeFormatProcessing: {
     zh: '时间格式处理',
@@ -397,6 +453,7 @@ export default {
     tr: 'Zaman Formatı İşleme',
     ja: '時間フォーマット処理',
     hu: 'Időformátum feldolgozás',
+    ko: '시간 형식 처리',
   },
   promptCustomFunctionCustomRequirement: {
     zh: '请帮我生成一个自定义函数，包含测试用例和预期结果，描述需求：',
@@ -404,6 +461,7 @@ export default {
     tr: 'Lütfen bana bir özel fonksiyon oluşturma konusunda yardımcı olun, test durumlarını ve beklenen sonuçları içerir, gereksinimleri açıklayın:',
     ja: 'テストケースと期待される結果を含むカスタム関数を生成するのにお手伝いください。要件を説明してください：',
     hu: 'Segítsen egy egyedi függvény generálásában, beleértve a teszteseteket és az elvárt eredményeket, írja le az igényeket:',
+    ko: '사용자 정의 함수 생성을 도와주세요. 테스트 케이스와 예상 결과를 포함해 주세요. 요구사항을 설명해 주세요:',
   },
   schema: {
     zh: '编解码',
@@ -411,6 +469,7 @@ export default {
     tr: 'Şemalar',
     ja: 'スキーマ',
     hu: 'Sémák',
+    ko: '스키마',
   },
   reportSmartHomeStatus: {
     zh: '智能家居设备状态上报',
@@ -418,6 +477,7 @@ export default {
     tr: 'Akıllı Ev Cihaz Durum Gönderimi',
     ja: 'スマートホームデバイス状態報告',
     hu: 'Intelligens otthoni eszközállapot jelentés',
+    ko: '스마트홈 기기 상태 보고',
   },
   industrialDeviceAlarm: {
     zh: '工业设备告警消息',
@@ -425,6 +485,7 @@ export default {
     tr: 'Endüstriyel Cihaz Alarm Mesajları',
     ja: '産業用デバイスアラームメッセージ',
     hu: 'Ipari eszköz figyelmeztetés üzenetek',
+    ko: '산업용 기기 경보 메시지',
   },
   connectedCarTelemetry: {
     zh: '车联网车辆遥测数据',
@@ -432,6 +493,7 @@ export default {
     tr: 'Bağlantılı Araba Telemetri Verileri',
     ja: '車載テレメトリーデータ',
     hu: 'Csatlakoztatott autó telemetria adatok',
+    ko: '커넥티드 카 원격 측정 데이터',
   },
   smartMeterReadings: {
     zh: '智能电表实时读数',
@@ -439,6 +501,7 @@ export default {
     tr: 'Akıllı Sayaç Gerçek Zamanlı Okumalar',
     ja: 'スマートメーターリアルタイム読取値',
     hu: 'Okos mérőóra valós idejű értékek',
+    ko: '스마트 미터 실시간 값',
   },
   promptSchemaCustomRequirement: {
     zh: '请根据需求生成对应的数据 Schema 和示例数据，描述需求：',
@@ -446,6 +509,7 @@ export default {
     tr: 'lütfen gereksinimlere göre karşılık gelen veri şemasını ve örnek verileri oluşturun, gereksinimleri açıklayın:',
     ja: '要件に従って対応するデータスキーマと例示データを生成してください。要件を説明してください：',
     hu: 'kérem generálja a megfelelő adatsémát és példaadatokat az igényeknek megfelelően, írja le az igényeket:',
+    ko: '요구사항에 맞는 데이터 스키마와 예시 데이터를 생성해 주세요. 요구사항을 설명해 주세요:',
   },
   promptCustomPayload: {
     zh: '请根据需求生成对应的测试数据，描述需求：',
@@ -453,6 +517,7 @@ export default {
     tr: 'lütfen gereksinimlere göre karşılık gelen test verilerini oluşturun, gereksinimleri açıklayın:',
     ja: '要件に従って対応するテストデータを生成してください。要件を説明してください：',
     hu: 'kérem generálja a megfelelő tesztadatokat az igényeknek megfelelően, írja le az igényeket:',
+    ko: '요구사항에 맞는 테스트 데이터를 생성해 주세요. 요구사항을 설명해 주세요:',
   },
   askEMQX: {
     zh: '询问 EMQX 相关问题',
@@ -460,6 +525,7 @@ export default {
     tr: 'EMQX ilgili sorunları sor',
     ja: 'EMQX関連の質問を尋ねる',
     hu: 'EMQX kapcsolatos kérdéseket kérdezhet',
+    ko: 'EMQX 관련 질문하기',
   },
   promptAskEMQX: {
     zh: '请输入 EMQX 任意相关的问题，问题描述：',
@@ -467,6 +533,7 @@ export default {
     tr: 'EMQX ilgili herhangi bir soruyu girin, soruyu açıklayın:',
     ja: 'EMQX関連の質問を入力してください。質問を説明してください：',
     hu: 'Kérjük, bármilyen kapcsolódó kérdést EMQX-re írjon be, a kérdés leírását:',
+    ko: 'EMQX와 관련된 질문을 입력해 주세요. 질문을 설명해 주세요:',
   },
   askMQTTFaq: {
     zh: '询问 MQTT 相关问题',
@@ -474,6 +541,7 @@ export default {
     tr: 'MQTT ilgili sorunları sor',
     ja: 'MQTT関連の質問を尋ねる',
     hu: 'MQTT kapcsolatos kérdéseket kérdezhet',
+    ko: 'MQTT 관련 질문하기',
   },
   promptAskMQTTFaq: {
     zh: '请输入 MQTT 相关问题，问题描述：',
@@ -481,6 +549,7 @@ export default {
     tr: 'MQTT ilgili herhangi bir soruyu girin, soruyu açıklayın:',
     ja: 'MQTT関連の質問を入力してください。質問を説明してください：',
     hu: 'Kérjük, bármilyen kapcsolódó kérdést MQTT-re írjon be, a kérdés leírását:',
+    ko: 'MQTT와 관련된 질문을 입력해 주세요. 질문을 설명해 주세요:',
   },
   // MCP Settings UI
   mcpTitle: {
@@ -489,6 +558,7 @@ export default {
     tr: 'MCP (Model Context Protocol)',
     ja: 'MCP (モデルコンテキストプロトコル)',
     hu: 'MCP (Model Context Protocol)',
+    ko: 'MCP (Model Context Protocol)',
   },
   mcpEnableLabel: {
     zh: '启用 MCP',
@@ -496,6 +566,7 @@ export default {
     tr: 'MCP Etkinleştir',
     ja: 'MCPを有効にする',
     hu: 'MCP engedélyezése',
+    ko: 'MCP 활성화',
   },
   mcpEnableTooltip: {
     zh: '启用 MCP 让 AI 使用外部工具和服务',
@@ -503,6 +574,7 @@ export default {
     tr: "AI'nın dış araçları ve hizmetleri kullanmasına izin vermek için MCP'yi etkinleştirin",
     ja: 'AIが外部ツールやサービスを使用できるようにMCPを有効にする',
     hu: 'Engedélyezze az MCP-t, hogy az AI külső eszközöket és szolgáltatásokat használhasson',
+    ko: 'MCP를 활성화하면 AI가 외부 도구와 서비스를 사용할 수 있습니다',
   },
   mcpServerConfigLabel: {
     zh: 'MCP 服务器配置',
@@ -510,6 +582,7 @@ export default {
     tr: 'MCP Sunucu Yapılandırması',
     ja: 'MCPサーバー構成',
     hu: 'MCP szerver konfiguráció',
+    ko: 'MCP 서버 설정',
   },
   mcpServerConfigTooltip: {
     zh: '以 JSON 格式配置 MCP 服务器，支持多个服务器',
@@ -517,6 +590,7 @@ export default {
     tr: 'MCP sunucularını JSON formatında yapılandırın, birden çok sunucuyu destekler',
     ja: 'MCPサーバーをJSON形式で構成、複数のサーバーをサポート',
     hu: 'MCP szerverek konfigurálása JSON formátumban, több szerver támogatása',
+    ko: 'JSON 형식으로 MCP 서버를 설정합니다. 여러 서버를 지원합니다',
   },
   mcpConfiguredServersLabel: {
     zh: '已配置的 MCP 服务器',
@@ -524,6 +598,7 @@ export default {
     tr: 'Yapılandırılmış MCP Sunucuları',
     ja: '構成済みのMCPサーバー',
     hu: 'Konfigurált MCP szerverek',
+    ko: '설정된 MCP 서버',
   },
   mcpConfiguredServersTooltip: {
     zh: '显示当前已配置的 MCP 服务器列表',
@@ -531,6 +606,7 @@ export default {
     tr: 'Şu anda yapılandırılmış MCP sunucularının listesini görüntüler',
     ja: '現在構成されているMCPサーバーのリストを表示',
     hu: 'A jelenleg konfigurált MCP szerverek listájának megjelenítése',
+    ko: '현재 설정된 MCP 서버 목록을 표시합니다',
   },
   mcpNoServersConfigured: {
     zh: '尚未配置 MCP 服务器',
@@ -538,6 +614,7 @@ export default {
     tr: 'Henüz MCP sunucusu yapılandırılmadı',
     ja: 'MCPサーバーはまだ構成されていません',
     hu: 'Még nincs konfigurált MCP szerver',
+    ko: '아직 설정된 MCP 서버가 없습니다',
   },
   mcpAvailableTools: {
     zh: '可用工具：',
@@ -545,6 +622,7 @@ export default {
     tr: 'Kullanılabilir Araçlar:',
     ja: '利用可能なツール：',
     hu: 'Elérhető eszközök:',
+    ko: '사용 가능한 도구:',
   },
   mcpDeleteConfirm: {
     zh: '确定要删除服务器 "{0}" 吗？',
@@ -552,6 +630,7 @@ export default {
     tr: '"{0}" sunucusunu silmek istediğinizden emin misiniz?',
     ja: 'サーバー「{0}」を削除してもよろしいですか？',
     hu: 'Biztosan törölni szeretné a(z) "{0}" szervert?',
+    ko: '서버 "{0}"을(를) 삭제하시겠습니까?',
   },
   mcpCopySuccess: {
     zh: '已复制到剪贴板',
@@ -559,6 +638,7 @@ export default {
     tr: 'Panoya kopyalandı',
     ja: 'クリップボードにコピーされました',
     hu: 'Vágólapra másolva',
+    ko: '클립보드에 복사되었습니다',
   },
   mcpCopyFailed: {
     zh: '复制失败，请手动选择并复制',
@@ -566,6 +646,7 @@ export default {
     tr: 'Kopyalama başarısız oldu, lütfen manuel olarak seçin ve kopyalayın',
     ja: 'コピーに失敗しました。手動で選択してコピーしてください',
     hu: 'Másolás sikertelen, kérjük, válassza ki és másolja manuálisan',
+    ko: '복사에 실패했습니다. 수동으로 선택하여 복사해 주세요',
   },
   mcpConfigError: {
     zh: '配置必须包含 mcpServers 对象',
@@ -573,6 +654,7 @@ export default {
     tr: 'Yapılandırma mcpServers nesnesini içermelidir',
     ja: '構成にはmcpServersオブジェクトを含める必要があります',
     hu: 'A konfigurációnak tartalmaznia kell az mcpServers objektumot',
+    ko: '설정에는 mcpServers 객체가 포함되어야 합니다',
   },
   mcpServerConfigInvalid: {
     zh: '服务器 "{0}" 配置无效，必须包含 url 或 command+args 数组',
@@ -580,6 +662,7 @@ export default {
     tr: 'Sunucu "{0}" yapılandırması geçersiz, url veya komut ve args dizisini içermelidir',
     ja: 'サーバー「{0}」の構成が無効です。urlまたはコマンドとargs配列を含める必要があります',
     hu: 'A(z) "{0}" szerver konfigurációja érvénytelen, tartalmaznia kell az url-t vagy a parancsot és az args tömböt',
+    ko: '서버 "{0}"의 설정이 유효하지 않습니다. url 또는 command와 args 배열을 포함해야 합니다',
   },
   mcpInvalidJsonFormat: {
     zh: 'JSON 格式无效',
@@ -587,6 +670,7 @@ export default {
     tr: 'Geçersiz JSON biçimi',
     ja: '無効なJSON形式',
     hu: 'Érvénytelen JSON formátum',
+    ko: '유효하지 않은 JSON 형식입니다',
   },
   mcpFailedParseConfig: {
     zh: '无法解析存储的配置，重置为默认',
@@ -594,6 +678,7 @@ export default {
     tr: 'Depolanan yapılandırma ayrıştırılamadı, varsayılana sıfırlandı',
     ja: '保存された構成の解析に失敗しました。デフォルトにリセットします',
     hu: 'Nem sikerült elemezni a tárolt konfigurációt, visszaállítás alapértelmezettre',
+    ko: '저장된 설정을 파싱하지 못해 기본값으로 재설정했습니다',
   },
   mcpServerTestSuccess: {
     zh: '服务器连接成功',
@@ -601,6 +686,7 @@ export default {
     tr: 'Sunucu başarıyla bağlandı',
     ja: 'サーバー接続成功',
     hu: 'A(z) szerver sikeresen csatlakoztatva',
+    ko: '서버에 성공적으로 연결되었습니다',
   },
   mcpServerTestFailed: {
     zh: '服务器连接失败',
@@ -608,6 +694,7 @@ export default {
     tr: 'Sunucu bağlantısı başarısız',
     ja: 'サーバー接続に失敗しました',
     hu: 'A(z) szerver csatlakoztatása sikertelen',
+    ko: '서버 연결에 실패했습니다',
   },
   mcpCalling: {
     zh: 'MCP 调用',
@@ -615,6 +702,7 @@ export default {
     tr: 'MCP Çağrı',
     ja: 'MCP呼び出し',
     hu: 'MCP hívás',
+    ko: 'MCP 호출',
   },
   mcpResultAnalysisPrompts: {
     zh: '请继续分析结果，并以简洁清晰的方式呈现数据。完成后请说明"[DONE]"',
@@ -622,5 +710,6 @@ export default {
     tr: 'Lütfen sonucu analiz etmeye devam edin ve verileri özlü ve net bir şekilde sunun. "[DONE]" ile bitirin',
     ja: '結果の分析を続け、データを簡潔かつ明確な方法で提示してください。「[DONE]」で終了してください',
     hu: 'Kérjük, folytassa az eredmény elemzését, és mutassa be az adatokat tömör és világos módon. Fejezze be "[DONE]" jelzéssel',
+    ko: '결과 분석을 계속 진행하고, 데이터를 간결하고 명확하게 제시해 주세요. 마지막에 "[DONE]"이라고 표시해 주세요',
   },
 }

--- a/src/lang/copilot.ts
+++ b/src/lang/copilot.ts
@@ -380,7 +380,7 @@ export default {
     en: 'Please help me analyze an EMQX log, including explanations of alerts and error messages, and provide solutions, log content:',
     tr: 'Lütfen bana bir EMQX günlüğü analiz etme konusunda yardımcı olun, uyarıların ve hata mesajlarının açıklamalarını içerir ve çözümler sağlar, günlük içeriği:',
     ja: 'EMQXログを分析してください。アラートとエラーメッセージの説明を含み、解決策を提供します。ログの内容',
-    hu: 'Segítsen elemezeni egy EMQX naplót, beleértve az riasztások és hibaüzenetek magyarázatát, és megoldásokat nyújt, naplótartalom:',
+    hu: 'Segítsen elemzeni egy EMQX naplót, beleértve az riasztások és hibaüzenetek magyarázatát, és megoldásokat nyújt, naplótartalom:',
     ko: 'EMQX 로그 분석을 도와주세요. 경고 및 오류 메시지에 대한 설명과 해결 방안을 포함해 주세요. 로그 내용:',
   },
   programmingLang: {

--- a/src/lang/help.ts
+++ b/src/lang/help.ts
@@ -5,6 +5,7 @@ export default {
     ja: 'MQTT について',
     tr: 'MQTT hakkında',
     hu: 'Minden MQTT-ről',
+    ko: 'MQTT에 관한 모든 것',
   },
   docs: {
     zh: 'MQTTX 文档',
@@ -12,6 +13,7 @@ export default {
     ja: 'MQTTX ドキュメント',
     tr: 'MQTTX Belgeleri',
     hu: 'MQTTX dokumentáció',
+    ko: 'MQTTX 문서',
   },
   forum: {
     zh: 'MQTTX 论坛',
@@ -19,6 +21,7 @@ export default {
     ja: 'MQTTX フォーラム',
     tr: 'MQTTX Forum',
     hu: 'MQTTX fórum',
+    ko: 'MQTTX 포럼',
   },
   learn: {
     zh: '学习 MQTT',
@@ -26,6 +29,7 @@ export default {
     ja: 'MQTT を学ぶ',
     tr: 'MQTT öğrenin',
     hu: 'Tanulj MQTT-t',
+    ko: 'MQTT 배우기',
   },
   publicMqttBroker: {
     zh: 'MQTT 公共服务器',
@@ -33,6 +37,7 @@ export default {
     ja: '公共 MQTT ブローカー',
     tr: 'Herkese açık MQTT Broker',
     hu: 'Nyilvános MQTT Broker',
+    ko: '공용 MQTT 브로커',
   },
   mqtt5Explore: {
     zh: 'MQTT 5 探索',
@@ -40,6 +45,7 @@ export default {
     ja: 'MQTT 5 を探る',
     tr: 'MQTT 5 Keşfedin',
     hu: 'Fedezze fel az MQTT 5-öt',
+    ko: 'MQTT 5 살펴보기',
   },
   guideTitle: {
     zh: 'MQTT 入门',
@@ -47,6 +53,7 @@ export default {
     ja: 'MQTT 初心者ガイド',
     tr: 'MQTT Başlangıç Kılavuzu',
     hu: 'MQTT kezdők útmutatója',
+    ko: 'MQTT 초보자 가이드',
   },
   guideDesc: {
     zh: '丰富、易理解的 MQTT 指南，助您快速入门 MQTT 协议。',
@@ -54,6 +61,7 @@ export default {
     ja: '豊富で分かりやすい MQTT ガイドで、MQTT プロトコルをすぐに始めることができます。',
     tr: 'Zengin ve kolay anlaşılabilen MQTT kılavuzu, MQTT protokolünü hızlı bir şekilde başlamanıza yardımcı olur.',
     hu: 'A gazdag és könnyen érthető MQTT útmutató segít abban, hogy gyorsan elkezdhesse a MQTT protokollt.',
+    ko: 'MQTT 프로토콜을 빠르게 시작할 수 있도록 도와주는 풍부하고 이해하기 쉬운 MQTT 가이드입니다.',
   },
   guideArticle1: {
     zh: '物联网首选协议，关于 MQTT 你需要了解这些',
@@ -61,6 +69,7 @@ export default {
     ja: 'What is The MQTT and Why is it the Best Protocol for IoT?',
     tr: 'What is The MQTT and Why is it the Best Protocol for IoT?',
     hu: 'What is The MQTT and Why is it the Best Protocol for IoT?',
+    ko: 'MQTT란 무엇이며 왜 IoT를 위한 최고의 프로토콜인가요?',
   },
   guideArticle2: {
     zh: 'MQTT 协议快速体验',
@@ -68,6 +77,7 @@ export default {
     ja: 'The Easiest Guide to Getting Started with MQTT',
     tr: 'The Easiest Guide to Getting Started with MQTT',
     hu: 'The Easiest Guide to Getting Started with MQTT',
+    ko: 'MQTT를 가장 쉽게 시작하는 가이드',
   },
   guideArticle3: {
     zh: 'MQTT 发布订阅模式介绍',
@@ -75,6 +85,7 @@ export default {
     ja: 'Introduction to MQTT publish-subscribe model',
     tr: 'Introduction to MQTT publish-subscribe model',
     hu: 'Introduction to MQTT publish-subscribe model',
+    ko: 'MQTT 발행-구독 모델 소개',
   },
   guideArticle4: {
     zh: '创建 MQTT 连接时如何设置参数？',
@@ -82,6 +93,7 @@ export default {
     ja: 'How to Set Parameters When Establishing an MQTT Connection?',
     tr: 'How to Set Parameters When Establishing an MQTT Connection?',
     hu: 'How to Set Parameters When Establishing an MQTT Connection?',
+    ko: 'MQTT 연결을 설정할 때 매개변수는 어떻게 지정하나요?',
   },
   guideArticle5: {
     zh: '通过案例理解 MQTT 主题与通配符',
@@ -89,6 +101,7 @@ export default {
     ja: 'Understanding MQTT Topics & Wildcards by Case',
     tr: 'Understanding MQTT Topics & Wildcards by Case',
     hu: 'Understanding MQTT Topics & Wildcards by Case',
+    ko: '사례로 이해하는 MQTT 토픽과 와일드카드',
   },
   guideArticle6: {
     zh: 'MQTT 持久会话与 Clean Session 详解',
@@ -96,6 +109,7 @@ export default {
     ja: 'MQTT Persistent Session and Clean Session Explained',
     tr: 'MQTT Persistent Session and Clean Session Explained',
     hu: 'MQTT Persistent Session and Clean Session Explained',
+    ko: 'MQTT 지속 세션과 클린 세션 설명',
   },
   guideArticle7: {
     zh: 'MQTT QoS 0, 1, 2 介绍',
@@ -103,6 +117,7 @@ export default {
     ja: 'Introduction to MQTT QoS 0, 1, 2',
     tr: 'Introduction to MQTT QoS 0, 1, 2',
     hu: 'Introduction to MQTT QoS 0, 1, 2',
+    ko: 'MQTT QoS 0, 1, 2 소개',
   },
   guideArticle8: {
     zh: 'MQTT 保留消息是什么？如何使用？',
@@ -110,6 +125,7 @@ export default {
     ja: "The Beginner's Guide to MQTT Retained Messages",
     tr: "The Beginner's Guide to MQTT Retained Messages",
     hu: "The Beginner's Guide to MQTT Retained Messages",
+    ko: 'MQTT 유지 메시지 초보자 가이드',
   },
   guideArticle9: {
     zh: 'MQTT 遗嘱消息（Will Message）的使用',
@@ -117,6 +133,7 @@ export default {
     ja: 'Use of MQTT Will Message',
     tr: 'Use of MQTT Will Message',
     hu: 'Use of MQTT Will Message',
+    ko: 'MQTT Will 메시지 사용법',
   },
   guideArticle10: {
     zh: 'MQTT 协议 Keep Alive 详解',
@@ -124,6 +141,7 @@ export default {
     ja: 'What is the MQTT Keep Alive parameter for?',
     tr: 'What is the MQTT Keep Alive parameter for?',
     hu: 'What is the MQTT Keep Alive parameter for?',
+    ko: 'MQTT Keep Alive 매개변수는 어떤 역할을 하나요?',
   },
   practiceTitle: {
     zh: 'MQTT 编程',
@@ -131,6 +149,7 @@ export default {
     ja: 'MQTT プログラミング',
     tr: 'MQTT Programlama',
     hu: 'MQTT programozás',
+    ko: 'MQTT 프로그래밍',
   },
   practiceDesc: {
     zh: '丰富的 MQTT 实战代码，助您快速开发 MQTT 服务及应用。',
@@ -138,6 +157,7 @@ export default {
     ja: '豊富な MQTT 実践コードで、MQTT サービスとアプリケーションをすぐに開発できます。',
     tr: 'Zengin MQTT uygulama kodu, MQTT hizmetlerini ve uygulamalarını hızlı bir şekilde geliştirmenize yardımcı olur.',
     hu: 'Gazdag MQTT gyakorlati kód, amely segít a MQTT szolgáltatások és alkalmazások gyors fejlesztésében.',
+    ko: 'MQTT 서비스와 애플리케이션을 빠르게 개발하도록 도와주는 풍부한 MQTT 실습 코드입니다.',
   },
   miniProgram: {
     zh: '微信小程序',
@@ -145,6 +165,7 @@ export default {
     ja: 'WeChat Mini Program',
     tr: 'WeChat Mini Program',
     hu: 'WeChat Mini Program',
+    ko: 'WeChat 미니 프로그램',
   },
   raspberryPi: {
     zh: '树莓派',
@@ -152,5 +173,6 @@ export default {
     ja: 'Raspberry Pi',
     tr: 'Raspberry Pi',
     hu: 'Raspberry Pi',
+    ko: 'Raspberry Pi',
   },
 }

--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -5,10 +5,11 @@ import enLocale from 'element-ui/lib/locale/lang/en'
 import jaLocale from 'element-ui/lib/locale/lang/ja'
 import trLocale from 'element-ui/lib/locale/lang/tr-TR'
 import huLocale from 'element-ui/lib/locale/lang/hu'
+import koLocale from 'element-ui/lib/locale/lang/ko'
 
 import { formati18n } from '@/utils/i18n'
 
-const supportLang: SupportLangModel = ['zh', 'en', 'ja', 'tr', 'hu']
+const supportLang: SupportLangModel = ['zh', 'en', 'ja', 'tr', 'hu', 'ko']
 const i18nModules: i18nLocaleModel = [
   'connections',
   'settings',
@@ -22,7 +23,7 @@ const i18nModules: i18nLocaleModel = [
   'copilot',
 ]
 
-const { en, zh, ja, tr, hu }: VueI18n.LocaleMessages = formati18n(i18nModules, supportLang)
+const { en, zh, ja, tr, hu, ko }: VueI18n.LocaleMessages = formati18n(i18nModules, supportLang)
 
 const lang: VueI18n.LocaleMessages = {
   en: { ...en, ...enLocale },
@@ -30,6 +31,7 @@ const lang: VueI18n.LocaleMessages = {
   ja: { ...ja, ...jaLocale },
   tr: { ...tr, ...trLocale },
   hu: { ...hu, ...huLocale },
+  ko: { ...ko, ...koLocale },
 }
 
 export default lang

--- a/src/lang/log.ts
+++ b/src/lang/log.ts
@@ -5,6 +5,7 @@ export default {
     ja: 'ログ',
     tr: 'Günlük',
     hu: 'Napló',
+    ko: '로그',
   },
   logLevel: {
     zh: '日志等级',
@@ -12,6 +13,7 @@ export default {
     ja: 'ログレベル',
     tr: 'Günlük Seviyesi',
     hu: 'Napló Szint',
+    ko: '로그 레벨',
   },
   logLevelDesc: {
     zh: '等级：DEBUG > INFO > WARN > ERROR',
@@ -19,5 +21,6 @@ export default {
     ja: 'レベル：DEBUG > INFO > WARN > ERROR',
     tr: 'Seviyeler: DEBUG > INFO > WARN > ERROR',
     hu: 'Szintek: DEBUG > INFO > WARN > ERROR',
+    ko: '레벨: DEBUG > INFO > WARN > ERROR',
   },
 }

--- a/src/lang/menu.ts
+++ b/src/lang/menu.ts
@@ -5,6 +5,7 @@ export default {
     ja: 'MQTTX について',
     tr: 'MQTTX Hakkında',
     hu: 'A MQTTX-ről',
+    ko: 'MQTTX 정보',
   },
   preferences: {
     en: 'Preferences',
@@ -12,6 +13,7 @@ export default {
     ja: '設定',
     tr: 'Tercihler',
     hu: 'Beállítások',
+    ko: '환경설정',
   },
   checkForUpdate: {
     en: 'Check for update',
@@ -19,6 +21,7 @@ export default {
     ja: '更新を確認',
     tr: 'Güncellemeleri kontrol et',
     hu: 'Frissítések keresése',
+    ko: '업데이트 확인',
   },
   hideMQTTX: {
     en: 'Hide MQTTX',
@@ -26,6 +29,7 @@ export default {
     ja: 'MQTTX を隠す',
     tr: 'MQTTX Gizle',
     hu: 'MQTTX elrejtése',
+    ko: 'MQTTX 가리기',
   },
   hideOthers: {
     en: 'Hide Others',
@@ -33,6 +37,7 @@ export default {
     ja: '他を隠す',
     tr: 'Diğerlerini Gizle',
     hu: 'Mások elrejtése',
+    ko: '기타 가리기',
   },
   unhid: {
     en: 'Show All',
@@ -40,6 +45,7 @@ export default {
     ja: 'すべて表示',
     tr: 'Tümünü Göster',
     hu: 'Mindent mutat',
+    ko: '모두 보기',
   },
   quit: {
     en: 'Quit MQTTX',
@@ -47,6 +53,7 @@ export default {
     ja: 'MQTTX を終了',
     tr: "MQTTX'i Kapat",
     hu: 'MQTTX kilépése',
+    ko: 'MQTTX 종료',
   },
   file: {
     en: 'File',
@@ -54,6 +61,7 @@ export default {
     ja: 'ファイル',
     tr: 'Dosya',
     hu: 'Fájl',
+    ko: '파일',
   },
   newWindow: {
     en: 'New Window',
@@ -61,6 +69,7 @@ export default {
     ja: '新しいウィンドウ',
     tr: 'Yeni pencere',
     hu: 'Új ablak',
+    ko: '새 창',
   },
   closeWindow: {
     en: 'Close Window',
@@ -68,6 +77,7 @@ export default {
     ja: 'ウィンドウを閉じる',
     tr: 'Pencereyi Kapat',
     hu: 'Ablak bezárása',
+    ko: '창 닫기',
   },
   edit: {
     en: 'Edit',
@@ -75,6 +85,7 @@ export default {
     ja: '編集',
     tr: 'Düzenle',
     hu: 'Szerkesztés',
+    ko: '편집',
   },
   undo: {
     en: 'Undo',
@@ -82,6 +93,7 @@ export default {
     ja: '元に戻す',
     tr: 'Geri Al',
     hu: 'Visszavonás',
+    ko: '실행 취소',
   },
   redo: {
     en: 'Redo',
@@ -89,6 +101,7 @@ export default {
     ja: 'やり直す',
     tr: 'Yinele',
     hu: 'Újra',
+    ko: '다시 실행',
   },
   cut: {
     en: 'Cut',
@@ -96,6 +109,7 @@ export default {
     ja: '切り取り',
     tr: 'Kes',
     hu: 'Kivágás',
+    ko: '잘라내기',
   },
   copy: {
     en: 'Copy',
@@ -103,6 +117,7 @@ export default {
     ja: 'コピー',
     tr: 'Kopyala',
     hu: 'Másolás',
+    ko: '복사',
   },
   paste: {
     en: 'Paste',
@@ -110,6 +125,7 @@ export default {
     ja: '貼り付け',
     tr: 'Yapıştır',
     hu: 'Beillesztés',
+    ko: '붙여넣기',
   },
   pasteAndMatchStyle: {
     en: 'Paste and Match Style',
@@ -117,6 +133,7 @@ export default {
     ja: 'スタイルを貼り付けて一致させる',
     tr: 'Stili Yapıştır ve Eşleştir',
     hu: 'Stílus beillesztése és egyeztetése',
+    ko: '붙여넣고 스타일 일치',
   },
   delete: {
     en: 'Delete',
@@ -124,6 +141,7 @@ export default {
     ja: '削除',
     tr: 'Sil',
     hu: 'Törlés',
+    ko: '삭제',
   },
   selectAll: {
     en: 'Select All',
@@ -131,6 +149,7 @@ export default {
     ja: 'すべて選択',
     tr: 'Tümünü Seç',
     hu: 'Összes kijelölése',
+    ko: '모두 선택',
   },
   speech: {
     en: 'Speech',
@@ -138,6 +157,7 @@ export default {
     ja: '音声',
     tr: 'Konuşma',
     hu: 'Beszéd',
+    ko: '말하기',
   },
   startSpeaking: {
     en: 'Start Speaking',
@@ -145,6 +165,7 @@ export default {
     ja: '読み上げを開始',
     tr: 'Konuşmaya Başla',
     hu: 'Beszéd indítása',
+    ko: '말하기 시작',
   },
   stopSpeaking: {
     en: 'Stop Speaking',
@@ -152,6 +173,7 @@ export default {
     ja: '読み上げを停止',
     tr: 'Konuşmayı Durdur',
     hu: 'Beszéd leállítása',
+    ko: '말하기 중단',
   },
   newConnections: {
     en: 'New Connection',
@@ -159,6 +181,7 @@ export default {
     tr: 'Yeni bağlantı',
     ja: '新しい接続',
     hu: 'Új kapcsolat',
+    ko: '새 연결',
   },
   sendPayload: {
     en: 'Send Payload',
@@ -166,6 +189,7 @@ export default {
     ja: 'ペイロードを送信',
     tr: 'Yük Gönder',
     hu: 'Küldés',
+    ko: '페이로드 전송',
   },
   search: {
     en: 'Search',
@@ -173,6 +197,7 @@ export default {
     ja: '検索',
     tr: 'Ara',
     hu: 'Keresés',
+    ko: '검색',
   },
   view: {
     en: 'View',
@@ -180,6 +205,7 @@ export default {
     ja: '表示',
     tr: 'Görünüm',
     hu: 'Nézet',
+    ko: '보기',
   },
   reload: {
     en: 'Reload',
@@ -187,6 +213,7 @@ export default {
     ja: '再読み込み',
     tr: 'Yeniden Yükle',
     hu: 'Újratöltés',
+    ko: '새로 고침',
   },
   forceReload: {
     en: 'Force Reload',
@@ -194,6 +221,7 @@ export default {
     ja: '強制再読み込み',
     tr: 'Zorla Yeniden Yükle',
     hu: 'Újratöltés kényszerítése',
+    ko: '강제 새로 고침',
   },
   toggleDevTools: {
     en: 'Toggle Developer Tools',
@@ -201,6 +229,7 @@ export default {
     ja: '開発者ツールを切り替え',
     tr: 'Geliştirici Araçlarını Aç/Kapat',
     hu: 'Fejlesztői eszközök megjelenítése/elrejtése',
+    ko: '개발자 도구 전환',
   },
   actualSize: {
     en: 'Actual Size',
@@ -208,6 +237,7 @@ export default {
     ja: '実際のサイズ',
     tr: 'Gerçek Boyut',
     hu: 'Valódi méret',
+    ko: '실제 크기',
   },
   zoomIn: {
     en: 'Zoom In',
@@ -215,6 +245,7 @@ export default {
     ja: '拡大',
     tr: 'Yakınlaştır',
     hu: 'Nagyítás',
+    ko: '확대',
   },
   zoomOut: {
     en: 'Zoom Out',
@@ -222,6 +253,7 @@ export default {
     ja: '縮小',
     tr: 'Uzaklaştır',
     hu: 'Kicsinyítés',
+    ko: '축소',
   },
   toggleFullScreen: {
     en: 'Toggle Full Screen',
@@ -229,6 +261,7 @@ export default {
     ja: '全画面表示を切り替え',
     tr: 'Tam Ekranı Aç/Kapat',
     hu: 'Teljes képernyő megjelenítése/elrejtése',
+    ko: '전체 화면 전환',
   },
   window: {
     en: 'Window',
@@ -236,6 +269,7 @@ export default {
     ja: 'ウィンドウ',
     tr: 'Pencere',
     hu: 'Ablak',
+    ko: '창',
   },
   minimize: {
     en: 'Minimize',
@@ -243,6 +277,7 @@ export default {
     ja: '最小化',
     tr: 'Küçült',
     hu: 'Kis méret',
+    ko: '최소화',
   },
   zoom: {
     en: 'Zoom',
@@ -250,6 +285,7 @@ export default {
     ja: 'ズーム',
     tr: 'Yakınlaştır',
     hu: 'Nagyítás',
+    ko: '확대/축소',
   },
   bringAllToFront: {
     en: 'Bring All to Front',
@@ -257,6 +293,7 @@ export default {
     ja: 'すべてを前面に表示',
     tr: 'Tümünü Öne Getir',
     hu: 'Mindet előtérbe',
+    ko: '모두 앞으로 가져오기',
   },
   help: {
     en: 'Help',
@@ -264,6 +301,7 @@ export default {
     ja: 'ヘルプ',
     tr: 'Yardım',
     hu: 'Súgó',
+    ko: '도움말',
   },
   learnMoreMQTTX: {
     en: 'Learn More About MQTTX',
@@ -271,6 +309,7 @@ export default {
     ja: 'MQTTX についてもっと知る',
     tr: 'MQTTX Hakkında Daha Fazla Bilgi Edinin',
     hu: 'Tudjon meg többet az MQTTX-ről',
+    ko: 'MQTTX에 대해 자세히 알아보기',
   },
   learnMoreEMQX: {
     en: 'Learn More About EMQX',
@@ -278,6 +317,7 @@ export default {
     ja: 'EMQX についてもっと知る',
     tr: 'EMQX Hakkında Daha Fazla Bilgi Edinin',
     hu: 'Tudjon meg többet az EMQX-ről',
+    ko: 'EMQX에 대해 자세히 알아보기',
   },
   reportProblem: {
     en: 'Report Problem',
@@ -285,6 +325,7 @@ export default {
     ja: '問題を報告',
     tr: 'Sorunu Bildir',
     hu: 'Probléma jelentése',
+    ko: '문제 보고',
   },
   MQTTXWebsite: {
     en: 'MQTTX Website',
@@ -292,6 +333,7 @@ export default {
     ja: 'MQTTX ウェブサイト',
     tr: 'MQTTX Web Sitesi',
     hu: 'MQTTX weboldal',
+    ko: 'MQTTX 웹사이트',
   },
   EMQXWebsite: {
     en: 'EMQX Website',
@@ -299,6 +341,7 @@ export default {
     ja: 'EMQX ウェブサイト',
     tr: 'EMQX Web Sitesi',
     hu: 'EMQX weboldal',
+    ko: 'EMQX 웹사이트',
   },
   installCLI: {
     en: 'Install MQTTX CLI',
@@ -306,5 +349,6 @@ export default {
     ja: 'MQTTX CLI をインストール',
     tr: 'MQTTX CLI Yükleyin',
     hu: 'MQTTX CLI telepítése',
+    ko: 'MQTTX CLI 설치',
   },
 }

--- a/src/lang/script.ts
+++ b/src/lang/script.ts
@@ -5,6 +5,7 @@ export default {
     tr: 'Özel Fonksiyonlar',
     ja: 'カスタム関数',
     hu: 'Egyedi függvények',
+    ko: '함수',
   },
   schemaTab: {
     zh: '编解码',
@@ -12,6 +13,7 @@ export default {
     tr: 'Şemalar',
     ja: 'スキーマ',
     hu: 'Sémák',
+    ko: '스키마',
   },
   script: {
     zh: '脚本',
@@ -19,6 +21,7 @@ export default {
     tr: 'Komut dosyası',
     ja: 'スクリプト',
     hu: 'Script',
+    ko: '스크립트',
   },
   functionName: {
     zh: '自定义函数',
@@ -26,6 +29,7 @@ export default {
     tr: 'Fonksiyon',
     ja: '関数',
     hu: 'Függvény',
+    ko: '함수',
   },
   schemaType: {
     zh: '编解码类型',
@@ -33,6 +37,7 @@ export default {
     tr: 'Şema Türü',
     ja: 'スキーマタイプ',
     hu: 'Séma Típus',
+    ko: '스키마 유형',
   },
   schemaName: {
     zh: '编解码',
@@ -40,6 +45,7 @@ export default {
     tr: 'Şema',
     ja: 'スキーマ',
     hu: 'Séma',
+    ko: '스키마',
   },
   test: {
     zh: '测 试',
@@ -47,6 +53,7 @@ export default {
     tr: 'Test',
     ja: 'テスト',
     hu: 'Teszt',
+    ko: '테스트',
   },
   input: {
     zh: '输入',
@@ -54,6 +61,7 @@ export default {
     tr: 'Girdi',
     ja: 'インプット',
     hu: 'Bemenet',
+    ko: '입력',
   },
   output: {
     zh: '输出',
@@ -61,6 +69,7 @@ export default {
     tr: 'Çıktı',
     ja: 'アウトプット',
     hu: 'Kimenet',
+    ko: '출력',
   },
   saveScript: {
     zh: '保存脚本',
@@ -68,6 +77,7 @@ export default {
     tr: 'Komut dosyası kaydet',
     ja: '保存',
     hu: 'Script mentés',
+    ko: '스크립트 저장',
   },
   useScript: {
     zh: '运行脚本',
@@ -75,6 +85,7 @@ export default {
     tr: 'Komut dosyası kullan',
     ja: 'スクリプトを使う',
     hu: 'Használja a Scriptet',
+    ko: '스크립트 실행',
   },
   removeScript: {
     zh: '停止脚本',
@@ -82,6 +93,7 @@ export default {
     tr: 'Komut dosyası durdur',
     ja: '停止',
     hu: 'Script leállítás',
+    ko: '스크립트 중지',
   },
   applyType: {
     zh: '应用于',
@@ -89,6 +101,7 @@ export default {
     tr: 'Uygulanan',
     ja: '適用対象',
     hu: 'Alkazva',
+    ko: '적용 대상',
   },
   startScript: {
     zh: '脚本功能已开启',
@@ -96,6 +109,7 @@ export default {
     tr: 'Komut dosyası aktif',
     ja: 'スクリプトが有効になっています',
     hu: 'Script engedélyezve',
+    ko: '스크립트가 시작되었습니다',
   },
   stopScirpt: {
     zh: '脚本功能已停止',
@@ -103,6 +117,7 @@ export default {
     tr: 'Komut dosyası durduruldu',
     ja: 'スクリプトが停止しました',
     hu: 'Script le lett állítva',
+    ko: '스크립트가 중지되었습니다',
   },
   inUseScript: {
     zh: '脚本正在使用中',
@@ -110,6 +125,7 @@ export default {
     tr: 'Komut dosyası kullanılıyor',
     ja: 'スクリプトが使用中です',
     hu: 'Script használatban van',
+    ko: '스크립트가 사용 중입니다',
   },
   uploadJs: {
     zh: '导入 .js 文件',
@@ -117,6 +133,7 @@ export default {
     tr: '.js dosyasını içe aktar',
     ja: '.jsファイルをインポート',
     hu: '.js fájl importálása',
+    ko: '.js 파일 가져오기',
   },
   uploadProto: {
     zh: '导入 .proto 文件',
@@ -124,6 +141,7 @@ export default {
     tr: '.proto dosyasını içe aktar',
     ja: '.protoファイルをインポート',
     hu: '.proto fájl importálása',
+    ko: '.proto 파일 가져오기',
   },
   uploadAvsc: {
     zh: '导入 .avsc 文件',
@@ -131,6 +149,7 @@ export default {
     tr: '.avsc dosyasını içe aktar',
     ja: '.avsc ファイルをインポート',
     hu: '.avsc fájl importálása',
+    ko: '.avsc 파일 가져오기',
   },
   importFunction: {
     zh: '导入自定义函数',
@@ -138,6 +157,7 @@ export default {
     tr: 'Fonksiyonu İçe Aktar',
     ja: '関数をインポート',
     hu: 'Függvény importálása',
+    ko: '함수 가져오기',
   },
   importSchema: {
     zh: '导入编解码',
@@ -145,6 +165,7 @@ export default {
     tr: 'Şemayı İçe Aktar',
     ja: 'スキーマをインポート',
     hu: 'Séma importálása',
+    ko: '스키마 가져오기',
   },
   selectMessageName: {
     zh: '指定类型名称',
@@ -152,6 +173,7 @@ export default {
     tr: 'Mesaj adını seç',
     ja: 'メッセージ名を選択',
     hu: 'Üzenet nevének kiválasztása',
+    ko: '메시지 이름 선택',
   },
   protoName: {
     zh: '类型名称',
@@ -159,6 +181,7 @@ export default {
     tr: 'Proto adı',
     ja: 'Proto名',
     hu: 'Proto név',
+    ko: 'Proto 이름',
   },
   mustSelect: {
     zh: '至少选择一个函数或者编解码',
@@ -166,6 +189,7 @@ export default {
     tr: 'Fonksiyon veya şema seçilmeli, veya her ikisi de seçilebilir.',
     ja: '関数またはスキーマを選択する必要があります。両方を選択することも可能です。',
     hu: 'Választani kell egy függvényt vagy sémát, de mindkettőt is választhatja.',
+    ko: '함수 또는 스키마 중 하나를 선택해야 하며, 둘 다 선택할 수도 있습니다.',
   },
   mustProtoName: {
     zh: '必须填写类型名称',
@@ -173,5 +197,6 @@ export default {
     tr: 'Proto adı gereklidir',
     ja: 'Proto名は必須です',
     hu: 'Szükséges a Proto név',
+    ko: 'Proto 이름은 필수입니다',
   },
 }

--- a/src/lang/settings.ts
+++ b/src/lang/settings.ts
@@ -5,6 +5,7 @@ export default {
     tr: 'Ayarlar',
     ja: '設定',
     hu: 'Beállítások',
+    ko: '설정',
   },
   general: {
     zh: '基础',
@@ -12,6 +13,7 @@ export default {
     tr: 'Genel',
     ja: '一般',
     hu: 'Általános',
+    ko: '일반',
   },
   language: {
     zh: '语言',
@@ -19,6 +21,7 @@ export default {
     tr: 'Dil',
     ja: '言語',
     hu: 'Nyelv',
+    ko: '언어',
   },
   automatically: {
     zh: '自动检查更新',
@@ -26,6 +29,7 @@ export default {
     tr: 'Otomatik güncelleme',
     ja: '自動更新チェック',
     hu: 'Frissítések automatikus ellenőrzése',
+    ko: '자동 업데이트 확인',
   },
   maxReconnectTimes: {
     zh: '最大重连次数',
@@ -33,6 +37,7 @@ export default {
     tr: 'Maks yeniden bağlantı süreleri',
     ja: '最大再接続回数',
     hu: 'Max újracsatlakozás száma',
+    ko: '최대 재연결 횟수',
   },
   maxPayloadDisplaySize: {
     zh: '最大 Payload 显示大小',
@@ -40,6 +45,7 @@ export default {
     tr: 'Maks payload görüntüleme boyutu',
     ja: '最大ペイロード表示サイズ',
     hu: 'Max payload megjelenítési méret',
+    ko: '최대 페이로드 표시 크기',
   },
   maxPayloadDisplaySizeDesc: {
     zh: '达到或超过该大小的消息在消息列表中会折叠显示（最小 16KB，默认 512KB，最大 2MB）。',
@@ -47,6 +53,7 @@ export default {
     tr: 'Bu değeri aşan payloadlar mesaj listesinde daraltılır (min 16KB, default 512KB, max 2MB).',
     ja: 'この値以上のペイロードはメッセージ一覧で折りたたまれます（最小 16KB、既定 512KB、最大 2MB）。',
     hu: 'Az ennél nagyobb payloadok a listában összecsukva jelennek meg (min 16KB, default 512KB, max 2MB).',
+    ko: '이 값 이상의 페이로드는 메시지 목록에서 접혀 표시됩니다 (최소 16KB, 기본값 512KB, 최대 2MB).',
   },
   maxPayloadDisplaySizeRange: {
     zh: '可设置范围为 {min} 到 {max}。',
@@ -54,6 +61,7 @@ export default {
     tr: 'İzin verilen aralık {min} ile {max}.',
     ja: '設定可能範囲は{min}〜{max}です。',
     hu: 'A megengedett tartomány: {min}–{max}.',
+    ko: '설정 가능한 범위는 {min}에서 {max}까지입니다.',
   },
   appearance: {
     zh: '外观',
@@ -61,6 +69,7 @@ export default {
     tr: 'Görünüm',
     ja: '外観',
     hu: 'Megjelenés',
+    ko: '모양',
   },
   theme: {
     zh: '主题',
@@ -68,6 +77,7 @@ export default {
     tr: 'Tema',
     ja: 'テーマ',
     hu: 'Téma',
+    ko: '테마',
   },
   light: {
     zh: '明亮',
@@ -75,6 +85,7 @@ export default {
     tr: 'Açık',
     ja: 'ライト',
     hu: 'Világos',
+    ko: '라이트',
   },
   dark: {
     zh: '暗黑',
@@ -82,6 +93,7 @@ export default {
     tr: 'Koyu',
     ja: 'ダーク',
     hu: 'Sötét',
+    ko: '다크',
   },
   night: {
     zh: '夜间',
@@ -89,6 +101,7 @@ export default {
     tr: 'Geceleyin',
     ja: '夜',
     hu: 'Éjszaka',
+    ko: '나이트',
   },
   advanced: {
     zh: '高级',
@@ -96,6 +109,7 @@ export default {
     tr: 'Gelişmiş',
     ja: '詳細',
     hu: 'Haladó',
+    ko: '고급',
   },
   dataBackup: {
     zh: '数据备份',
@@ -103,6 +117,7 @@ export default {
     tr: 'Yedekleme',
     ja: 'データバックアップ',
     hu: 'Adatmentés',
+    ko: '데이터 백업',
   },
   dataRecovery: {
     zh: '数据恢复',
@@ -110,6 +125,7 @@ export default {
     tr: 'Veri kurtarma',
     ja: 'データ復旧',
     hu: 'Adat visszaállítás',
+    ko: '데이터 복구',
   },
   historyCleanup: {
     zh: '清除历史数据',
@@ -117,6 +133,7 @@ export default {
     tr: 'Geçmiş verileri temizle',
     ja: '履歴データをクリアする',
     hu: 'Előzmények törlése',
+    ko: '기록 데이터 지우기',
   },
   dataManage: {
     zh: '数据管理',
@@ -124,6 +141,7 @@ export default {
     tr: 'Veri yönetimi',
     ja: 'データ管理',
     hu: 'Adatkezelés',
+    ko: '데이터 관리',
   },
   autoResub: {
     zh: '自动恢复订阅',
@@ -131,6 +149,7 @@ export default {
     tr: 'Otomatik yeniden abone ol',
     ja: '自動的に再購読',
     hu: 'Automata újra feliratkozás',
+    ko: '자동 재구독',
   },
   multiTopics: {
     zh: '多主题订阅',
@@ -138,6 +157,7 @@ export default {
     tr: 'Çoklu başlık abone ol',
     ja: '複数のトピックを購読',
     hu: 'Több téma feliratkozás',
+    ko: '다중 토픽 구독',
   },
   topicWhitespaceDetection: {
     zh: '主题空格检测',
@@ -145,6 +165,7 @@ export default {
     tr: 'Konu Boşluk Tespiti',
     ja: 'トピック空白検出',
     hu: 'Téma szóköz észlelés',
+    ko: '토픽 공백 감지',
   },
   topicWhitespaceDetectionDesc: {
     zh: '用于提示主题中的空格字符，帮助提前识别可能导致发布与订阅不匹配的情况。',
@@ -152,6 +173,7 @@ export default {
     tr: 'Konulardaki boşlukları vurgulayarak yayın/abone olma uyuşmazlıklarını önlemeye yardımcı olur.',
     ja: 'トピック内の空白を示し、送受信の不一致を防ぐための確認に役立ちます。',
     hu: 'Kiemeli a szóközöket a témákban, hogy segítsen megelőzni a közzététel/előfizetés eltéréseket.',
+    ko: '토픽 내 공백을 강조 표시하여 발행/구독 불일치를 방지하는 데 도움을 줍니다.',
   },
   enableHardwareAcceleration: {
     zh: '启用 GPU 加速',
@@ -159,6 +181,7 @@ export default {
     tr: 'GPU Hızlandırmayı Etkinleştir',
     ja: 'GPUアクセラレーションを有効にする',
     hu: 'GPU gyorsítás engedélyezése',
+    ko: 'GPU 가속 사용',
   },
   enableHardwareAccelerationDesc: {
     zh: 'GPU 加速利用显卡硬件渲染界面，可使操作更流畅并降低 CPU 占用。如果此选项关闭或遇到画面卡顿、花屏等问题，请检查您的显卡驱动是否为最新版本。',
@@ -166,6 +189,7 @@ export default {
     tr: "GPU hızlandırma, işlemleri daha akıcı hale getirmek ve CPU kullanımını azaltmak için grafik donanımını kullanarak UI'yi render eder. Bu seçenek devre dışıysa veya ekran gecikmesi, görsel bozukluklar veya diğer sorunlar yaşıyorsanız, lütfen grafik sürücünüzün güncel olduğundan emin olun.",
     ja: 'GPUアクセラレーションは、グラフィックハードウェアを使用してUIをレンダリングし、操作をスムーズにし、CPU使用率を低下させます。このオプションが無効になっている場合、または画面のラグ、アーティファクト、その他の問題が発生した場合は、グラフィックドライバーが最新であるかどうかを確認してください。',
     hu: 'A GPU gyorsítás grafikus hardvert használ a UI rendereléséhez, így a műveletek gördülékenyebbek és a CPU-használat alacsonyabb. Ha ez a lehetőség le van tiltva, vagy képernyő akadozást, artefaktokat vagy más problémákat tapasztal, kérjük, ellenőrizze, hogy a grafikus illesztőprogram naprakész-e.',
+    ko: 'GPU 가속은 그래픽 하드웨어를 사용하여 UI를 렌더링함으로써 더 부드러운 동작과 낮은 CPU 사용량을 제공합니다. 이 옵션이 비활성화되어 있거나 화면 지연, 화면 깨짐 또는 기타 문제가 발생하는 경우, 그래픽 드라이버가 최신 버전인지 확인해 주세요.',
   },
   restartRequired: {
     zh: '需要重启',
@@ -173,6 +197,7 @@ export default {
     tr: 'Yeniden Başlatma Gerekiyor',
     ja: '再起動が必要です',
     hu: 'Újraindítás szükséges',
+    ko: '재시작 필요',
   },
   restartRequiredDesc: {
     zh: 'GPU 加速设置已更新。需要重启应用才能生效，是否立即重启？',
@@ -180,6 +205,7 @@ export default {
     tr: 'GPU hızlandırma ayarı güncellendi. Değişikliği uygulamak için uygulamayı şimdi yeniden başlatın?',
     ja: 'GPUアクセラレーション設定が更新されました。変更を適用するために今すぐアプリを再起動しますか？',
     hu: 'A GPU gyorsítás beállítása frissítve lett. Alkalmazza a változást az alkalmazás újraindításával most?',
+    ko: 'GPU 가속 설정이 업데이트되었습니다. 지금 앱을 재시작하여 변경 사항을 적용하시겠습니까?',
   },
   restartNow: {
     zh: '立即重启',
@@ -187,6 +213,7 @@ export default {
     tr: 'Şimdi Yeniden Başlat',
     ja: '今すぐ再起動',
     hu: 'Újraindítás most',
+    ko: '지금 재시작',
   },
   restartLater: {
     zh: '稍后重启',
@@ -194,6 +221,7 @@ export default {
     tr: 'Sonra',
     ja: '後で',
     hu: 'Később',
+    ko: '나중에',
   },
   autoResubDesc: {
     zh: '开启后，MQTTX 连接后会自动重新订阅本地保存的所有订阅',
@@ -201,6 +229,7 @@ export default {
     tr: 'Etkinleştirildiğinde, MQTTX bağlandıktan sonra yerel olarak kaydedilen tüm aboneliklere otomatik olarak yeniden abone olur',
     ja: '有効にした後、MQTTXは接続した後にローカルに保存されたすべてのサブスクリプションに自動的に再購読します',
     hu: 'Ha engedélyezve van, az MQTTX csatlakozás után automatikusan újra feliratkozik a helyben mentett összes előfizetésre',
+    ko: '활성화하면 MQTTX는 연결 후 로컬에 저장된 모든 구독을 자동으로 재구독합니다',
   },
   cleanHistoryDialogMessage: {
     zh: '即将删除所有连接中的历史消息记录、发送端记录的发布消息、主题、保留标志、历史连接配置和主题树数据。确定吗？',
@@ -208,6 +237,7 @@ export default {
     tr: 'Bu işlem, tüm bağlantılardaki geçmiş mesaj kayıtlarını, gönderen tarafından yayınlanan mesajları, konuları, saklama bayraklarını, geçmiş bağlantı yapılandırmalarını ve konu ağacı verilerini silecektir. Emin misiniz?',
     ja: 'これにより、すべての接続の履歴メッセージ記録、送信者によって公開されたメッセージ、トピック、保持フラグ、過去の接続設定、およびトピックツリーデータが削除されます。よろしいですか？',
     hu: 'Ez törölni fogja az összes kapcsolat előzményüzeneteit, a küldő által közzétett üzeneteket, témákat, megtartási jelzőket, korábbi kapcsolati beállításokat és témastruktúra adatokat. Biztos benne?',
+    ko: '모든 연결의 기록 메시지, 발신자가 발행한 메시지, 토픽, 유지 플래그, 이전 연결 설정 및 토픽 트리 데이터가 삭제됩니다. 계속하시겠습니까?',
   },
   syncOsTheme: {
     zh: '同步操作系统主题',
@@ -215,6 +245,7 @@ export default {
     tr: 'İşletim Sistemi Teması ile Senkronizasyon',
     ja: 'OSテーマと同期する',
     hu: 'Szinkronizálás az OS témával',
+    ko: 'OS 테마와 동기화',
   },
   syncOsThemeDesc: {
     zh: '开启后，系统将跟随操作系统主题自动切换',
@@ -222,6 +253,7 @@ export default {
     tr: 'Sisteminiz yaptığında Işık ve Gece temaları arasında otomatik olarak geçiş yapın.',
     ja: 'システムが切り替えると、ライトテーマとナイトテーマを自動的に切り替えます。',
     hu: 'Automatikusan válthat a Világos és az Éjszakai témák között, amikor a rendszer ezt teszi.',
+    ko: '시스템 설정에 따라 라이트 테마와 나이트 테마 사이를 자동으로 전환합니다.',
   },
   multiTopicsDesc: {
     zh: '开启后，将支持一次订阅多个主题，使用逗号（,）分隔',
@@ -229,6 +261,7 @@ export default {
     tr: 'Açık kaldığında, birden fazla konu abone olmak için bir kez abone olunabilir.',
     ja: '複数のトピックを一度に購読することができます。コンマで区切ります。',
     hu: 'Egy időben több témára feliratkozhat.',
+    ko: '쉼표로 구분하여 한 번에 여러 토픽을 구독할 수 있도록 합니다',
   },
   jsonHighlight: {
     zh: 'JSON 数据高亮',
@@ -236,6 +269,7 @@ export default {
     tr: 'JSON Vurgulama',
     ja: 'JSONハイライト',
     hu: 'JSON Kiemelés',
+    ko: 'JSON 하이라이트',
   },
   jsonHighlightDesc: {
     zh: '启用此选项后，将对接收到的 JSON 格式的 Payload 数据进行实时高亮显示。<br/>注意：这可能影响应用的性能。如果你在使用时遇到性能问题，可以尝试关闭这个选项。',
@@ -243,6 +277,7 @@ export default {
     tr: 'Bu özelliği etkinleştirerek, JSON formatındaki alınan yük verilerini gerçek zamanlı olarak vurgulayabilirsiniz. <br/>Not: Bu, uygulamanın performansını etkileyebilir. Performans sorunları yaşıyorsanız, bu özelliği devre dışı bırakmayı düşünün.',
     ja: 'この機能を有効にすると、リアルタイムで受信したJSON形式のPayloadデータをハイライト表示します。<br/>注意：これによりアプリケーションのパフォーマンスが影響を受ける可能性があります。パフォーマンスに問題がある場合は、この機能を無効にすることを検討してください。',
     hu: 'Engedélyezze ezt a funkciót, hogy a JSON formátumú, fogadott terhelési adatokat valós időben kiemelje. <br/>Megjegyzés: Ez befolyásolhatja az alkalmazás teljesítményét. Ha teljesítményproblémákat tapasztal, fontolja meg ennek a funkcióknak a letiltását.',
+    ko: 'JSON 형식으로 수신된 페이로드 데이터를 실시간으로 하이라이트합니다. <br/>이 기능을 사용하면 애플리케이션 성능에 영향을 줄 수 있으므로, 성능 문제가 발생하면 비활성화하는 것을 고려해 주세요.',
   },
   model: {
     zh: '模型',
@@ -250,6 +285,7 @@ export default {
     tr: 'Model',
     ja: 'モデル',
     hu: 'Modell',
+    ko: '모델',
   },
   enableCopilot: {
     zh: '启用 Copilot',
@@ -257,6 +293,7 @@ export default {
     tr: "Copilot'u Etkinleştir",
     ja: 'Copilotを有効にする',
     hu: 'Copilot engedélyezése',
+    ko: 'Copilot 사용',
   },
   importProgress: {
     zh: '导入进度',
@@ -264,6 +301,7 @@ export default {
     tr: 'İlerleme İçe Aktar',
     ja: '進捗をインポート',
     hu: 'Importálás folyamatban',
+    ko: '가져오기 진행 상황',
   },
   exportProgress: {
     zh: '导出进度',
@@ -271,6 +309,7 @@ export default {
     tr: 'İlerleme Dışa Aktar',
     ja: '進捗をエクスポート',
     hu: 'Exportálás folyamatban',
+    ko: '내보내기 진행 상황',
   },
   extends: {
     zh: '扩展',
@@ -278,6 +317,7 @@ export default {
     tr: 'Uzantılar',
     ja: '拡張',
     hu: 'Kiterjesztések',
+    ko: '확장 기능',
   },
   downloadingCLI: {
     zh: '下载 MQTTX CLI 中...',
@@ -285,6 +325,7 @@ export default {
     tr: 'MQTTX CLI indiriliyor...',
     ja: 'MQTTX CLIをダウンロード中...',
     hu: 'MQTTX CLI letöltése...',
+    ko: 'MQTTX CLI 다운로드 중...',
   },
   installCLITips: {
     zh: '一键安装 MQTTX CLI，您将被提示需要管理员权限。安装后，可在终端运行 MQTTX。',
@@ -292,6 +333,7 @@ export default {
     tr: "MQTTX CLI'yi tek tıklama ile kurun. Kurulum sırasında yönetici erişimi için uyarılacaksınız. Kurulumdan sonra, MQTTX'i terminalde çalıştırabilirsiniz.",
     ja: 'MQTTX CLIをワンクリックでインストールします。インストール中に管理者アクセスのプロンプトが表示されます。インストール後、ターミナルでMQTTXを実行できます。',
     hu: 'Egy kattintással telepítheti az MQTTX CLI-t. Telepítés közben rendszergazdai hozzáférésre vonatkozó kérést fog kapni. Telepítés után a terminálban futtathatja az MQTTX-et.',
+    ko: 'MQTTX CLI를 원클릭으로 설치합니다. 설치 중 관리자 권한을 요청하는 메시지가 표시됩니다. 설치 후에는 터미널에서 MQTTX를 실행할 수 있습니다.',
   },
   ignoreQoS0Message: {
     zh: '忽略 QoS 0 消息',
@@ -299,6 +341,7 @@ export default {
     tr: 'QoS 0 Mesajını Yakalamayın',
     ja: 'QoS 0 メッセージを無視する',
     hu: 'QoS 0 üzeneteket figyelmen kívül hagyás',
+    ko: 'QoS 0 메시지 무시',
   },
   ignoreQoS0MessageDesc: {
     zh: '开启后，MQTTX 将忽略 QoS 0 的消息，不会将其存储到本地，已保存的消息不会被自动清除，从而提高性能',
@@ -306,5 +349,6 @@ export default {
     tr: 'Etkinleştirdiğinizde, MQTTX QoS 0 mesajlarını yok sayacak ve bunları yerel olarak depolamayacaktır. Zaten kaydedilmiş olan mesajlar otomatik olarak temizlenmeyecektir, performansı artıracaktır.',
     ja: 'この機能を有効にすると、MQTTX は QoS 0 メッセージを無視し、それらをローカルに保存しません。すでに保存されたメッセージは自動的にクリアされません。これにより、パフォーマンスが向上します。',
     hu: 'Ha engedélyezve van, az MQTTX figyelmen kívül hagyja a QoS 0 üzeneteket, és nem tárolja őket helyben. Már mentett üzeneteket nem fog automatikusan törölni, ami teljesítmény javítását eredményezi.',
+    ko: '활성화하면 MQTTX는 QoS 0 메시지를 무시하고 로컬에 저장하지 않습니다. 이미 저장된 메시지는 자동으로 삭제되지 않으며, 이를 통해 성능이 향상됩니다',
   },
 }

--- a/src/lang/update.ts
+++ b/src/lang/update.ts
@@ -5,6 +5,7 @@ export default {
     ja: '利用可能な更新',
     tr: 'Güncelleme Mevcut',
     hu: 'Frissítés elérhető',
+    ko: '사용 가능한 업데이트',
   },
   ignoreVersion: {
     zh: '忽略',
@@ -12,6 +13,7 @@ export default {
     ja: '却下',
     tr: 'Reddet',
     hu: 'Elutasít',
+    ko: '무시',
   },
   nextRemind: {
     zh: '稍后提醒',
@@ -19,6 +21,7 @@ export default {
     ja: '後でリマインドしてください',
     tr: 'Bana daha sonra hatırlat',
     hu: 'Emlékeztessen később',
+    ko: '나중에 알림',
   },
   update: {
     zh: '更新',
@@ -26,6 +29,7 @@ export default {
     ja: '更新',
     tr: 'Güncelle',
     hu: 'Frissítés',
+    ko: '업데이트',
   },
   downloadProgress: {
     zh: '下载进度',
@@ -33,6 +37,7 @@ export default {
     ja: 'ダウンロード進行状況',
     tr: 'İndirme İlerlemesi',
     hu: 'Letöltési Előrehaladás',
+    ko: '다운로드 진행률',
   },
   downloading: {
     zh: '下载更新中...',
@@ -40,6 +45,7 @@ export default {
     ja: '更新をダウンロード中...',
     tr: 'Güncelleme indiriliyor...',
     hu: 'Frissítés letöltése...',
+    ko: '업데이트 다운로드 중...',
   },
   downloaded: {
     zh: '安装并重启',
@@ -47,6 +53,7 @@ export default {
     ja: '再起動してアップデートをインストール',
     tr: 'Yeniden Başlat ve Güncellemeyi Yükle',
     hu: 'Újraindítás és Frissítés Telepítése',
+    ko: '재시작하고 업데이트 설치',
   },
   cancel: {
     zh: '取消更新',
@@ -54,6 +61,7 @@ export default {
     ja: '更新をキャンセル',
     tr: 'Güncellemeyi iptal et',
     hu: 'Frissítés megszakítása',
+    ko: '업데이트 취소',
   },
   install: {
     zh: '安装并重启',
@@ -61,5 +69,6 @@ export default {
     ja: 'インストールして再起動',
     tr: 'Kur ve Tekrar Başlat',
     hu: 'Telepítés és újraindítás',
+    ko: '설치하고 다시 시작',
   },
 }

--- a/src/lang/viewer.ts
+++ b/src/lang/viewer.ts
@@ -5,6 +5,7 @@ export default {
     tr: 'Görüntüleyici',
     ja: 'ビューア',
     hu: 'Megjelenítő',
+    ko: '뷰어',
   },
   dashboard: {
     zh: '仪表盘',
@@ -12,6 +13,7 @@ export default {
     tr: 'Gösterge Paneli',
     ja: 'ダッシュボード',
     hu: 'Irányítópult',
+    ko: '대시보드',
   },
   dashboards: {
     zh: '仪表盘',
@@ -19,6 +21,7 @@ export default {
     tr: 'Gösterge Panelleri',
     ja: 'ダッシュボード',
     hu: 'Irányítópultok',
+    ko: '대시보드',
   },
   createDashboard: {
     zh: '新建仪表盘',
@@ -26,6 +29,7 @@ export default {
     tr: 'Gösterge Paneli Oluştur',
     ja: 'ダッシュボードを作成',
     hu: 'Irányítópult létrehozása',
+    ko: '대시보드 생성',
   },
   hideDashboards: {
     zh: '隐藏仪表盘',
@@ -33,6 +37,7 @@ export default {
     tr: 'Gösterge Panellerini Gizle',
     ja: 'ダッシュボードを非表示',
     hu: 'Irányítópultok elrejtése',
+    ko: '대시보드 숨기기',
   },
   noWidgetsTitle: {
     zh: '添加可视化组件，开始使用仪表盘',
@@ -40,6 +45,7 @@ export default {
     tr: 'Yeni gösterge panelinizi bir görselleştirme ekleyerek başlatın',
     ja: '新しいダッシュボードを可視化の追加から始めましょう',
     hu: 'Kezdje az új irányítópultot egy vizualizáció hozzáadásával',
+    ko: '시각화를 추가하여 새 대시보드를 시작하세요',
   },
   noWidgetsHint: {
     zh: '选择一个数据源，然后通过图表、统计和其他小部件查询并可视化你的数据',
@@ -47,6 +53,7 @@ export default {
     tr: "Bir veri kaynağı seçin, ardından verilerinizi grafikler, istatistikler ve diğer widget'larla sorgulayın ve görselleştirin",
     ja: 'データソースを選択し、チャートや統計、その他のウィジェットでデータをクエリして可視化しましょう',
     hu: 'Válasszon ki egy adatforrást, majd lekérdezze és vizualizálja adatait diagramokkal, statisztikákkal és egyéb widgetekkel',
+    ko: '데이터 소스를 선택한 다음 차트, 통계 및 기타 위젯으로 데이터를 조회하고 시각화하세요',
   },
   addVisualization: {
     zh: '添加可视化组件',
@@ -54,6 +61,7 @@ export default {
     tr: 'Görselleştirme Ekle',
     ja: '可視化を追加',
     hu: 'Vizualizáció hozzáadása',
+    ko: '시각화 추가',
   },
   topicsTree: {
     zh: '主题树',
@@ -61,6 +69,7 @@ export default {
     tr: 'Konular Ağacı',
     ja: 'トピックツリー',
     hu: 'Témafa',
+    ko: '토픽 트리',
   },
   payloadInspector: {
     zh: '消息体查看器',
@@ -68,6 +77,7 @@ export default {
     tr: 'Mesaj Gövdesi İzleme',
     ja: 'ペイロードインスペクター',
     hu: 'Üzenetgövde figyelő',
+    ko: '페이로드 인스펙터',
   },
   diffView: {
     zh: '差异视图',
@@ -75,6 +85,7 @@ export default {
     tr: 'Fark Görünümü',
     ja: '差分ビュー',
     hu: 'Különbség nézet',
+    ko: '차이 보기',
   },
   jsonTree: {
     zh: 'JSON 树',
@@ -82,6 +93,7 @@ export default {
     tr: 'JSON Ağacı',
     ja: 'JSON ツリー',
     hu: 'JSON fa',
+    ko: 'JSON 트리',
   },
   searchInJson: {
     zh: '在 JSON 中搜索',
@@ -89,6 +101,7 @@ export default {
     tr: 'JSON da arama',
     ja: 'JSON で検索',
     hu: 'JSON-ban keresés',
+    ko: 'JSON에서 검색',
   },
   invalidJsonFormat: {
     zh: '无效的 JSON 格式',
@@ -96,6 +109,7 @@ export default {
     tr: 'Geçersiz JSON formatı',
     ja: '無効な JSON 形式',
     hu: 'Érvénytelen JSON formátum',
+    ko: '유효하지 않은 JSON 형식',
   },
   filterDesc: {
     zh: '输入关键字进行过滤',
@@ -103,6 +117,7 @@ export default {
     tr: 'Filtrelemek için anahtar kelimeyi girin',
     ja: 'フィルタリングするためにキーワードを入力してください',
     hu: 'Adja meg a kulcsszót a szűréshez',
+    ko: '필터링할 키워드를 입력해 주세요',
   },
   expendAll: {
     zh: '全部展开',
@@ -110,6 +125,7 @@ export default {
     tr: 'Tümünü Genişlet',
     ja: 'すべて展開',
     hu: 'Összes kibontás',
+    ko: '모두 펼치기',
   },
   collapseAll: {
     zh: '全部折叠',
@@ -117,6 +133,7 @@ export default {
     tr: 'Tümünü Kapat',
     ja: 'すべて折りたたむ',
     hu: 'Összes összecsukás',
+    ko: '모두 접기',
   },
   selectedTopicInfo: {
     zh: '选择主题以查看详情',
@@ -129,6 +146,7 @@ export default {
     tr: 'Konu Ağacını Temizle',
     ja: 'トピックツリーをクリア',
     hu: 'Témafa törlése',
+    ko: '토픽 트리 지우기',
   },
   clearTopicTreeConfirm: {
     zh: '确定清除主题树吗？',
@@ -136,6 +154,7 @@ export default {
     tr: 'Konu ağacını temizlemek istediğinizden emin misiniz?',
     ja: 'トピックツリーをクリアしてもよろしいですか？',
     hu: 'Témafa törlése megerősítésre kerül?',
+    ko: '토픽 트리를 지우시겠습니까?',
   },
   clearTopicTreeSuccess: {
     zh: '成功清除主题树',
@@ -143,6 +162,7 @@ export default {
     tr: 'Konu ağacı başarıyla temizlendi',
     ja: 'トピックツリーが正常にクリアされました',
     hu: 'Témafa sikeresen törlésre került',
+    ko: '토픽 트리를 성공적으로 지웠습니다',
   },
   clearTopicTreeNotEffectConnList: {
     zh: '清除主题树不会影响连接列表的数据',
@@ -150,6 +170,7 @@ export default {
     tr: 'Konu ağacını temizlemek, bağlantı listesi verilerini etkilemez',
     ja: 'トピックツリーをクリアしても接続リストのデータには影響しません',
     hu: 'Témafa törlése nem befolyásolja a kapcsolatlista adatainak',
+    ko: '토픽 트리를 지워도 연결 목록 데이터에는 영향을 주지 않습니다',
   },
   noPayloadFromTopicNode: {
     zh: '该主题节点的最新消息不可用或已从数据库中删除',
@@ -157,6 +178,7 @@ export default {
     tr: 'Bu konu düğümü için en son mesaj mevcut değil veya veritabanından kaldırılmış',
     ja: 'このトピックノードの最新メッセージは利用できないか、データベースから削除されています',
     hu: 'A témacsomópont legfrissebb üzenete nem elérhető vagy eltávolításra került a adatbázisból',
+    ko: '이 토픽 노드의 최신 메시지를 사용할 수 없거나 데이터베이스에서 삭제되었습니다',
   },
   visualizeTree: {
     zh: '可视化主题树',
@@ -164,6 +186,7 @@ export default {
     tr: 'Konu Ağacını Görselleştir',
     ja: 'トピックツリーを視覚化',
     hu: 'Témafa vizualizálása',
+    ko: '토픽 트리 시각화',
   },
   visualizeJsonTree: {
     zh: '可视化 JSON 树',
@@ -171,6 +194,7 @@ export default {
     tr: 'JSON Ağacını Görselleştir',
     ja: 'JSON ツリーを視覚化',
     hu: 'JSON fa vizualizálása',
+    ko: 'JSON 트리 시각화',
   },
   visualize: {
     zh: '可视化',
@@ -178,6 +202,7 @@ export default {
     tr: 'Görselleştir',
     ja: '視覚化',
     hu: 'Vizualizálás',
+    ko: '시각화',
   },
   visualizeTreeTooltip: {
     zh: '选择根节点并设置展开层级来可视化主题树。点击节点可展开或折叠子主题。',
@@ -185,6 +210,7 @@ export default {
     tr: 'Konu ağacını görselleştirmek için bir kök düğüm seçin ve genişletme seviyesini ayarlayın. Alt konuları genişletmek veya daraltmak için düğümlere tıklayın.',
     ja: 'ルートノードを選択し、展開レベルを設定してトピックツリーを視覚化します。ノードをクリックしてサブトピックを展開または折りたたみます。',
     hu: 'Válasszon egy gyökércsomópontot és állítsa be a kibontási szintet a témafa vizualizálásához. Kattintson a csomópontokra az altémák kibontásához vagy összecsukásához.',
+    ko: '루트 노드를 선택하고 펼침 레벨을 설정하여 토픽 트리를 시각화하세요. 노드를 클릭하면 하위 토픽을 펼치거나 접을 수 있습니다.',
   },
   visualizeJsonTreeTooltip: {
     zh: '设置展开层级以可视化 JSON 树。点击节点可展开或折叠子树。右键点击可复制子树为 JSON。',
@@ -192,6 +218,7 @@ export default {
     tr: 'JSON ağacını görselleştirmek için genişletme seviyesini ayarlayın. Alt ağaçları genişletmek veya daraltmak için düğümlere tıklayın. Alt ağacı JSON olarak kopyalamak için sağ tıklayın.',
     ja: '展開レベルを設定して JSON ツリーを視覚化します。ノードをクリックしてサブツリーを展開または折りたたみます。右クリックでサブツリーをJSONとしてコピーします。',
     hu: 'Állítsa be a kibontási szintet a JSON fa vizualizálásához. Kattintson a csomópontokra az alfa kibontásához vagy összecsukásához. Jobb kattintással másolja az alfát JSON-ként.',
+    ko: '펼침 레벨을 설정하여 JSON 트리를 시각화하세요. 노드를 클릭하면 하위 트리를 펼치거나 접을 수 있습니다. 마우스 오른쪽 버튼을 클릭하면 하위 트리를 JSON으로 복사합니다.',
   },
   trafficMonitor: {
     zh: '流量监控',
@@ -199,6 +226,7 @@ export default {
     tr: 'Trafik İzleme',
     ja: 'トラフィックモニター',
     hu: 'Forgalom figyelés',
+    ko: '트래픽 모니터',
   },
   brokerTrafficMonitorTooltip: {
     zh: '监控所选连接的 Broker 流量数据（收发总量和速率）。数据基于系统主题采样，可能存在一定误差。可选择自定义时间范围查看，默认显示近 24 小时数据。',
@@ -206,6 +234,7 @@ export default {
     ja: '選択した接続の Broker トラフィックデータ（総量とレート）を監視します。システムトピックからサンプリングされたデータで、多少の誤差が生じる可能性があります。カスタム時間範囲を選択可能、デフォルトは過去24時間です。',
     tr: 'Seçilen bağlantının Broker trafik verilerini (toplam ve hız) izleyin. Sistem konularından örneklenen veriler bazı sapmalar gösterebilir. Özelleştirilebilir zaman aralığı, varsayılan son 24 saat.',
     hu: 'A kiválasztott kapcsolat Broker forgalmi adatainak (összes és sebesség) figyelése. Rendszertémákból mintavételezett adatok, némi eltérés lehetséges. Testreszabható időtartam, alapértelmezetten az utolsó 24 óra.',
+    ko: '선택한 연결의 브로커 트래픽 데이터(총량 및 속도)를 모니터링합니다. 데이터는 시스템 토픽에서 샘플링되며 다소 오차가 있을 수 있습니다. 사용자 지정 시간 범위를 선택할 수 있으며 기본값은 최근 24시간입니다.',
   },
   accumulatedReceivedTraffic: {
     zh: '累计接收流量',
@@ -213,6 +242,7 @@ export default {
     tr: 'Toplam Alınan',
     ja: '累計受信トラフィック',
     hu: 'Összesített Fogadott',
+    ko: '누적 수신량',
   },
   accumulatedSentTraffic: {
     zh: '累计发送流量',
@@ -220,6 +250,7 @@ export default {
     tr: 'Toplam Gönderilen',
     ja: '累計送信トラフィック',
     hu: 'Összesített Küldött',
+    ko: '누적 송신량',
   },
   receivedTrafficRate: {
     zh: '接收流量速率',
@@ -227,6 +258,7 @@ export default {
     tr: 'Alınan Hız',
     ja: '受信速度',
     hu: 'Fogadott sebesség',
+    ko: '수신 속도',
   },
   sentTrafficRate: {
     zh: '发送流量速率',
@@ -234,6 +266,7 @@ export default {
     tr: 'Gönderilen Hız',
     ja: '送信速度',
     hu: 'Küldött sebesség',
+    ko: '송신 속도',
   },
   current: {
     zh: '当前',
@@ -241,6 +274,7 @@ export default {
     tr: 'Şu an ',
     ja: '現在',
     hu: 'Jelenlegi ',
+    ko: '현재 ',
   },
   syncConnection: {
     zh: '同步连接数据',
@@ -248,6 +282,7 @@ export default {
     tr: 'Bağlantı Verilerini Senkronize Et',
     ja: '接続データを同期',
     hu: 'Kapcsolat adatainak szinkronizálása',
+    ko: '연결 데이터 동기화',
   },
   syncConnectionTitle: {
     zh: '同步连接主题树',
@@ -255,6 +290,7 @@ export default {
     tr: 'Bağlantı Konu Ağacını Senkronize Et',
     ja: '接続トピックツリーを同期',
     hu: 'Kapcsolat Témafa Szinkronizálása',
+    ko: '연결 토픽 트리 동기화',
   },
   syncConnectionToTopicTreeSuccess: {
     zh: '连接 {connectionName} 同步到主题树成功',
@@ -262,6 +298,7 @@ export default {
     tr: 'Bağlantı {connectionName} konu ağacına senkronize edildi',
     ja: '接続 {connectionName} をトピックツリーに同期成功',
     hu: 'Kapcsolat {connectionName} sikeresen szinkronizálva a téma fával',
+    ko: '연결 {connectionName}을(를) 토픽 트리에 동기화했습니다',
   },
   syncConnectionToTopicTreeFailed: {
     zh: '同步连接 {connectionId} 到主题树失败',
@@ -269,6 +306,7 @@ export default {
     tr: 'Bağlantı {connectionId} konu ağacına senkronize edilemedi',
     ja: '接続 {connectionId} をトピックツリーに同期できませんでした',
     hu: 'Nem sikerült szinkronizálni a {connectionId} kapcsolatot a téma fával',
+    ko: '연결 {connectionId}을(를) 토픽 트리에 동기화하지 못했습니다',
   },
   syncTakeLongTime: {
     zh: '数据同步中，请耐心等待...',
@@ -276,6 +314,7 @@ export default {
     tr: 'Veri senkronize ediliyor, lütfen bekleyin...',
     ja: 'データを同期中、お待ちください...',
     hu: 'Adatok szinkronizálása folyamatban, kérjük várjon...',
+    ko: '데이터 동기화 중입니다. 잠시만 기다려 주세요...',
   },
   syncConnectionToTopicTreeTips: {
     zh: '将当前连接的主题消息转换为主题树结构视图',
@@ -283,6 +322,7 @@ export default {
     tr: 'Geçerli bağlantı mesaj listesini konu ağacı yapısı görünümüne dönüştür',
     ja: '現在の接続メッセージリストをトピックツリー構造のビューに変換',
     hu: 'Az aktuális kapcsolat üzenetlistájának átalakítása témafa struktúra nézetté',
+    ko: '현재 연결의 토픽 메시지를 토픽 트리 구조 보기로 변환합니다',
   },
   messageHistory: {
     zh: '消息历史',
@@ -290,6 +330,7 @@ export default {
     tr: 'Mesaj Geçmişi',
     ja: 'メッセージ履歴',
     hu: 'Üzenet történet',
+    ko: '메시지 기록',
   },
   messageJsonViewer: {
     zh: '消息 JSON 查看器',
@@ -297,6 +338,7 @@ export default {
     tr: 'Mesaj JSON Görüntüleyici',
     ja: 'メッセージ JSON ビューア',
     hu: 'Üzenet JSON Megjelenítő',
+    ko: '메시지 JSON 뷰어',
   },
   previous: {
     zh: '上一个',
@@ -304,6 +346,7 @@ export default {
     tr: 'Önceki',
     ja: '前',
     hu: 'Előző',
+    ko: '이전',
   },
   currentLabel: {
     zh: '当前',
@@ -311,6 +354,7 @@ export default {
     tr: 'Mevcut',
     ja: '現在',
     hu: 'Jelenlegi',
+    ko: '현재',
   },
   yes: {
     zh: '是',
@@ -318,6 +362,7 @@ export default {
     tr: 'Evet',
     ja: 'はい',
     hu: 'Igen',
+    ko: '예',
   },
   no: {
     zh: '否',
@@ -325,6 +370,7 @@ export default {
     tr: 'Hayır',
     ja: 'いいえ',
     hu: 'Nem',
+    ko: '아니오',
   },
   olderMessage: {
     zh: '更早的消息',
@@ -332,6 +378,7 @@ export default {
     tr: 'Eski mesaj',
     ja: '古いメッセージ',
     hu: 'Régi üzenet',
+    ko: '더 오래된 메시지',
   },
   newerMessage: {
     zh: '更新的消息',
@@ -339,6 +386,7 @@ export default {
     tr: 'Yeni mesaj',
     ja: '新しいメッセージ',
     hu: 'Új üzenet',
+    ko: '더 새로운 메시지',
   },
   goToLatestMessage: {
     zh: '跳转到最新消息',
@@ -346,6 +394,7 @@ export default {
     tr: 'En son mesaja git',
     ja: '最新メッセージに移動',
     hu: 'Ugrás a legújabb üzenethez',
+    ko: '최신 메시지로 이동',
   },
   selectTopicWithMessages: {
     zh: '选择至少包含 2 条消息的主题以查看差异',
@@ -353,6 +402,7 @@ export default {
     tr: 'Farkları görüntülemek için en az 2 mesaj içeren bir konu seçin',
     ja: '差分を表示するには、少なくとも2つのメッセージを含むトピックを選択してください',
     hu: 'Válasszon ki egy témát legalább 2 üzenettel a különbségek megtekintéséhez',
+    ko: '차이를 보려면 메시지가 2개 이상인 토픽을 선택해 주세요',
   },
   failedToLoadMessages: {
     zh: '加载消息失败',
@@ -360,6 +410,7 @@ export default {
     tr: 'Mesajlar yüklenemedi',
     ja: 'メッセージの読み込みに失敗しました',
     hu: 'Nem sikerült betölteni az üzeneteket',
+    ko: '메시지를 불러오지 못했습니다',
   },
   general: {
     zh: '常规',
@@ -367,6 +418,7 @@ export default {
     tr: 'Genel',
     ja: '一般',
     hu: 'Általános',
+    ko: '일반',
   },
   preview: {
     zh: '预览',
@@ -374,6 +426,7 @@ export default {
     tr: 'Önizleme',
     ja: 'プレビュー',
     hu: 'Előnézet',
+    ko: '미리보기',
   },
   dataSource: {
     zh: '数据源',
@@ -381,6 +434,7 @@ export default {
     tr: 'Veri Kaynağı',
     ja: 'データソース',
     hu: 'Adatforrás',
+    ko: '데이터 소스',
   },
   connection: {
     zh: '连接',
@@ -388,6 +442,7 @@ export default {
     tr: 'Bağlantı',
     ja: '接続',
     hu: 'Kapcsolat',
+    ko: '연결',
   },
   topicPattern: {
     zh: '主题模式',
@@ -395,6 +450,7 @@ export default {
     tr: 'Konu Deseni',
     ja: 'トピックパターン',
     hu: 'Téma minta',
+    ko: '토픽 패턴',
   },
   valueField: {
     zh: '字段',
@@ -402,6 +458,7 @@ export default {
     tr: 'Değer Alanı',
     ja: '値フィールド',
     hu: 'Érték mező',
+    ko: '값 필드',
   },
   messageName: {
     zh: '消息名称',
@@ -409,6 +466,7 @@ export default {
     tr: 'Mesaj Adı',
     ja: 'メッセージ名',
     hu: 'Üzenet név',
+    ko: '메시지 이름',
   },
   fallbackValue: {
     zh: '回退值',
@@ -416,6 +474,7 @@ export default {
     tr: 'Yedek Değer',
     ja: 'フォールバック値',
     hu: 'Tartalék érték',
+    ko: '대체 값',
   },
   color: {
     zh: '颜色',
@@ -423,6 +482,7 @@ export default {
     tr: 'Renk',
     ja: '色',
     hu: 'Szín',
+    ko: '색상',
   },
   smoothLines: {
     zh: '平滑线条',
@@ -430,6 +490,7 @@ export default {
     tr: 'Düz Çizgiler',
     ja: 'スムーズライン',
     hu: 'Sima vonalak',
+    ko: '부드러운 선',
   },
   areaFill: {
     zh: '区域填充',
@@ -437,6 +498,7 @@ export default {
     tr: 'Alan Doldurma',
     ja: 'エリア塗りつぶし',
     hu: 'Terület kitöltés',
+    ko: '영역 채우기',
   },
   min: {
     zh: '最小值',
@@ -444,6 +506,7 @@ export default {
     tr: 'Min',
     ja: '最小',
     hu: 'Min',
+    ko: '최소',
   },
   max: {
     zh: '最大值',
@@ -451,6 +514,7 @@ export default {
     tr: 'Max',
     ja: '最大',
     hu: 'Max',
+    ko: '최대',
   },
   decimals: {
     zh: '小数位数',
@@ -458,6 +522,7 @@ export default {
     tr: 'Ondalık',
     ja: '小数点',
     hu: 'Tizedesjegyek',
+    ko: '소수점 자릿수',
   },
   unit: {
     zh: '单位',
@@ -465,6 +530,7 @@ export default {
     tr: 'Birim',
     ja: '単位',
     hu: 'Egység',
+    ko: '단위',
   },
   type: {
     zh: '类型',
@@ -472,6 +538,7 @@ export default {
     tr: 'Tür',
     ja: 'タイプ',
     hu: 'Típus',
+    ko: '유형',
   },
   title: {
     zh: '标题',
@@ -479,6 +546,7 @@ export default {
     tr: 'Başlık',
     ja: 'タイトル',
     hu: 'Cím',
+    ko: '제목',
   },
   options: {
     zh: '选项',
@@ -486,6 +554,7 @@ export default {
     tr: 'Seçenekler',
     ja: 'オプション',
     hu: 'Beállítások',
+    ko: '옵션',
   },
   description: {
     zh: '描述',
@@ -493,6 +562,7 @@ export default {
     tr: 'Açıklama',
     ja: '説明',
     hu: 'Leírás',
+    ko: '설명',
   },
   noDashboards: {
     zh: '无仪表盘',
@@ -500,6 +570,7 @@ export default {
     tr: 'Gösterge Paneli Yok',
     ja: 'ダッシュボードなし',
     hu: 'Nincs irányítópult',
+    ko: '대시보드 없음',
   },
   createDashboardToGetStarted: {
     zh: '创建新仪表盘开始使用',
@@ -507,6 +578,7 @@ export default {
     tr: 'Başlamak için yeni bir gösterge paneli oluşturun',
     ja: '新しいダッシュボードを作成して開始',
     hu: 'Hozzon létre egy új irányítópultot a kezdéshez',
+    ko: '시작하려면 새 대시보드를 생성하세요',
   },
   confirmLeaveEditing: {
     zh: '放弃当前编辑并切换仪表盘？',
@@ -514,6 +586,7 @@ export default {
     tr: 'Mevcut düzenlemeleri iptal et ve gösterge paneline geç?',
     ja: '現在の編集を破棄してダッシュボードを切り替えますか？',
     hu: 'Elveti a jelenlegi szerkesztéseket és vált az irányítópultra?',
+    ko: '현재 편집 내용을 취소하고 대시보드를 전환하시겠습니까?',
   },
   inputValidationFailed: {
     zh: '请检查必填字段',
@@ -521,6 +594,7 @@ export default {
     tr: 'Lütfen gerekli alanları kontrol edin',
     ja: '必須フィールドを確認してください',
     hu: 'Kérjük ellenőrizze a kötelező mezőket',
+    ko: '필수 항목을 확인해 주세요',
   },
   noDashboardSelected: {
     zh: '未选择仪表盘',
@@ -528,6 +602,7 @@ export default {
     tr: 'Gösterge paneli seçilmedi',
     ja: 'ダッシュボードが選択されていません',
     hu: 'Nincs irányítópult kiválasztva',
+    ko: '선택된 대시보드가 없습니다',
   },
   widgetTypeRequired: {
     zh: '需要小部件类型',
@@ -535,6 +610,7 @@ export default {
     tr: 'Widget türü gerekli',
     ja: 'ウィジェットタイプが必要です',
     hu: 'Widget típus szükséges',
+    ko: '위젯 유형은 필수입니다',
   },
   unknownWidgetType: {
     zh: '未知的小部件类型',
@@ -542,6 +618,7 @@ export default {
     tr: 'Bilinmeyen widget türü',
     ja: '不明なウィジェットタイプ',
     hu: 'Ismeretlen widget típus',
+    ko: '알 수 없는 위젯 유형',
   },
   fallbackValueTip: {
     zh: '当没有数据时，显示的值',
@@ -549,6 +626,7 @@ export default {
     tr: 'Veri yokken gösterilecek değer',
     ja: 'データがない場合に表示される値',
     hu: 'Az adatok esetén megjelenített érték',
+    ko: '데이터가 없을 때 표시되는 값',
   },
   connectionRequired: {
     zh: '需要连接',
@@ -556,6 +634,7 @@ export default {
     tr: 'Bağlantı gerekli',
     ja: '接続が必要です',
     hu: 'Kapcsolat szükséges',
+    ko: '연결은 필수입니다',
   },
   topicPatternRequired: {
     zh: '需要主题模式',
@@ -563,6 +642,7 @@ export default {
     tr: 'Konu deseni gerekli',
     ja: 'トピックパターンが必要です',
     hu: 'Téma minta szükséges',
+    ko: '토픽 패턴은 필수입니다',
   },
   failedToSaveTimeRangeSettings: {
     zh: '保存时间范围设置失败',
@@ -570,6 +650,7 @@ export default {
     tr: 'Zaman aralığı ayarları kaydedilemedi',
     ja: '時間範囲設定の保存に失敗しました',
     hu: 'Nem sikerült menteni az időtartam beállításokat',
+    ko: '시간 범위 설정을 저장하지 못했습니다',
   },
   failedToSaveDashboardOrder: {
     zh: '保存仪表盘顺序失败',
@@ -577,5 +658,6 @@ export default {
     tr: 'Gösterge paneli sırası kaydedilemedi',
     ja: 'ダッシュボードの順序の保存に失敗しました',
     hu: 'Nem sikerült menteni az irányítópult sorrendet',
+    ko: '대시보드 순서를 저장하지 못했습니다',
   },
 }

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -8,7 +8,7 @@ declare global {
 
   type Theme = 'light' | 'dark' | 'night'
 
-  type Language = 'zh' | 'en' | 'ja' | 'tr' | 'hu'
+  type Language = 'zh' | 'en' | 'ja' | 'tr' | 'hu' | 'ko'
 
   type Protocol = 'ws' | 'wss' | 'mqtt' | 'mqtts'
 

--- a/src/types/locale.d.ts
+++ b/src/types/locale.d.ts
@@ -5,6 +5,7 @@ declare module 'element-ui/lib/locale/lang/zh-CN' {}
 declare module 'element-ui/lib/locale/lang/ja' {}
 declare module 'element-ui/lib/locale/lang/tr-TR' {}
 declare module 'element-ui/lib/locale/lang/hu' {}
+declare module 'element-ui/lib/locale/lang/ko' {}
 
 type i18nLocaleModel = [
   'connections',
@@ -18,7 +19,7 @@ type i18nLocaleModel = [
   'viewer',
   'copilot',
 ]
-type SupportLangModel = ['zh', 'en', 'ja', 'tr', 'hu']
+type SupportLangModel = ['zh', 'en', 'ja', 'tr', 'hu', 'ko']
 
 declare module '*.json' {
   const value: any

--- a/src/utils/ai/copilot.ts
+++ b/src/utils/ai/copilot.ts
@@ -36,6 +36,7 @@ export const LANGUAGE_MAP = {
   tr: 'Lütfen Türkçe cevap verin（Turkish）',
   ja: '日本語で回答してください（Japanese）',
   hu: 'Kérjük, magyarul válaszoljon（Hungarian）',
+  ko: '한국어로 답변해 주세요（Korean）',
 }
 
 export const loadSystemPrompt = (lang: Language, command?: string, mcpData?: MCPPromptData) => {

--- a/src/views/settings/index.vue
+++ b/src/views/settings/index.vue
@@ -577,6 +577,7 @@ export default class Settings extends Vue {
     { label: '日本語', value: 'ja' },
     { label: 'Türkçe', value: 'tr' },
     { label: 'Magyar', value: 'hu' },
+    { label: '한국어', value: 'ko' },
   ]
   private themeOptions: Options[] = [
     { label: 'Light', value: 'light' },


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

MQTTX desktop currently supports 5 UI languages: Simplified Chinese, English,
Japanese, Turkish, and Hungarian. Korean is not available.

#### Issue Number

None

#### What is the new behavior?

Korean (한국어) is available as a UI language, selectable in
Settings → Language.

- Korean translations for all 528 UI strings across the 11 locale modules
  (about, common, connections, copilot, help, log, menu, script, settings,
  update, viewer)
- Locale registration: `Language` / `SupportLangModel` types, `lang/index.ts`
  (incl. element-ui `ko` locale), Settings language selector, and Copilot
  `LANGUAGE_MAP`
- Database: a new `koLang` migration widens the `currentLang` CHECK
  constraint, and the `SettingEntity` enum now includes `ko` — same approach
  as the `huLang` migration

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The migration is additive (widens the allowed language set) and preserves all
existing data; `down()` safely remaps `ko` to `en` before restoring the
previous constraint.

#### Specific Instructions

- Migration verified with `yarn run db:migration:run` and
  `yarn run db:migration:revert` (both up and down paths tested).
- Locale key parity checked: every entry with `hu` has a matching `ko`
  (528/528) across all 11 locale files.
- Desktop app only; `web/` locales are not included in this PR.

#### Other information

- Follows the same pattern as previous language additions: Turkish (#626) and
  Hungarian (#761).
- macOS app menu items follow Apple's official Korean terminology
  (Edit > 말하기 > 말하기 시작 / 말하기 중단).
- MQTT domain terms are translated consistently (retained message → 유지 메시지,
  topic → 토픽, payload → 페이로드; MQTT/QoS/TLS/WebSocket kept as-is).
