### PR TITLE
fix(copilot): add missing mcpConnectionFailed i18n key

### DIFF
--- a/src/lang/copilot.ts
+++ b/src/lang/copilot.ts
@@ -609,6 +609,14 @@ export default {
     ja: 'サーバー接続に失敗しました',
     hu: 'A(z) szerver csatlakoztatása sikertelen',
   },
+  mcpConnectionFailed: {
+    zh: '连接 MCP 服务器 {0} 失败',
+    en: 'Failed to connect to MCP server {0}',
+    tr: '{0} MCP sunucusuna bağlanılamadı',
+    ja: 'MCPサーバー {0} への接続に失敗しました',
+    hu: 'Nem sikerült csatlakozni a(z) {0} MCP szerverhez',
+    ko: 'MCP 서버 {0} 연결에 실패했습니다',
+  },
   mcpCalling: {
     zh: 'MCP 调用',
     en: 'MCP Calling',


### PR DESCRIPTION
### PR Checklist

#### What is the current behavior?

`MCPSettings.vue` references the i18n key `copilot.mcpConnectionFailed` when an
MCP server connection test throws:

```ts
message: `${this.$t('copilot.mcpConnectionFailed', [serverName]).toString()}: ${...}`
```

However, this key is not defined in `src/lang/copilot.ts` (or anywhere else),
so the error toast renders the raw key path instead of a translated message:

```
copilot.mcpConnectionFailed: connect ECONNREFUSED ...
```

The reference was introduced in 2cf37bf2 (`feat(copilot): localize MCPSettings
UI with i18n support`) together with the other `mcp*` keys, but the definition
for this one key was missed.

#### Issue Number

None

#### What is the new behavior?

`mcpConnectionFailed` is defined in `src/lang/copilot.ts`, placed right after
`mcpServerTestFailed`, using the same `{0}` list-interpolation style as the
existing keys. The error toast now shows a proper localized message, e.g.:

```
Failed to connect to MCP server filesystem: connect ECONNREFUSED ...
```

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Purely additive: one new i18n key, no code changes.

#### Specific Instructions

The entry includes a `ko` translation for consistency with #2056 (pending).
Until Korean is registered in `supportLang`, the `ko` value is inert —
`formati18n` only reads languages present in `supportLang` — so this PR is
safe to merge independently of and in either order with #2056.

#### Other information

None
