### PR TITLE
fix(security): escape MQTT topic and payload rendering to prevent XSS

### DIFF
--- a/src/components/MsgLeftItem.vue
+++ b/src/components/MsgLeftItem.vue
@@ -68,7 +68,7 @@ import Prism from 'prismjs'
 import { Getter } from 'vuex-class'
 import { SHOW_MAX_LENGTH } from '@/utils/data'
 import MqttProperties from './MqttProperties.vue'
-import { highlightSearchTerm, highlightInPrismCode } from '@/utils/highlightSearch'
+import { highlightSearchTerm, highlightInPrismCode, escapeHtml } from '@/utils/highlightSearch'
 
 @Component({
   components: {
@@ -109,7 +109,7 @@ export default class MsgLeftItem extends Vue {
     if (this.searchParams.topic) {
       return highlightSearchTerm(this.topic, this.searchParams.topic, 'search-highlight')
     }
-    return this.topic
+    return escapeHtml(this.topic)
   }
 
   get highlightedPayload(): string {
@@ -124,7 +124,7 @@ export default class MsgLeftItem extends Vue {
     if (this.searchParams.payload) {
       return highlightSearchTerm(preview, this.searchParams.payload, 'search-highlight')
     }
-    return preview
+    return escapeHtml(preview)
   }
 
   public customMenu(event: MouseEvent) {

--- a/src/components/MsgRightItem.vue
+++ b/src/components/MsgRightItem.vue
@@ -30,7 +30,7 @@
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator'
 import MqttProperties from './MqttProperties.vue'
-import { highlightSearchTerm } from '@/utils/highlightSearch'
+import { highlightSearchTerm, escapeHtml } from '@/utils/highlightSearch'
 
 @Component({
   components: {
@@ -53,7 +53,7 @@ export default class MsgRightItem extends Vue {
     if (this.searchParams.topic) {
       return highlightSearchTerm(this.topic, this.searchParams.topic, 'search-highlight')
     }
-    return this.topic
+    return escapeHtml(this.topic)
   }
 
   get highlightedPayload(): string {

--- a/src/utils/highlightSearch.ts
+++ b/src/utils/highlightSearch.ts
@@ -63,7 +63,12 @@ export function highlightInPrismCode(
   })
 }
 
-function escapeHtml(text: string): string {
+/**
+ * Escapes HTML special characters so the value is safe to insert via v-html
+ * @param text - The raw text
+ * @returns HTML-escaped string
+ */
+export function escapeHtml(text: string): string {
   const div = document.createElement('div')
   div.textContent = text
   return div.innerHTML

--- a/src/widgets/TreeNodeInfo.vue
+++ b/src/widgets/TreeNodeInfo.vue
@@ -70,6 +70,7 @@ import { findSubTopics, findFullTopicPath, isPayloadEmpty } from '@/utils/topicT
 import Prism from 'prismjs'
 import { jsonStringify, jsonParse } from '@/utils/jsonUtils'
 import { isXML, escapeXmlForHtml } from '@/utils/xmlUtils'
+import { escapeHtml } from '@/utils/highlightSearch'
 import MqttProperties from '@/components/MqttProperties.vue'
 
 @Component({
@@ -90,13 +91,13 @@ export default class TreeNodeInfo extends Vue {
   get latestMessage(): string {
     const payload = this.node.message?.payload || ''
     if (this.payloadFormat === 'json') {
-      return jsonStringify(jsonParse(payload.toString()), null, 2)
+      return escapeHtml(jsonStringify(jsonParse(payload.toString()), null, 2))
     }
     if (this.payloadFormat === 'xml') {
       // Escape HTML entities for XML content
       return escapeXmlForHtml(payload.toString())
     }
-    return payload.toString()
+    return escapeHtml(payload.toString())
   }
 
   get payloadFormat(): string {

--- a/tests/unit/utils/highlightSearch.spec.ts
+++ b/tests/unit/utils/highlightSearch.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai'
+import { escapeHtml, highlightSearchTerm } from '@/utils/highlightSearch'
+
+describe('highlightSearch', () => {
+  describe('escapeHtml', () => {
+    it('should escape HTML tags in MQTT topic names', () => {
+      const maliciousTopic = `poc/<img src=x onerror="alert('xss')">`
+      const result = escapeHtml(maliciousTopic)
+      expect(result).to.not.include('<img')
+      expect(result).to.include('&lt;img')
+    })
+
+    it('should escape ampersands, quotes and angle brackets', () => {
+      expect(escapeHtml(`a & b <c> "d"`)).to.equal('a &amp; b &lt;c&gt; "d"')
+    })
+
+    it('should leave normal topic names untouched', () => {
+      expect(escapeHtml('sensor/+/temperature')).to.equal('sensor/+/temperature')
+    })
+
+    it('should handle empty string', () => {
+      expect(escapeHtml('')).to.equal('')
+    })
+  })
+
+  describe('highlightSearchTerm', () => {
+    it('should escape HTML in text when highlighting', () => {
+      const text = `poc/<img src=x onerror="alert('xss')">`
+      const result = highlightSearchTerm(text, 'img', 'search-highlight')
+      expect(result).to.not.include('<img')
+      expect(result).to.include('&lt;')
+      expect(result).to.include('<span class="search-highlight">img</span>')
+    })
+
+    it('should escape HTML in the matched search term itself', () => {
+      const result = highlightSearchTerm('a<script>b</script>c', '<script>', 'search-highlight')
+      expect(result).to.not.include('<script>')
+      expect(result).to.include('<span class="search-highlight">&lt;script&gt;</span>')
+    })
+
+    it('should return the original text when search term is empty', () => {
+      expect(highlightSearchTerm('topic/name', '', 'search-highlight')).to.equal('topic/name')
+    })
+
+    it('should highlight normal search terms', () => {
+      const result = highlightSearchTerm('sensor/temperature', 'temp', 'search-highlight')
+      expect(result).to.equal('sensor/<span class="search-highlight">temp</span>erature')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Reported to security@emqx.io by an external security researcher: received MQTT messages render their topic through `v-html` without escaping when no search term is active. A publisher able to send messages to a broker can inject HTML event handlers into the topic name, which then execute in the renderer of any connected client subscribed to a matching topic filter. Because the desktop renderer runs with `nodeIntegration: true` and `contextIsolation: false`, this XSS can be escalated to OS command execution with the privileges of the user running MQTTX.

## Changes

- `MsgLeftItem.vue` / `MsgRightItem.vue`: escape `highlightedTopic` when no search term is active (the search-highlighting path was already escaped via `highlightSearchTerm`)
- `MsgLeftItem.vue`: escape the large-message payload preview (`highlightedPayloadPreview`)
- `TreeNodeInfo.vue`: escape payload in the topic tree info panel for JSON and plaintext formats (XML was already escaped)
- `highlightSearch.ts`: export the shared `escapeHtml` helper
- Add unit tests for `escapeHtml` and `highlightSearchTerm` escaping behavior

## Verification

- 329 unit tests passing, including 8 new escaping tests
- The `yarn build` (web bundle) failure caused by vm2 requiring Node built-ins is pre-existing and unrelated — reproduced on a clean tree

## Follow-up (out of scope for this hotfix)

- Renderer hardening: `contextIsolation: true` + preload bridge, disable `nodeIntegration`, re-enable `webSecurity`
- Evaluate a CVE and reply to the reporter after the v1.13.1 hotfix release