### PR TITLE
feat(connections): allow deleting and managing subscriptions when disconnected

### DIFF
--- a/src/components/SubscriptionsList.vue
+++ b/src/components/SubscriptionsList.vue
@@ -268,7 +268,7 @@ export default class SubscriptionsList extends Vue {
   private client: Partial<MqttClient> = {
     connected: false,
   }
-  public showDialog: boolean = false
+  public showDialog = false
   private subRecord: SubscriptionModel = {
     id: getSubscriptionId(),
     topic: 'testtopic/#',
@@ -376,16 +376,6 @@ export default class SubscriptionsList extends Vue {
   }
 
   private openDialog() {
-    if (!this.client || !this.client.connected) {
-      this.$notify({
-        title: this.$tc('connections.notConnect'),
-        message: '',
-        type: 'error',
-        duration: 3000,
-        offset: 30,
-      })
-      return false
-    }
     this.resetSubs()
     this.setColor()
     this.setNewSubscribeId()
@@ -405,6 +395,22 @@ export default class SubscriptionsList extends Vue {
       this.subLoading = true
       this.subRecord.color = this.topicColor || this.getBorderColor()
       if (!this.isEdit) {
+        if (!this.client || !this.client.connected) {
+          const topicsArr = this.multiTopics
+            ? [...new Set(this.subRecord.topic.split(','))].filter(Boolean)
+            : this.subRecord.topic
+          const aliasArr = this.multiTopics ? this.subRecord.alias?.split(',') : this.subRecord.alias
+          if (!Array.isArray(topicsArr)) {
+            this.saveTopicToSubList(this.subRecord.topic, this.subRecord.qos, undefined, undefined, this.subRecord.id)
+          } else {
+            topicsArr.forEach((topic, index) => {
+              this.saveTopicToSubList(topic, this.subRecord.qos, index, aliasArr as string[], this.subRecord.id)
+            })
+          }
+          await this.syncSubscriptions(this.subsList, true)
+          this.subLoading = false
+          return
+        }
         await this.subscribe(this.subRecord)
       } else {
         this.updateSub()
@@ -573,6 +579,11 @@ export default class SubscriptionsList extends Vue {
     }
     const selectedTopic = this.selectedTopic
     const disabled = this.subRecord.disabled
+    if (!this.client || !this.client.connected) {
+      const updatedSubs = this.subsList.map((sub) => (sub.id === selectedTopic.id ? { ...this.subRecord } : sub))
+      await this.syncSubscriptions(updatedSubs, true)
+      return
+    }
     const res = await this.unsubscribe({ ...selectedTopic, disabled }, disabled)
     if (!res) {
       return
@@ -586,51 +597,31 @@ export default class SubscriptionsList extends Vue {
   }
 
   private unsubscribe(row: SubscriptionModel, disable?: boolean): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (!this.client || !this.client.connected) {
-        this.$notify({
-          title: this.$tc('connections.notConnect'),
-          message: '',
-          type: 'error',
-          duration: 3000,
-          offset: 30,
-        })
-        resolve(false)
-        return false
+    return new Promise((resolve) => {
+      const { topic, qos, disabled } = row
+      const finalize = async () => {
+        if (!this.record.id) return resolve(false)
+        const subscriptions = disable
+          ? this.setSubsDisable(topic, disabled)
+          : this.subsList.filter((sub) => sub.topic !== topic)
+        await this.syncSubscriptions(subscriptions)
+        this.$emit('deleteTopic', topic)
+        this.$log.info(`${disable ? 'Disabled' : 'Removed'} topic: ${topic}`)
+        resolve(true)
+      }
+
+      if (!this.client || !this.client.connected || !this.client.unsubscribe) {
+        return finalize()
       }
       this.unsubLoading = true
-      const { topic, qos, disabled } = row
-      if (this.client.unsubscribe) {
-        this.client.unsubscribe(topic, { qos }, async (error) => {
-          this.unsubLoading = false
-          if (error) {
-            this.$emit('onSubError', error.toString(), `Topic: ${topic}`)
-            resolve(false)
-            return false
-          }
-          if (this.record.id) {
-            let payload: {
-              id: string
-              subscriptions: SubscriptionModel[]
-            } = {
-              id: this.record.id,
-              subscriptions: [],
-            }
-            if (disable) {
-              payload.subscriptions = this.setSubsDisable(topic, disabled)
-              this.$log.info(`Disabled topic: ${topic}`)
-            } else {
-              payload.subscriptions = this.subsList.filter((sub: SubscriptionModel) => sub.topic !== topic)
-              this.$log.info(`Removed topic: ${topic}`)
-            }
-            await this.syncSubscriptions(payload.subscriptions)
-            this.$emit('deleteTopic', topic)
-            this.$log.info(`Unsubscribe topic: ${topic}`)
-            resolve(true)
-            return true
-          }
-        })
-      }
+      this.client.unsubscribe(topic, { qos }, (error) => {
+        this.unsubLoading = false
+        if (error) {
+          this.$emit('onSubError', error.toString(), `Topic: ${topic}`)
+          return resolve(false)
+        }
+        finalize()
+      })
     })
   }
 
@@ -703,16 +694,6 @@ export default class SubscriptionsList extends Vue {
 
   private handleTopicEdit() {
     this.showContextmenu = false
-    if (!this.client || !this.client.connected) {
-      this.$notify({
-        title: this.$tc('connections.notConnect'),
-        message: '',
-        type: 'error',
-        duration: 3000,
-        offset: 30,
-      })
-      return
-    }
     this.isEdit = true
     this.showDialog = true
     this.setColor()
@@ -743,20 +724,15 @@ export default class SubscriptionsList extends Vue {
 
   private async setTopicDisabled(disable: boolean) {
     this.showContextmenu = false
-    if (!this.client || !this.client.connected) {
-      this.$notify({
-        title: this.$tc('connections.notConnect'),
-        message: '',
-        type: 'error',
-        duration: 3000,
-        offset: 30,
-      })
-      return
-    }
     if (!this.selectedTopic) {
       return
     }
     this.selectedTopic.disabled = disable
+    if (!this.client || !this.client.connected) {
+      const updatedSubs = this.setSubsDisable(this.selectedTopic.topic, disable)
+      await this.syncSubscriptions(updatedSubs)
+      return
+    }
     if (disable) {
       await this.unsubscribe(this.selectedTopic, true)
     } else {

--- a/web/src/components/SubscriptionsList.vue
+++ b/web/src/components/SubscriptionsList.vue
@@ -363,10 +363,6 @@ export default class SubscriptionsList extends Vue {
     this.getCurrentConnection(this.connectionId)
     this.subRecord.topic = this.subRecord.topic.replace(/[\r\n]+/g, '')
     this.subRecord.alias = this.subRecord.alias?.replace(/[\r\n]+/g, '') || ''
-    if (!this.client || !this.client.connected) {
-      this.$message.warning(this.$tc('connections.notConnect'))
-      return false
-    }
     this.subForm.validate(async (valid: boolean) => {
       if (!valid) {
         return false
@@ -374,6 +370,27 @@ export default class SubscriptionsList extends Vue {
       this.subLoading = true
       this.subRecord.color = this.topicColor || this.getBorderColor()
       if (!this.isEdit) {
+        if (!this.client || !this.client.connected) {
+          const topicsArr = this.multiTopics
+            ? [...new Set(this.subRecord.topic.split(','))].filter(Boolean)
+            : this.subRecord.topic
+          const aliasArr = this.multiTopics ? this.subRecord.alias?.split(',') : this.subRecord.alias
+          if (!Array.isArray(topicsArr)) {
+            this.saveTopicToSubList(this.subRecord.topic, this.subRecord.qos)
+          } else {
+            topicsArr.forEach((topic, index) => {
+              this.saveTopicToSubList(topic, this.subRecord.qos, index, aliasArr as string[])
+            })
+          }
+          this.record.subscriptions = this.subsList
+          if (this.record.id) {
+            updateConnection(this.record.id, this.record)
+            this.changeSubs({ id: this.connectionId, subscriptions: this.subsList })
+            this.showDialog = false
+          }
+          this.subLoading = false
+          return
+        }
         await this.subscribe(this.subRecord)
       } else {
         this.updateSub()
@@ -450,6 +467,10 @@ export default class SubscriptionsList extends Vue {
         properties = {
           subscriptionIdentifier,
         }
+      } else if (this.record.mqttVersion !== '5.0') {
+        nl = undefined
+        rap = undefined
+        rh = undefined
       }
       this.client.subscribe(topicsArr, { qos, nl, rap, rh, properties }, async (error, granted) => {
         this.subLoading = false
@@ -508,6 +529,17 @@ export default class SubscriptionsList extends Vue {
 
   private async updateSub() {
     if (this.selectedTopic) {
+      if (!this.client || !this.client.connected) {
+        this.subsList = this.subsList.map((sub) => (sub.id === this.selectedTopic!.id ? { ...this.subRecord } : sub))
+        this.record.subscriptions = this.subsList
+        if (this.record.id) {
+          updateConnection(this.record.id, this.record)
+          this.changeSubs({ id: this.connectionId, subscriptions: this.subsList })
+          this.showDialog = false
+        }
+        this.subLoading = false
+        return
+      }
       const res = await this.unsubscribe(this.selectedTopic)
       if (res) {
         this.subscribe(this.subRecord)
@@ -516,51 +548,33 @@ export default class SubscriptionsList extends Vue {
   }
 
   private unsubscribe(row: SubscriptionModel, disable?: boolean): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (!this.client || !this.client.connected) {
-        this.$notify({
-          title: this.$tc('connections.notConnect'),
-          message: '',
-          type: 'error',
-          duration: 3000,
-          offset: 30,
-        })
-        resolve(false)
-        return false
+    return new Promise((resolve) => {
+      const { topic, qos, disabled } = row
+      const finalize = () => {
+        if (!this.record.id) return resolve(false)
+        const subscriptions = disable
+          ? this.setSubsDisable(topic, disabled)
+          : this.subsList.filter((sub) => sub.topic !== topic)
+        this.record.subscriptions = subscriptions
+        updateConnection(this.record.id, this.record)
+        this.changeSubs({ id: this.record.id, subscriptions })
+        this.$emit('deleteTopic')
+        this.subsList = subscriptions
+        resolve(true)
+      }
+
+      if (!this.client || !this.client.connected || !this.client.unsubscribe) {
+        return finalize()
       }
       this.unsubLoading = true
-      const { topic, qos, disabled } = row
-      if (this.client.unsubscribe) {
-        this.client.unsubscribe(topic, { qos }, async (error) => {
-          this.unsubLoading = false
-          if (error) {
-            this.$message.error(error)
-            resolve(false)
-            return false
-          }
-          if (this.record.id) {
-            let payload: {
-              id: string
-              subscriptions: SubscriptionModel[]
-            } = {
-              id: this.record.id,
-              subscriptions: [],
-            }
-            if (disable) {
-              payload.subscriptions = this.setSubsDisable(topic, disabled)
-            } else {
-              payload.subscriptions = this.subsList.filter((sub: SubscriptionModel) => sub.topic !== topic)
-            }
-            this.record.subscriptions = payload.subscriptions
-            updateConnection(this.record.id, this.record)
-            this.changeSubs(payload)
-            this.$emit('deleteTopic')
-            this.subsList = payload.subscriptions
-            resolve(true)
-            return true
-          }
-        })
-      }
+      this.client.unsubscribe(topic, { qos }, (error) => {
+        this.unsubLoading = false
+        if (error) {
+          this.$message.error(error)
+          return resolve(false)
+        }
+        finalize()
+      })
     })
   }
 
@@ -662,20 +676,20 @@ export default class SubscriptionsList extends Vue {
 
   private async setTopicDisabled(disable: boolean) {
     this.showContextmenu = false
-    if (!this.client || !this.client.connected) {
-      this.$notify({
-        title: this.$tc('connections.notConnect'),
-        message: '',
-        type: 'error',
-        duration: 3000,
-        offset: 30,
-      })
-      return
-    }
     if (!this.selectedTopic) {
       return
     }
     this.selectedTopic.disabled = disable
+    if (!this.client || !this.client.connected) {
+      const updatedSubs = this.setSubsDisable(this.selectedTopic.topic, disable)
+      this.record.subscriptions = updatedSubs
+      if (this.record.id) {
+        updateConnection(this.record.id, this.record)
+        this.changeSubs({ id: this.connectionId, subscriptions: updatedSubs })
+        this.subsList = updatedSubs
+      }
+      return
+    }
     if (disable) {
       await this.unsubscribe(this.selectedTopic, true)
     } else {


### PR DESCRIPTION
### PR Checklist

If you have any questions, you can refer to the [Contributing Guide](https://github.com/emqx/MQTTX/blob/main/.github/CONTRIBUTING.md)

#### What is the current behavior?

When disconnected from the MQTT broker, clicking the delete (`x`) icon on a subscription or toggling/editing a subscription fails with a `"Not Connected"` notification because `unsubscribe()` hard-blocks execution if `!this.client.connected`. Users cannot remove or edit unauthorized or invalid subscriptions offline, which can cause reconnection loops if auto-resubscribe is enabled.

#### Issue Number

Fixes #1640

#### What is the new behavior?

1. When disconnected, clicking delete (`x`) on a subscription removes it directly from the local database/storage and UI (`syncSubscriptions`) without throwing an error or attempting broker network packets.
2. When disconnected, users can also disable, enable, and edit subscriptions offline so they persist before reconnecting.
3. When connected, the standard MQTT `UNSUBSCRIBE` broker packet flow is preserved.
4. Synchronized across both Desktop (`src/components/SubscriptionsList.vue`) and Web (`web/src/components/SubscriptionsList.vue`).

#### Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

#### Specific Instructions

None.

#### Other information

- Unit tests: 329 passing (`npm run test:unit`)
- Formatted with repository Prettier configuration.